### PR TITLE
"Show on" dropdown

### DIFF
--- a/social-plugins/fb-comments.php
+++ b/social-plugins/fb-comments.php
@@ -46,16 +46,19 @@ function fb_comments_automatic($content) {
 	
 	if ( isset ( $post ) ) {
 		if ( comments_open( get_the_ID() ) && post_type_supports( get_post_type(), 'comments' ) ) {
-			if ( is_singular() ) {
-				$options = get_option('fb_options');
-	
-				foreach($options['comments'] as $param => $val) {
-					$param = str_replace('_', '-', $param);
-	
-					$params[$param] = $val;
+			$options = get_option('fb_options');
+			if (!is_home() && $options['comments']['show_on']) {
+				if ( ( is_page() && ( $options['comments']['show_on']=='all pages' || $options['comments']['show_on'] == 'all posts and pages' ) )
+						or ( is_single() &&  ( $options['comments']['show_on'] == 'all posts' || $options['comments']['show_on'] == 'all posts and pages' ) ) )
+				{
+					foreach($options['comments'] as $param => $val) {
+						$param = str_replace('_', '-', $param);
+		
+						$params[$param] = $val;
+					}
+		
+					$content .= fb_get_comments($params);
 				}
-	
-				$content .= fb_get_comments($params);
 			}
 			else {
 			}
@@ -136,6 +139,12 @@ function fb_get_comments_fields_array() {
 													'options' => array('light' => 'light', 'dark' => 'dark'),
 													'help_text' => 'The color scheme of the plugin.',
 													),
+										array('name' => 'show_on',
+													'type' => 'dropdown',
+													'default' => 'all posts',
+													'options' => array('all posts' => 'all posts', 'all pages' => 'all pages', 'all posts and pages' => 'all posts and pages', 'none' => 'none'),
+													'help_text' => __( 'Changes whether the plugin appears on all posts or pages. When changed, individual settings are removed.', 'facebook' ),
+													)
 										);
 
 	return $array;

--- a/social-plugins/fb-comments.php
+++ b/social-plugins/fb-comments.php
@@ -47,17 +47,17 @@ function fb_comments_automatic($content) {
 	if ( isset ( $post ) ) {
 		if ( comments_open( get_the_ID() ) && post_type_supports( get_post_type(), 'comments' ) ) {
 			$options = get_option('fb_options');
-			if (!is_home() && $options['comments']['show_on']) {
-				if ( ( is_page() && ( $options['comments']['show_on']=='all pages' || $options['comments']['show_on'] == 'all posts and pages' ) )
+			if ( ! is_home() && $options['comments']['show_on'] ) {
+				if ( ( is_page() && ( $options['comments']['show_on'] == 'all pages' || $options['comments']['show_on'] == 'all posts and pages' ) )
 						or ( is_single() &&  ( $options['comments']['show_on'] == 'all posts' || $options['comments']['show_on'] == 'all posts and pages' ) ) )
 				{
-					foreach($options['comments'] as $param => $val) {
-						$param = str_replace('_', '-', $param);
+					foreach( $options['comments'] as $param => $val ) {
+						$param = str_replace( '_', '-', $param );
 		
 						$params[$param] = $val;
 					}
 		
-					$content .= fb_get_comments($params);
+					$content .= fb_get_comments( $params );
 				}
 			}
 			else {
@@ -141,9 +141,9 @@ function fb_get_comments_fields_array() {
 													),
 										array('name' => 'show_on',
 													'type' => 'dropdown',
-													'default' => 'all posts',
-													'options' => array('all posts' => 'all posts', 'all pages' => 'all pages', 'all posts and pages' => 'all posts and pages', 'none' => 'none'),
-													'help_text' => __( 'Changes whether the plugin appears on all posts or pages. When changed, individual settings are removed.', 'facebook' ),
+													'default' => 'all posts and pages',
+													'options' => array('all posts' => 'all posts', 'all pages' => 'all pages', 'all posts and pages' => 'all posts and pages'),
+													'help_text' => __( 'Whether the plugin will appear on all posts or pages.', 'facebook' ),
 													)
 										);
 

--- a/social-plugins/fb-like.php
+++ b/social-plugins/fb-like.php
@@ -44,11 +44,14 @@ function fb_like_button_automatic($content) {
 				break;
 		}
 	
-		if ( empty( $options['like']['show_on_homepage'] ) && is_singular() ) {
+		if ( is_home() && $options['like']['show_on_homepage'] ) {
 			$content = $new_content;
 		}
-		elseif ( isset($options['like']['show_on_homepage']) ) {
-			$content = $new_content;
+		elseif ( $options['like']['show_on'] ) {
+			if ( is_page() && ( $options['like']['show_on']=='all pages' || $options['like']['show_on'] == 'all posts and pages' ) )
+				$content = $new_content;
+			elseif ( is_single() && ( $options['like']['show_on']=='all posts' || $options['like']['show_on'] == 'all posts and pages' ) )
+				$content = $new_content;
 		}
 	}
 
@@ -191,6 +194,12 @@ function fb_get_like_fields_array($placement) {
 													'default' => 'both',
 													'options' => array('top' => 'top', 'bottom' => 'bottom', 'both' => 'both'),
 													'help_text' => __( 'Where the button will display on the page or post.', 'facebook' ),
+													);
+		$array['children'][] = array('name' => 'show_on',
+													'type' => 'dropdown',
+													'default' => 'all posts',
+													'options' => array('all posts' => 'all posts', 'all pages' => 'all pages', 'all posts and pages' => 'all posts and pages', 'none' => 'none'),
+													'help_text' => __( 'Changes whether the plugin appears on all posts or pages. When changed, individual settings are removed.', 'facebook' ),
 													);
 		$array['children'][] = array('name' => 'show_on_homepage',
 													'type' => 'checkbox',

--- a/social-plugins/fb-like.php
+++ b/social-plugins/fb-like.php
@@ -48,9 +48,9 @@ function fb_like_button_automatic($content) {
 			$content = $new_content;
 		}
 		elseif ( $options['like']['show_on'] ) {
-			if ( is_page() && ( $options['like']['show_on']=='all pages' || $options['like']['show_on'] == 'all posts and pages' ) )
+			if ( is_page() && ( $options['like']['show_on'] == 'all pages' || $options['like']['show_on'] == 'all posts and pages' ) )
 				$content = $new_content;
-			elseif ( is_single() && ( $options['like']['show_on']=='all posts' || $options['like']['show_on'] == 'all posts and pages' ) )
+			elseif ( is_single() && ( $options['like']['show_on'] == 'all posts' || $options['like']['show_on'] == 'all posts and pages' ) )
 				$content = $new_content;
 		}
 	}
@@ -197,9 +197,9 @@ function fb_get_like_fields_array($placement) {
 													);
 		$array['children'][] = array('name' => 'show_on',
 													'type' => 'dropdown',
-													'default' => 'all posts',
-													'options' => array('all posts' => 'all posts', 'all pages' => 'all pages', 'all posts and pages' => 'all posts and pages', 'none' => 'none'),
-													'help_text' => __( 'Changes whether the plugin appears on all posts or pages. When changed, individual settings are removed.', 'facebook' ),
+													'default' => 'all posts and pages',
+													'options' => array('all posts' => 'all posts', 'all pages' => 'all pages', 'all posts and pages' => 'all posts and pages'),
+													'help_text' => __( 'Whether the plugin will appear on all posts or pages.', 'facebook' ),
 													);
 		$array['children'][] = array('name' => 'show_on_homepage',
 													'type' => 'checkbox',

--- a/social-plugins/fb-recommendations-bar.php
+++ b/social-plugins/fb-recommendations-bar.php
@@ -7,12 +7,11 @@ function fb_get_recommendations_bar($options = array()) {
 
 function fb_recommendations_bar_automatic($content) {
 	$options = get_option('fb_options');
-	if (!is_home() && $options['recommendations_bar']['show_on']) {
-		if ( ( is_page() && ( $options['recommendations_bar']['show_on']=='all pages' || $options['recommendations_bar']['show_on'] == 'all posts and pages' ) )
+	if ( ! is_home() && $options['recommendations_bar']['show_on'] ) {
+		if ( ( is_page() && ( $options['recommendations_bar']['show_on'] == 'all pages' || $options['recommendations_bar']['show_on'] == 'all posts and pages' ) )
 				or ( is_single() &&  ( $options['recommendations_bar']['show_on'] == 'all posts' || $options['recommendations_bar']['show_on'] == 'all posts and pages' ) ) )
 		{
-
-			$content .= fb_get_recommendations_bar($options['recommendations_bar']);
+			$content .= fb_get_recommendations_bar( $options['recommendations_bar'] );
 		}
 	}
 	
@@ -58,9 +57,9 @@ function fb_get_recommendations_bar_fields_array() {
 													),
 										array('name' => 'show_on',
 													'type' => 'dropdown',
-													'default' => 'all posts',
-													'options' => array('all posts' => 'all posts', 'all pages' => 'all pages', 'all posts and pages' => 'all posts and pages', 'none' => 'none'),
-													'help_text' => __( 'Changes whether the plugin appears on all posts or pages. When changed, individual settings are removed.', 'facebook' ),
+													'default' => 'all posts and pages',
+													'options' => array('all posts' => 'all posts', 'all pages' => 'all pages', 'all posts and pages' => 'all posts and pages'),
+													'help_text' => __( 'Whether the plugin will appear on all posts or pages.', 'facebook' ),
 													)
 										);
 

--- a/social-plugins/fb-recommendations-bar.php
+++ b/social-plugins/fb-recommendations-bar.php
@@ -6,12 +6,16 @@ function fb_get_recommendations_bar($options = array()) {
 }
 
 function fb_recommendations_bar_automatic($content) {
-	if (!is_home()) {
-		$options = get_option('fb_options');
+	$options = get_option('fb_options');
+	if (!is_home() && $options['recommendations_bar']['show_on']) {
+		if ( ( is_page() && ( $options['recommendations_bar']['show_on']=='all pages' || $options['recommendations_bar']['show_on'] == 'all posts and pages' ) )
+				or ( is_single() &&  ( $options['recommendations_bar']['show_on'] == 'all posts' || $options['recommendations_bar']['show_on'] == 'all posts and pages' ) ) )
+		{
 
-		$content .= fb_get_recommendations_bar($options['recommendations_bar']);
+			$content .= fb_get_recommendations_bar($options['recommendations_bar']);
+		}
 	}
-
+	
 	return $content;
 }
 
@@ -52,6 +56,12 @@ function fb_get_recommendations_bar_fields_array() {
 													'options' => array('left' => 'left', 'right' => 'right'),
 													'help_text' => __( 'The side of the window that the plugin will display.', 'facebook' ),
 													),
+										array('name' => 'show_on',
+													'type' => 'dropdown',
+													'default' => 'all posts',
+													'options' => array('all posts' => 'all posts', 'all pages' => 'all pages', 'all posts and pages' => 'all posts and pages', 'none' => 'none'),
+													'help_text' => __( 'Changes whether the plugin appears on all posts or pages. When changed, individual settings are removed.', 'facebook' ),
+													)
 										);
 
 	return $array;

--- a/social-plugins/fb-send.php
+++ b/social-plugins/fb-send.php
@@ -11,22 +11,22 @@ function fb_send_button_automatic($content) {
 	global $post;
 	
 	if ( isset( $post ) ) {
-		if ( isset($options['send']['show_on_homepage']) ) {
+		if ( isset( $options['send']['show_on_homepage'] ) ) {
 			$options['send']['href'] = get_permalink($post->ID);
 		}
 	
 		$new_content = '';
 	
-		switch ($options['send']['position']) {
+		switch ( $options['send']['position'] ) {
 			case 'top':
-				$new_content = fb_get_send_button($options['send']) . $content;
+				$new_content = fb_get_send_button( $options['send'] ) . $content;
 				break;
 			case 'bottom':
-				$new_content = $content . fb_get_send_button($options['send']);
+				$new_content = $content . fb_get_send_button( $options['send'] );
 				break;
 			case 'both':
-				$new_content = fb_get_send_button($options['send']) . $content;
-				$new_content .= fb_get_send_button($options['send']);
+				$new_content = fb_get_send_button( $options['send'] ) . $content;
+				$new_content .= fb_get_send_button( $options['send'] );
 				break;
 		}
 	
@@ -34,9 +34,9 @@ function fb_send_button_automatic($content) {
 			$content = $new_content;
 		}
 		elseif ( $options['send']['show_on'] ) {
-			if ( is_page() && ( $options['send']['show_on']=='all pages' || $options['send']['show_on'] == 'all posts and pages' ) )
+			if ( is_page() && ( $options['send']['show_on'] == 'all pages' || $options['send']['show_on'] == 'all posts and pages' ) )
 				$content = $new_content;
-			elseif ( is_single() && ( $options['send']['show_on']=='all posts' || $options['send']['show_on'] == 'all posts and pages' ) )
+			elseif ( is_single() && ( $options['send']['show_on'] == 'all posts' || $options['send']['show_on'] == 'all posts and pages' ) )
 				$content = $new_content;
 		}
 		
@@ -161,9 +161,9 @@ function fb_get_send_fields_array($placement) {
 													);
 		$array['children'][] = array('name' => 'show_on',
 													'type' => 'dropdown',
-													'default' => 'all posts',
-													'options' => array('all posts' => 'all posts', 'all pages' => 'all pages', 'all posts and pages' => 'all posts and pages', 'none' => 'none'),
-													'help_text' => __( 'Changes whether the plugin appears on all posts or pages. When changed, individual settings are removed.', 'facebook' ),
+													'default' => 'all posts and pages',
+													'options' => array('all posts' => 'all posts', 'all pages' => 'all pages', 'all posts and pages' => 'all posts and pages'),
+													'help_text' => __( 'Whether the plugin will appear on all posts or pages.', 'facebook' ),
 													);
 		$array['children'][] = array('name' => 'show_on_homepage',
 													'type' => 'checkbox',

--- a/social-plugins/fb-send.php
+++ b/social-plugins/fb-send.php
@@ -30,12 +30,16 @@ function fb_send_button_automatic($content) {
 				break;
 		}
 	
-		if ( empty( $options['send']['show_on_homepage'] ) && is_singular() ) {
+		if ( is_home() && $options['send']['show_on_homepage'] ) {
 			$content = $new_content;
 		}
-		elseif ( isset($options['send']['show_on_homepage']) ) {
-			$content = $new_content;
+		elseif ( $options['send']['show_on'] ) {
+			if ( is_page() && ( $options['send']['show_on']=='all pages' || $options['send']['show_on'] == 'all posts and pages' ) )
+				$content = $new_content;
+			elseif ( is_single() && ( $options['send']['show_on']=='all posts' || $options['send']['show_on'] == 'all posts and pages' ) )
+				$content = $new_content;
 		}
+		
 	}
 	
 
@@ -154,6 +158,12 @@ function fb_get_send_fields_array($placement) {
 													'default' => 'both',
 													'options' => array('top' => 'top', 'bottom' => 'bottom', 'both' => 'both'),
 													'help_text' => __( 'Where the button will display on the page or post.', 'facebook' ),
+													);
+		$array['children'][] = array('name' => 'show_on',
+													'type' => 'dropdown',
+													'default' => 'all posts',
+													'options' => array('all posts' => 'all posts', 'all pages' => 'all pages', 'all posts and pages' => 'all posts and pages', 'none' => 'none'),
+													'help_text' => __( 'Changes whether the plugin appears on all posts or pages. When changed, individual settings are removed.', 'facebook' ),
 													);
 		$array['children'][] = array('name' => 'show_on_homepage',
 													'type' => 'checkbox',

--- a/social-plugins/fb-subscribe.php
+++ b/social-plugins/fb-subscribe.php
@@ -41,10 +41,13 @@ function fb_subscribe_button_automatic($content) {
 			}
 		}
 	
-		if ( empty( $options['subscribe']['show_on_homepage'] ) && is_singular() ) {
+		if ( is_home() && $options['subscribe']['show_on_homepage'] ) {
 			$content = $new_content;
 		}
-		elseif ( isset($options['subscribe']['show_on_homepage']) ) {
+		elseif ( $options['subscribe']['show_on'] ) {
+			if ( is_page() && ( $options['subscribe']['show_on']=='all pages' || $options['subscribe']['show_on'] == 'all posts and pages' ) )
+				$content = $new_content;
+			elseif ( is_single() && ( $options['subscribe']['show_on']=='all posts' || $options['subscribe']['show_on'] == 'all posts and pages' ) )
 			$content = $new_content;
 		}
 	}
@@ -187,11 +190,18 @@ function fb_get_subscribe_fields_array($placement) {
 													'options' => array('top' => 'top', 'bottom' => 'bottom', 'both' => 'both'),
 													'help_text' => __( 'Where the button will display on the page or post.', 'facebook' ),
 													);
+		$array['children'][] = array('name' => 'show_on',
+													'type' => 'dropdown',
+													'default' => 'all posts',
+													'options' => array('all posts' => 'all posts', 'all pages' => 'all pages', 'all posts and pages' => 'all posts and pages', 'none' => 'none'),
+													'help_text' => __( 'Changes whether the plugin appears on all posts or pages. When changed, individual settings are removed.', 'facebook' ),
+													);
 		$array['children'][] = array('name' => 'show_on_homepage',
 													'type' => 'checkbox',
 													'default' => true,
 													'help_text' => __( 'If the plugin should appear on the homepage as part of the Post previews.  If unchecked, the plugin will only display on the Post itself.', 'facebook' ),
 													);
+
 	}
 
 	if ($placement == 'widget') {

--- a/social-plugins/fb-subscribe.php
+++ b/social-plugins/fb-subscribe.php
@@ -11,14 +11,14 @@ function fb_subscribe_button_automatic($content) {
 	global $post;
 	
 	if ( isset ($post ) ) {
-		if ( isset($options['subscribe']['show_on_homepage']) ) {
+		if ( isset( $options['subscribe']['show_on_homepage'] ) ) {
 		
-			$options['subscribe']['href'] = get_permalink($post->ID);
+			$options['subscribe']['href'] = get_permalink( $post->ID );
 		}
 		
-		$fb_data = fb_get_user_meta(get_the_author_meta('ID'), 'fb_data', true);
+		$fb_data = fb_get_user_meta( get_the_author_meta( 'ID' ), 'fb_data', true );
 	
-		if (!$fb_data) {
+		if ( ! $fb_data ) {
 			return $content;
 		}
 	
@@ -26,17 +26,17 @@ function fb_subscribe_button_automatic($content) {
 	
 		$new_content = '';
 	
-		if (isset($fb_data['username'])) {
-			switch ($options['subscribe']['position']) {
+		if ( isset( $fb_data['username'] ) ) {
+			switch ( $options['subscribe']['position'] ) {
 				case 'top':
-					$new_content = fb_get_subscribe_button($options['subscribe']) . $content;
+					$new_content = fb_get_subscribe_button( $options['subscribe'] ) . $content;
 					break;
 				case 'bottom':
-					$new_content = $content . fb_get_subscribe_button($options['subscribe']);
+					$new_content = $content . fb_get_subscribe_button( $options['subscribe'] );
 					break;
 				case 'both':
-					$new_content = fb_get_subscribe_button($options['subscribe']) . $content;
-					$new_content .= fb_get_subscribe_button($options['subscribe']);
+					$new_content = fb_get_subscribe_button( $options['subscribe'] ) . $content;
+					$new_content .= fb_get_subscribe_button( $options['subscribe'] );
 					break;
 			}
 		}
@@ -45,15 +45,13 @@ function fb_subscribe_button_automatic($content) {
 			$content = $new_content;
 		}
 		elseif ( $options['subscribe']['show_on'] ) {
-			if ( is_page() && ( $options['subscribe']['show_on']=='all pages' || $options['subscribe']['show_on'] == 'all posts and pages' ) )
+			if ( is_page() && ( $options['subscribe']['show_on'] == 'all pages' || $options['subscribe']['show_on'] == 'all posts and pages' ) )
 				$content = $new_content;
-			elseif ( is_single() && ( $options['subscribe']['show_on']=='all posts' || $options['subscribe']['show_on'] == 'all posts and pages' ) )
+			elseif ( is_single() && ( $options['subscribe']['show_on'] == 'all posts' || $options['subscribe']['show_on'] == 'all posts and pages' ) )
 			$content = $new_content;
 		}
 	}
 	
-	
-
 	return $content;
 }
 
@@ -192,9 +190,9 @@ function fb_get_subscribe_fields_array($placement) {
 													);
 		$array['children'][] = array('name' => 'show_on',
 													'type' => 'dropdown',
-													'default' => 'all posts',
-													'options' => array('all posts' => 'all posts', 'all pages' => 'all pages', 'all posts and pages' => 'all posts and pages', 'none' => 'none'),
-													'help_text' => __( 'Changes whether the plugin appears on all posts or pages. When changed, individual settings are removed.', 'facebook' ),
+													'default' => 'all posts and pages',
+													'options' => array('all posts' => 'all posts', 'all pages' => 'all pages', 'all posts and pages' => 'all posts and pages'),
+													'help_text' => __( 'Whether the plugin will appear on all posts or pages.', 'facebook' ),
 													);
 		$array['children'][] = array('name' => 'show_on_homepage',
 													'type' => 'checkbox',


### PR DESCRIPTION
Added global setting to set whether social plugins show on all posts, all pages, both, or neither. Done for like button, subscribe button, send button, comments, and recommendations bar
