### PR TITLE
Additional OGP properties for page, frontpage

### DIFF
--- a/wp/wp-content/plugins/facebook/fb_open_graph.php
+++ b/wp/wp-content/plugins/facebook/fb_open_graph.php
@@ -41,6 +41,7 @@ function fb_add_og_protocol() {
 	);
 
 	if ( is_home() || is_front_page() ) {
+		$meta_tags['http://ogp.me/ns#title'] = get_bloginfo( 'name' );
 		$meta_tags['http://ogp.me/ns#description'] = get_bloginfo( 'description' );
 	} else if ( is_single() ) {
 		$post_type = get_post_type();

--- a/wp/wp-content/plugins/facebook/fb_open_graph.php
+++ b/wp/wp-content/plugins/facebook/fb_open_graph.php
@@ -104,6 +104,9 @@ function fb_add_og_protocol() {
 		$meta_tags['http://ogp.me/ns/profile#last_name'] = get_the_author_meta( 'last_name', $post->post_author );
 		if ( is_multi_author() )
 			$meta_tags['http://ogp.me/ns/profile#username'] = get_the_author_meta( 'login', $post->post_author );
+	} else if ( is_page() ) {
+		$meta_tags['http://ogp.me/ns#title'] = get_the_title();
+		$meta_tags['http://ogp.me/ns#url'] = apply_filters( 'rel_canonical', get_permalink() );
 	}
 
 	$options = get_option( 'fb_options' );

--- a/wp/wp-content/plugins/facebook/fb_social_publisher.php
+++ b/wp/wp-content/plugins/facebook/fb_social_publisher.php
@@ -270,7 +270,12 @@ function fb_publish_later($new_status, $old_status, $post) {
 
 add_action('delete_post', 'fb_delete_social_posts', 10);
 
-function fb_delete_social_posts($post_id) {
+function fb_delete_social_posts( $post_id ) {
+	global $facebook;
+
+	if ( ! isset( $facebook ) || ! is_object( $facebook ) || ! method_exists( $facebook, 'api' ) )
+		return;
+
 	$fb_page_post_id = get_post_meta($post_id, 'fb_fan_page_post_id', true);
 
 	try {

--- a/wp/wp-content/plugins/facebook/social_plugins/fb_like.php
+++ b/wp/wp-content/plugins/facebook/social_plugins/fb_like.php
@@ -39,7 +39,7 @@ function fb_like_button_automatic($content) {
 			$new_content = fb_get_like_button($options['like']) . $content;
 			break;
 		case 'bottom':
-			$new_content .= fb_get_like_button($options['like']);
+			$new_content = $content . fb_get_like_button($options['like']);
 			break;
 		case 'both':
 			$new_content = fb_get_like_button($options['like']) . $content;


### PR DESCRIPTION
Output an OGP title and URL for pages.

Output site title as OGP title for frontpage and home.

Fix a couple things that preventing me from testing my changes.

You should look into the cause of errors for `fb_social_publisher.php` that required me to need that extra conditional before I could see the new page admin screen.
