### PR TITLE
Open Graph protocol: category as article:section, full IRI property

### DIFF
--- a/wp/wp-content/plugins/facebook/fb_open_graph.php
+++ b/wp/wp-content/plugins/facebook/fb_open_graph.php
@@ -24,7 +24,7 @@ function fb_add_og_protocol() {
 	$meta_tags['article:tag'] = '';
 
 	// does theme support post thumbnails?
-	if ( function_exists( 'get_post_thumbnail_id' ) ) {
+	if ( function_exists( 'has_post_thumbnail' ) && has_post_thumbnail() ) {
 		list( $post_thumbnail_url, $post_thumbnail_width, $post_thumbnail_height ) = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' );
 		if ( ! empty( $post_thumbnail_url ) ) {
 			$meta_tags['og:image'] = $post_thumbnail_url;

--- a/wp/wp-content/plugins/facebook/fb_open_graph.php
+++ b/wp/wp-content/plugins/facebook/fb_open_graph.php
@@ -10,22 +10,22 @@ function fb_add_og_protocol() {
 
 	$meta_tags = array();
 
-	$meta_tags['og:type'] = 'article';
-	$meta_tags['og:site_name'] = get_bloginfo('name');
-	$meta_tags['og:url'] = get_permalink();
-	$meta_tags['og:title'] = get_the_title();
-	$meta_tags['og:description'] = get_bloginfo('description', 'display'); 
-	$meta_tags['article:published_time'] = get_the_date('c'); 
-	$meta_tags['article:modified_time'] = get_the_modified_date('c'); 
-	$meta_tags['article:author'] = get_author_posts_url( get_the_author_meta('ID') );
-	$meta_tags['article:section'] = '';
-	$meta_tags['article:tag'] = '';
+	$meta_tags['http://ogp.me/ns#locale'] = fb_get_locale();
+	$meta_tags['http://ogp.me/ns#site_name'] = get_bloginfo( 'name' );
+	$meta_tags['http://ogp.me/ns#type'] = 'article';
+	$meta_tags['http://ogp.me/ns#site_name'] = get_bloginfo('name');
+	$meta_tags['http://ogp.me/ns#url'] = get_permalink();
+	$meta_tags['http://ogp.me/ns#title'] = get_the_title();
+	$meta_tags['http://ogp.me/ns#description'] = get_bloginfo('description', 'display');
+	$meta_tags['http://ogp.me/ns/article#published_time'] = get_the_date('c'); 
+	$meta_tags['http://ogp.me/ns/article#modified_time'] = get_the_modified_date('c'); 
+	$meta_tags['http://ogp.me/ns/article#author'] = get_author_posts_url( get_the_author_meta('ID') );
 
 	$cat_ids = get_the_category();
 	if ( ! empty( $cat_ids ) ) {
 		$cat = get_category( $cat_ids[0] );
 		if ( ! empty( $cat ) )
-			$meta_tags['article:section'] = $cat->name;
+			$meta_tags['http://ogp.me/ns/article#section'] = $cat->name;
 
 		/*
 		TODO: output the rest of the categories as tags
@@ -39,30 +39,30 @@ function fb_add_og_protocol() {
 		} */
 	}
 
+	// TODO: add tags. treat tags as lower priority than multiple categories
+	// $meta_tags['http://ogp.me/ns/article#tag'] = '';
+
 	// does theme support post thumbnails?
 	if ( function_exists( 'has_post_thumbnail' ) && has_post_thumbnail() ) {
 		list( $post_thumbnail_url, $post_thumbnail_width, $post_thumbnail_height ) = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' );
 		if ( ! empty( $post_thumbnail_url ) ) {
-			$meta_tags['og:image'] = $post_thumbnail_url;
+			$meta_tags['http://ogp.me/ns#image'] = $post_thumbnail_url;
 
 			if ( ! empty($post_thumbnail_width) )
-				$meta_tags['og:image:width'] = $post_thumbnail_width;
+				$meta_tags['http://ogp.me/ns#image:width'] = $post_thumbnail_width;
 
 			if ( ! empty($post_thumbnail_height) )
-				$meta_tags['og:image:height'] = $post_thumbnail_height;
+				$meta_tags['http://ogp.me/ns#image:height'] = $post_thumbnail_height;
 		}
 	}
 
-	$meta_tags['og:site_name'] = get_bloginfo( 'name' );
-
 	$options = get_option( 'fb_options' );
 	if ( ! empty( $options['app_id'] ) )
-		$meta_tags['fb:app_id'] = $options['app_id'];
-	$meta_tags['og:locale'] = fb_get_locale();
+		$meta_tags['http://ogp.me/ns/fb#app_id'] = $options['app_id'];
 	
 	$meta_tags = apply_filters( 'fb_meta_tags', $meta_tags, $post );
 	
-	foreach ($meta_tags as $property => $content) {
+	foreach ( $meta_tags as $property => $content ) {
 		if ( $content )
 			echo "<meta property=\"$property\" content=\"" . esc_attr( $content ) . "\" />\n";
 	}

--- a/wp/wp-content/plugins/facebook/fb_open_graph.php
+++ b/wp/wp-content/plugins/facebook/fb_open_graph.php
@@ -15,7 +15,7 @@ function fb_add_og_protocol() {
 	$meta_tags['http://ogp.me/ns#type'] = 'article';
 	$meta_tags['http://ogp.me/ns#url'] = get_permalink();
 	$meta_tags['http://ogp.me/ns#title'] = get_the_title();
-	$meta_tags['http://ogp.me/ns#description'] = get_bloginfo('description', 'display');
+	$meta_tags['http://ogp.me/ns#description'] = apply_filters( 'the_excerpt', get_the_excerpt() );
 	$meta_tags['http://ogp.me/ns/article#published_time'] = get_the_date('c'); 
 	$meta_tags['http://ogp.me/ns/article#modified_time'] = get_the_modified_date('c'); 
 	$meta_tags['http://ogp.me/ns/article#author'] = get_author_posts_url( get_the_author_meta('ID') );

--- a/wp/wp-content/plugins/facebook/fb_open_graph.php
+++ b/wp/wp-content/plugins/facebook/fb_open_graph.php
@@ -10,8 +10,6 @@ function fb_add_og_protocol() {
 
 	$meta_tags = array();
 
-	$options = get_option( 'fb_options' );
-
 	$meta_tags['og:type'] = 'article';
 	$meta_tags['og:site_name'] = get_bloginfo('name');
 	$meta_tags['og:url'] = get_permalink();
@@ -22,6 +20,24 @@ function fb_add_og_protocol() {
 	$meta_tags['article:author'] = get_author_posts_url( get_the_author_meta('ID') );
 	$meta_tags['article:section'] = '';
 	$meta_tags['article:tag'] = '';
+
+	$cat_ids = get_the_category();
+	if ( ! empty( $cat_ids ) ) {
+		$cat = get_category( $cat_ids[0] );
+		if ( ! empty( $cat ) )
+			$meta_tags['article:section'] = $cat->name;
+
+		/*
+		TODO: output the rest of the categories as tags
+		unset( $cat_ids[0] );
+		if ( ! empty( $cat_ids ) ) {
+			foreach( $cat_ids as $cat_id ) {
+				$cat = get_category( $cat_id );
+				$article->addTag( $cat->name );
+				unset( $cat );
+			}
+		} */
+	}
 
 	// does theme support post thumbnails?
 	if ( function_exists( 'has_post_thumbnail' ) && has_post_thumbnail() ) {
@@ -38,8 +54,9 @@ function fb_add_og_protocol() {
 	}
 
 	$meta_tags['og:site_name'] = get_bloginfo( 'name' );
-	
-	if ( ! empty($options['app_id'] ) )
+
+	$options = get_option( 'fb_options' );
+	if ( ! empty( $options['app_id'] ) )
 		$meta_tags['fb:app_id'] = $options['app_id'];
 	$meta_tags['og:locale'] = fb_get_locale();
 	

--- a/wp/wp-content/plugins/facebook/fb_open_graph.php
+++ b/wp/wp-content/plugins/facebook/fb_open_graph.php
@@ -13,7 +13,6 @@ function fb_add_og_protocol() {
 	$meta_tags['http://ogp.me/ns#locale'] = fb_get_locale();
 	$meta_tags['http://ogp.me/ns#site_name'] = get_bloginfo( 'name' );
 	$meta_tags['http://ogp.me/ns#type'] = 'article';
-	$meta_tags['http://ogp.me/ns#site_name'] = get_bloginfo('name');
 	$meta_tags['http://ogp.me/ns#url'] = get_permalink();
 	$meta_tags['http://ogp.me/ns#title'] = get_the_title();
 	$meta_tags['http://ogp.me/ns#description'] = get_bloginfo('description', 'display');


### PR DESCRIPTION
Output the first category associated with the post as an OGP article:section.

Use full IRIs for improved compatibility with no prefix on parent elements <head> or <html>.

Use post excerpt instead of blog description for og:description.
