### PR TITLE
comments plugin width fix

### DIFF
--- a/social-plugins/fb-comments.php
+++ b/social-plugins/fb-comments.php
@@ -49,7 +49,7 @@ function fb_comments_automatic($content) {
 			foreach($options['comments'] as $param => $val) {
 				$param = str_replace('_', '-', $param);
 
-				$params['data-' . $param] = $val;
+				$params[$param] = $val;
 			}
 
 			$content .= fb_get_comments($params);


### PR DESCRIPTION
comments plugin was appending data_ to the width param and wasn't setting it correctly, this fixes that. tested on my site to verify it works. http://ericosgood.com/prog/facebook-android-sdk-tutorial/
