### PR TITLE
Added fallback for when $options[PLUGIN]['show_on'] is not set.

### DIFF
--- a/social-plugins/fb-comments.php
+++ b/social-plugins/fb-comments.php
@@ -48,7 +48,7 @@ function fb_comments_automatic($content) {
 		if ( comments_open( get_the_ID() ) && post_type_supports( get_post_type(), 'comments' ) ) {
 			$options = get_option('fb_options');
 			$show_indiv = get_post_meta( $post->ID, 'fb_social_plugin_settings_box_comments', true );
-			if ( ! is_home() && ( 'default' == $show_indiv || empty( $show_indiv ) ) && $options['comments']['show_on'] ) {
+			if ( ! is_home() && ( 'default' == $show_indiv || empty( $show_indiv ) ) && isset( $options['comments']['show_on'] ) ) {
 				if ( ( is_page() && ( $options['comments']['show_on'] == 'all pages' || $options['comments']['show_on'] == 'all posts and pages' ) )
 						or ( is_single() &&  ( $options['comments']['show_on'] == 'all posts' || $options['comments']['show_on'] == 'all posts and pages' ) ) )
 				{
@@ -61,7 +61,7 @@ function fb_comments_automatic($content) {
 					$content .= fb_get_comments( $params );
 				}
 			}
-			elseif ( 'show' == $show_indiv ) {
+			elseif ( 'show' == $show_indiv || ( ( ! isset( $options['comments']['show_on'] ) ) && ( 'default' == $show_indiv || empty( $show_indiv ) ) ) ) {
 				foreach( $options['comments'] as $param => $val ) {
 					$param = str_replace( '_', '-', $param );
 				

--- a/social-plugins/fb-like.php
+++ b/social-plugins/fb-like.php
@@ -55,7 +55,7 @@ function fb_like_button_automatic($content) {
 			elseif ( is_single() && ( $options['like']['show_on'] == 'all posts' || $options['like']['show_on'] == 'all posts and pages' ) )
 				$content = $new_content;
 		}
-		elseif ( 'show' == $show_indiv ) {
+		elseif ( 'show' == $show_indiv || ( ( ! isset( $options['like']['show_on'] ) ) && ( 'default' == $show_indiv || empty( $show_indiv ) ) ) ) {
 			$content = $new_content;
 		}
 	}

--- a/social-plugins/fb-recommendations-bar.php
+++ b/social-plugins/fb-recommendations-bar.php
@@ -9,14 +9,14 @@ function fb_recommendations_bar_automatic( $content ) {
 	global $post;
 	$show_indiv = get_post_meta( $post->ID, 'fb_social_plugin_settings_box_recommendations_bar', true );
 	$options = get_option('fb_options');
-	if ( ! is_home() && ( 'default' == $show_indiv || empty( $show_indiv ) ) && $options['recommendations_bar']['show_on'] ) {
+	if ( ! is_home() && ( 'default' == $show_indiv || empty( $show_indiv ) ) && isset( $options['recommendations_bar']['show_on'] ) ) {
 		if ( ( is_page() && ( $options['recommendations_bar']['show_on'] == 'all pages' || $options['recommendations_bar']['show_on'] == 'all posts and pages' ) )
 				or ( is_single() &&  ( $options['recommendations_bar']['show_on'] == 'all posts' || $options['recommendations_bar']['show_on'] == 'all posts and pages' ) ) )
 		{
 			$content .= fb_get_recommendations_bar( $options['recommendations_bar'] );
 		}
 	}
-	elseif ( 'show' == $show_indiv ) {
+	elseif ( 'show' == $show_indiv || ( ( ! isset( $options['recommendations_bar']['show_on'] ) ) && ( 'default' == $show_indiv || empty( $show_indiv ) ) ) ) {
 		$content .= fb_get_recommendations_bar( $options['recommendations_bar'] );
 	}
 	//elseif ( 'no' == $show_indiv ) {

--- a/social-plugins/fb-send.php
+++ b/social-plugins/fb-send.php
@@ -41,7 +41,7 @@ function fb_send_button_automatic($content) {
 			elseif ( is_single() && ( $options['send']['show_on'] == 'all posts' || $options['send']['show_on'] == 'all posts and pages' ) )
 				$content = $new_content;
 		}
-		elseif ( 'show' == $show_indiv ) {
+		elseif ( 'show' == $show_indiv || ( ( ! isset( $options['send']['show_on'] ) ) && ( 'default' == $show_indiv || empty( $show_indiv ) ) ) ) {
 			$content = $new_content;
 		}
 		

--- a/social-plugins/fb-subscribe.php
+++ b/social-plugins/fb-subscribe.php
@@ -52,7 +52,7 @@ function fb_subscribe_button_automatic($content) {
 			elseif ( is_single() && ( $options['subscribe']['show_on'] == 'all posts' || $options['subscribe']['show_on'] == 'all posts and pages' ) )
 				$content = $new_content;
 		}
-		elseif ( 'show' == $show_indiv ) {
+		elseif ( 'show' == $show_indiv || ( ( ! isset( $options['subscribe']['show_on'] ) ) && ( 'default' == $show_indiv || empty( $show_indiv ) ) ) ) {
 			$content = $new_content;
 		}
 	}


### PR DESCRIPTION
when users update from v1.0.1 to v1.0.2 it's not set and screws up their site. this fixes that.
