### PR TITLE
Only load what is required based on current settings

### DIFF
--- a/wp/wp-content/plugins/facebook/fb_core.php
+++ b/wp/wp-content/plugins/facebook/fb_core.php
@@ -164,8 +164,7 @@ function fb_get_locale() {
 }
 
 function fb_style() {
-	 wp_register_style( 'fb', plugins_url( 'style/style.css', __FILE__) );
-	 wp_enqueue_style( 'fb', plugins_url( 'style/style.css', __FILE__), array(), '1.0' );
+	wp_enqueue_style( 'fb', plugins_url( 'style/style.css', __FILE__), array(), '1.0' );
 }
 add_action( 'wp_enqueue_scripts', 'fb_style' );
 

--- a/wp/wp-content/plugins/facebook/fb_core.php
+++ b/wp/wp-content/plugins/facebook/fb_core.php
@@ -45,7 +45,7 @@ function fb_install_warning() {
 
 	$page = (isset($_GET['page']) ? $_GET['page'] : null);
 
-	if ((empty($options['app_id']) || empty($options['app_secret'])) && $page != 'facebook/fb_admin_menu.php') {
+	if ((empty($options['app_id']) || empty($options['app_secret'])) && $page != 'facebook/fb_admin_menu.php' && current_user_can( 'manage_options' ) ) {
 		fb_admin_dialog( sprintf( __('You must <a href="%s">configure the plugin</a> to enable Facebook for WordPress.', 'facebook' ), 'admin.php?page=facebook/fb_admin_menu.php' ), true);
 	}
 }

--- a/wp/wp-content/plugins/facebook/fb_core.php
+++ b/wp/wp-content/plugins/facebook/fb_core.php
@@ -67,7 +67,7 @@ add_action('admin_notices', 'fb_install_warning');
 function fb_js_sdk_setup() {
 	$options = get_option( 'fb_options' );
 
-	if ( ! isset( $options['app_id'] ) )
+	if ( empty( $options['app_id'] ) )
 		return;
 
 	$app_id = $options['app_id'];
@@ -82,7 +82,7 @@ function fb_js_sdk_setup() {
 	) );
 
 	// enforce minimum requirements
-	if ( ! isset( $args['appId'] ) )
+	if ( empty( $args['appId'] ) )
 		return;
 
 	echo '<script type="text/javascript">window.fbAsyncInit=function(){FB.init(' . json_encode( $args ) . ');';
@@ -115,7 +115,7 @@ function fb_root() {
 function fb_init() {
 	$options = get_option( 'fb_options' );
 
-	if ( ! isset( $options['app_id'] ) )
+	if ( empty( $options['app_id'] ) )
 		return;
 
 	add_action( 'wp_head', 'fb_js_sdk_setup' );

--- a/wp/wp-content/plugins/facebook/fb_login.php
+++ b/wp/wp-content/plugins/facebook/fb_login.php
@@ -6,6 +6,10 @@ function fb_check_connected_accounts() {
 
 	$options = get_option('fb_options');
 
+	// check if we have enough info to handle the authFacebook function
+	if ( ! $options || empty( $options['app_id'] ) || empty( $options['app_secret'] ) )
+		return;
+
 	//see if they have connected their account to facebook
 	$fb_data = get_user_meta($current_user->ID, 'fb_data', true);
 

--- a/wp/wp-content/plugins/facebook/includes/facebook_php_sdk/src/base_facebook.php
+++ b/wp/wp-content/plugins/facebook/includes/facebook_php_sdk/src/base_facebook.php
@@ -22,6 +22,7 @@ if (!function_exists('json_decode')) {
   throw new Exception('Facebook needs the JSON PHP extension.');
 }
 
+if ( ! class_exists( 'FacebookApiException' ) ):
 /**
  * Thrown when an API call returns an exception.
  *
@@ -105,7 +106,9 @@ class FacebookApiException extends Exception
     return $str . $this->message;
   }
 }
+endif;
 
+if ( ! class_exists( 'BaseFacebook' ) ):
 /**
  * Provides access to the Facebook Platform.  This class provides
  * a majority of the functionality needed, but the class is abstract
@@ -1267,3 +1270,4 @@ abstract class BaseFacebook
    */
   abstract protected function clearAllPersistentData();
 }
+endif;

--- a/wp/wp-content/plugins/facebook/includes/facebook_php_sdk/src/facebook.php
+++ b/wp/wp-content/plugins/facebook/includes/facebook_php_sdk/src/facebook.php
@@ -15,7 +15,9 @@
  * under the License.
  */
 
-require_once "base_facebook.php";
+require_once( dirname(__FILE__) . '/base_facebook.php' );
+
+if ( ! class_exists( 'Facebook' ) ):
 
 /**
  * Extends the BaseFacebook class with the intent of using
@@ -91,3 +93,4 @@ class Facebook extends BaseFacebook
                               $key));
   }
 }
+endif;

--- a/wp/wp-content/plugins/facebook/social_plugins/fb_social_plugins.php
+++ b/wp/wp-content/plugins/facebook/social_plugins/fb_social_plugins.php
@@ -1,46 +1,50 @@
 <?php
-require_once('fb_like.php');
-require_once('fb_send.php');
-require_once('fb_subscribe.php');
-require_once('fb_activity_feed.php');
-require_once('fb_recommendations.php');
-require_once('fb_recommendations_bar.php');
-require_once('fb_comments.php');
 
-add_action( 'widgets_init', create_function('', 'register_widget( "Facebook_Like_Button" );'));
-add_action( 'widgets_init', create_function('', 'register_widget( "Facebook_Send_Button" );'));
-add_action( 'widgets_init', create_function('', 'register_widget( "Facebook_Subscribe_Button" );'));
-add_action( 'widgets_init', create_function('', 'register_widget( "Facebook_Activity_Feed" );'));
-add_action( 'widgets_init', create_function('', 'register_widget( "Facebook_Recommendations" );'));
-
+/**
+ * Add social plugins through filters
+ * Individual social plugin files contain both administrative setting fields and display code
+ */
 function fb_apply_filters() {
 	$options = get_option('fb_options');
 
 	/*if (isset($options['recommendations_bar'])) {
 		add_filter('the_content', 'fb_recommendations_bar_automatic', 30);
-	}*/
+		require_once('fb_recommendations_bar.php');
+	}
+	add_action( 'widgets_init', create_function('', 'register_widget( "Facebook_Recommendations" );'));
+	require_once('fb_recommendations.php');
 
-	if (isset($options['like'])) {
-		add_filter('the_content', 'fb_like_button_automatic', 30);
+	require_once('fb_activity_feed.php');
+	add_action( 'widgets_init', create_function('', 'register_widget( "Facebook_Activity_Feed" );'));
+	*/
+
+	require_once( dirname(__FILE__) . '/fb_like.php' );
+	if ( array_key_exists( 'like', $options ) && array_key_exists( 'enabled', $options['like'] ) && $options['like']['enabled'] ) {
+		add_action( 'widgets_init', create_function('', 'register_widget( "Facebook_Like_Button" );') );
+		add_filter( 'the_content', 'fb_like_button_automatic', 30 );
 	}
 
-	if (isset($options['send'])) {
-		add_filter('the_content', 'fb_send_button_automatic', 30);
+	require_once( dirname(__FILE__) . '/fb_send.php' );
+	if ( array_key_exists( 'send', $options ) && array_key_exists( 'enabled', $options['send'] ) && $options['send']['enabled'] ) {
+		add_action( 'widgets_init', create_function('', 'register_widget( "Facebook_Send_Button" );') );
+		add_filter( 'the_content', 'fb_send_button_automatic', 30 );
 	}
 
-	if (isset($options['subscribe'])) {
-		add_filter('the_content', 'fb_subscribe_button_automatic', 30);
+	require_once( dirname(__FILE__) . '/fb_subscribe.php' );
+	if ( array_key_exists( 'subscribe', $options ) && array_key_exists( 'enabled', $options['subscribe'] ) && $options['subscribe']['enabled'] ) {
+		add_action( 'widgets_init', create_function('', 'register_widget( "Facebook_Subscribe_Button" );') );
+		add_filter( 'the_content', 'fb_subscribe_button_automatic', 30 );
 	}
 
-	if (isset($options['comments'])) {
-		add_filter('the_content', 'fb_comments_automatic', 30);
-		add_filter('comments_array', 'fb_close_wp_comments');
-		add_filter('the_posts', 'fb_set_wp_comment_status');
-		//add_filter('comments_open', 'fb_close_wp_comments', 10, 2);
-		//add_filter('pings_open', 'fb_close_wp_comments', 10, 2);
-		add_action('wp_footer', 'fb_hide_wp_comments', 30);
+	require_once( dirname(__FILE__) . '/fb_comments.php' );
+	if ( array_key_exists( 'comments', $options ) && array_key_exists( 'enabled', $options['comments'] ) && $options['comments']['enabled'] ) {
+		add_filter( 'the_content', 'fb_comments_automatic', 30 );
+		add_filter( 'comments_array', 'fb_close_wp_comments' );
+		add_filter( 'the_posts', 'fb_set_wp_comment_status' );
+		//add_filter( 'comments_open', 'fb_close_wp_comments', 10, 2 );
+		//add_filter( 'pings_open', 'fb_close_wp_comments', 10, 2 );
+		add_action( 'wp_footer', 'fb_hide_wp_comments', 30 );
 	}
 }
-
-fb_apply_filters();
+add_action( 'init', 'fb_apply_filters' );
 ?>


### PR DESCRIPTION
I have just installed the plugin and have not yet stored a Facebook application identifier or secret. What assumptions of the plugin will not function without this basic info? Hold them back.

Social plugins should only appear as a widget and act on filters when "enabled" through the settings page.

Other plugins might bundle a version of the Facebook SDK or other Facebook-related classes with the same names. Avoid throwing errors and causing site failures due to such collisions.
