### PR TITLE
Move css files to <head>

### DIFF
--- a/fb-core.php
+++ b/fb-core.php
@@ -3,7 +3,7 @@ add_action( 'init', 'fb_init' );
 add_action( 'admin_notices', 'fb_install_warning' );
 add_action( 'admin_notices', 'fb_ssl_warning' );
 //add_action( 'admin_notices', 'fb_rate_message' );
-add_action( 'wp_enqueue_scripts', 'fb_style' );
+add_action( 'wp_head', 'fb_style' );
 
 /**
  * Display an admin-facing warning if the current user hasn't authenticated with Facebook yet
@@ -239,5 +239,5 @@ function fb_get_locale() {
  * @since 1.0
  */
 function fb_style() {
-	wp_enqueue_style( 'fb', plugins_url( 'style/style.css', __FILE__), array(), '1.0' );
+	echo '<link rel="stylesheet" id="fb-css"  href="' . plugins_url( 'style/style.css', __FILE__, array(), '1.0' ) . '" type="text/css" media="all" />' . "\n";
 }

--- a/fb-social-publisher.php
+++ b/fb-social-publisher.php
@@ -609,7 +609,7 @@ function fb_publish_later($new_status, $old_status, $post) {
 				fb_post_to_fb_page($post->ID);
                 
                 if (isset($options['social_publisher']['publish_to_authors_facebook_timeline'])) {
-				    fb_post_to_author_fb_timeline($post->ID);
+			        fb_post_to_author_fb_timeline($post->ID);
                 }
 				break;
 			}

--- a/social-plugins/fb-comments.php
+++ b/social-plugins/fb-comments.php
@@ -9,7 +9,7 @@ function fb_insights_page() {
 
 
 function fb_hide_wp_comments() {
-	wp_enqueue_style( 'fb_hide_wp_comments', plugins_url( 'style/hide-wp-comments.css', dirname(__FILE__)), array(), '1.0' );
+	echo "\n" . '<link rel="stylesheet" id="fb_hide_wp_comments-css"  href="' . plugins_url( 'style/hide-wp-comments.css', dirname(__FILE__), array(), '1.0' ) . '" type="text/css" media="all" />';
 }
 
 function fb_set_wp_comment_status ( $posts ) {

--- a/social-plugins/fb-social-plugins.php
+++ b/social-plugins/fb-social-plugins.php
@@ -45,7 +45,7 @@ function fb_apply_filters() {
 		add_filter( 'the_content', 'fb_comments_automatic', 30 );
 		add_filter( 'comments_array', 'fb_close_wp_comments' );
 		add_filter( 'the_posts', 'fb_set_wp_comment_status' );
-		add_action( 'wp_enqueue_scripts', 'fb_hide_wp_comments' );
+		add_action( 'wp_head', 'fb_hide_wp_comments' );
 		add_filter( 'comments_number', 'fb_get_comments_count' );
 	}
 }


### PR DESCRIPTION
Moves css files to head instead of footer

https://github.com/facebook/wordpress/issues/194
