### PR TITLE
Check if options is array before looking for array keys

### DIFF
--- a/wp/wp-content/plugins/facebook/social_plugins/fb_social_plugins.php
+++ b/wp/wp-content/plugins/facebook/social_plugins/fb_social_plugins.php
@@ -26,6 +26,8 @@ require_once( dirname(__FILE__) . '/fb_comments.php' );
  */
 function fb_apply_filters() {
 	$options = get_option('fb_options');
+	if ( ! is_array( $options ) )
+		return;
 
 	/*if (isset($options['recommendations_bar'])) {
 		add_filter('the_content', 'fb_recommendations_bar_automatic', 30);


### PR DESCRIPTION
#65

`get_option('fb_options')` may return `false` if option not yet set. Reject anything that is not an array before running array-specific functions against the variable.
