### PR TITLE
non-cURL, SSL warning, etc.

### DIFF
--- a/fb-core.php
+++ b/fb-core.php
@@ -1,6 +1,7 @@
 <?php
 add_action( 'init', 'fb_init' );
 add_action( 'admin_notices', 'fb_install_warning' );
+add_action( 'admin_notices', 'fb_ssl_warning' );
 //add_action( 'admin_notices', 'fb_rate_message' );
 add_action( 'wp_enqueue_scripts', 'fb_style' );
 
@@ -16,6 +17,27 @@ function fb_install_warning() {
 
 	if ((empty($options['app_id']) || empty($options['app_secret'])) && $page != 'facebook-settings' && current_user_can( 'manage_options' ) ) {
 		fb_admin_dialog( sprintf( __('You must %sconfigure the plugin%s to enable Facebook for WordPress.', 'facebook' ), '<a href="admin.php?page=facebook-settings">', '</a>' ), true);
+	}
+}
+
+/**
+ * Display an admin-facing warning if openSSL is not installed properly
+ *
+ * @since 1.0.2
+ */
+function fb_ssl_warning() {
+	$options = get_option( 'fb_options' );
+
+	$page = (isset($_GET['page']) ? $_GET['page'] : null);
+
+	if ( ! wp_http_supports( array( 'ssl' => true ) )  && current_user_can( 'manage_options' ) ) {
+		$msg = 'SSL must be enabled for certain Facebook social plugins to work.';
+		if ( $options['social_publisher']['enabled'] ) {
+			unset($options['social_publisher']['enabled']);
+			update_option( 'fb_options', $options );
+			$msg .= ' Social Publisher will be disabled.';
+		}
+		fb_admin_dialog( __( $msg, 'facebook' ), true );
 	}
 }
 

--- a/includes/facebook-php-sdk/base_facebook.php
+++ b/includes/facebook-php-sdk/base_facebook.php
@@ -36,7 +36,9 @@ class FacebookApiException extends Exception
   public function __construct($result) {
     $this->result = $result;
 
-    $code = isset($result['error_code']) ? $result['error_code'] : 0;
+    //when api call fails (no available transport, i.e. cURL etc. not working), error code comes
+    // out as string 'http_failure', but $code needs to be int. is_int returns false if !isset()
+    $code = is_int($result['error_code']) ? $result['error_code'] : 0;
 
     if (isset($result['error_description'])) {
       // OAuth 2.0 Draft 10 style

--- a/includes/facebook-php-sdk/class-facebook-wp.php
+++ b/includes/facebook-php-sdk/class-facebook-wp.php
@@ -33,7 +33,7 @@ class Facebook_WP extends Facebook {
 			'httpversion' => '1.1',
 			'timeout' => 60,
 			'user-agent' => apply_filters( 'http_headers_useragent', 'WordPress/' . $wp_version . '; ' . get_bloginfo( 'url' ) . '; facebook-php-' . self::VERSION . '-wp' ),
-			'headers' => array( 'Expect:' ),
+			'headers' => array( 'Connection' => 'close'),
 			'sslverify' => false, // warning: might be overridden by 'https_ssl_verify' filter
 			'body' => http_build_query( $params, '', '&' )
 		);


### PR DESCRIPTION
Got non-cURL api calls to work, made social publisher be auto-disabled and error message for when SSL not enabled, and fixed small bug in base_facebook for when api calls don't go through and return 'http_failure' as code instead of an int
