### PR TITLE
Fix for issue #169 - alt for wp_trim_words in ver < 3.3

### DIFF
--- a/fb-open-graph.php
+++ b/fb-open-graph.php
@@ -28,7 +28,9 @@ function fb_output_og_protocol( $property, $content ) {
 }
 
 function fb_strip_and_format_desc( $post ) {
-	
+
+  global $wp_version;
+
 	$desc_no_html = "";
 	$desc_no_html = strip_shortcodes( $desc_no_html ); // Strip shortcodes first in case there is HTML inside the shortcode
         $desc_no_html = wp_strip_all_tags( $desc_no_html ); // Strip all html
@@ -42,10 +44,18 @@ function fb_strip_and_format_desc( $post ) {
 		$desc_no_html = wp_strip_all_tags($desc_no_html);
 		$excerpt_length = apply_filters('excerpt_length', 55);
 		$excerpt_more = apply_filters('excerpt_more', ' ' . '[...]');
-		$desc_no_html = wp_trim_words( $desc_no_html, $excerpt_length, $excerpt_more );
+    if ( $wp_version >= 3.3 ) {
+      $desc_no_html = wp_trim_words( $desc_no_html, $excerpt_length, $excerpt_more );
+    } else {
+      $length_of_original_str = strlen ( $desc_no_html );
+      $desc_no_html = substr( $desc_no_html, 0, $excerpt_length * 4 );
+      if ( $length_of_original_str > ( $excerpt_length * 4 ) ) {
+        $desc_no_html .= '...';
+      }
+    }
 		$desc_no_html = trim($desc_no_html); // Trim the final string, we may have stripped everything out of the post so this will make the value empty if that's the case
 	}
-	
+
 	$desc_no_html = str_replace( array( "\r\n", "\r", "\n" ), ' ',$desc_no_html); // I take it Facebook doesn't like new lines?
 	return $desc_no_html;
 }
@@ -64,7 +74,7 @@ function fb_add_og_protocol() {
 		'http://ogp.me/ns#site_name' => get_bloginfo( 'name' ),
 		'http://ogp.me/ns#type' => 'website'
 	);
-	
+
 	if ( is_home() || is_front_page() ) {
 		$meta_tags['http://ogp.me/ns#title'] = get_bloginfo( 'name' );
 		$meta_tags['http://ogp.me/ns#description'] = get_bloginfo( 'description' );
@@ -82,25 +92,25 @@ function fb_add_og_protocol() {
 				$meta_tags['http://ogp.me/ns#description'] = fb_strip_and_format_desc ( $post );
 			}
 		}
-		
+
 		$meta_tags['http://ogp.me/ns/article#published_time'] = get_the_date('c');
 		$meta_tags['http://ogp.me/ns/article#modified_time'] = get_the_modified_date('c');
-		
+
 		if ( post_type_supports( $post_type, 'author' ) && isset( $post->post_author ) )
 			$meta_tags['http://ogp.me/ns/article#author'] = get_author_posts_url( $post->post_author );
 
 		// add the first category as a section. all other categories as tags
 		$cat_ids = get_the_category();
-		
+
 		if ( ! empty( $cat_ids ) ) {
 			$cat = get_category( $cat_ids[0] );
-			
+
 			if ( ! empty( $cat ) )
 				$meta_tags['http://ogp.me/ns/article#section'] = $cat->name;
 
 			//output the rest of the categories as tags
 			unset( $cat_ids[0] );
-			
+
 			if ( ! empty( $cat_ids ) ) {
 				$meta_tags['http://ogp.me/ns/article#tag'] = array();
 				foreach( $cat_ids as $cat_id ) {
@@ -113,11 +123,11 @@ function fb_add_og_protocol() {
 
 		// add tags. treat tags as lower priority than multiple categories
 		$tags = get_the_tags();
-		
+
 		if ( $tags ) {
 			if ( ! array_key_exists( 'http://ogp.me/ns/article#tag', $meta_tags ) )
 				$meta_tags['http://ogp.me/ns/article#tag'] = array();
-				
+
 			foreach ( $tags as $tag ) {
 				$meta_tags['http://ogp.me/ns/article#tag'][] = $tag->name;
 			}
@@ -126,7 +136,7 @@ function fb_add_og_protocol() {
 		// does current post type and the current theme support post thumbnails?
 		if ( post_type_supports( $post_type, 'thumbnail' ) && function_exists( 'has_post_thumbnail' ) && has_post_thumbnail() ) {
 			list( $post_thumbnail_url, $post_thumbnail_width, $post_thumbnail_height ) = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' );
-			
+
 			if ( ! empty( $post_thumbnail_url ) ) {
 				$image = array( 'url' => $post_thumbnail_url );
 
@@ -135,7 +145,7 @@ function fb_add_og_protocol() {
 
 				if ( ! empty($post_thumbnail_height) )
 					$image['height'] = absint( $post_thumbnail_height );
-					
+
 				$meta_tags['http://ogp.me/ns#image'] = array( $image );
 			}
 		}
@@ -154,7 +164,7 @@ function fb_add_og_protocol() {
 	}
 
 	$options = get_option( 'fb_options' );
-	
+
 	if ( ! empty( $options['app_id'] ) )
 		$meta_tags['http://ogp.me/ns/fb#app_id'] = $options['app_id'];
 


### PR DESCRIPTION
Uses wp_trim_words for versions > 3.3, but just uses a php substr
function for earlier versions.

Since wp_trim_words counts words, not characters, I'm multiplying the
excerpt count by 4 to spoof this without adding a lot of word counting
logic.
