### PR TITLE
Invalid argument: null passed to foreach

### DIFF
--- a/fb-social-publisher.php
+++ b/fb-social-publisher.php
@@ -361,6 +361,8 @@ function fb_get_social_publisher_fields() {
     return;
 
 	$accounts = fb_get_user_pages();
+	if ( empty( $accounts ) )
+		return;
 
 	$accounts_options = array('disabled' => '[Disabled]');
 


### PR DESCRIPTION
`fb_get_user_pages()` may return `null`. if that happens and the `$accounts` variable is passed to `foreach` then PHP throws an invalid argument error. kill the error with a check before attempting an iterator
