### PR TITLE
Set priority of css files to 0 to put them in head

### DIFF
--- a/fb-core.php
+++ b/fb-core.php
@@ -3,7 +3,7 @@ add_action( 'init', 'fb_init' );
 add_action( 'admin_notices', 'fb_install_warning' );
 add_action( 'admin_notices', 'fb_ssl_warning' );
 //add_action( 'admin_notices', 'fb_rate_message' );
-add_action( 'wp_enqueue_scripts', 'fb_style' );
+add_action( 'wp_enqueue_scripts', 'fb_style', 0);
 
 /**
  * Display an admin-facing warning if the current user hasn't authenticated with Facebook yet

--- a/social-plugins/fb-social-plugins.php
+++ b/social-plugins/fb-social-plugins.php
@@ -45,7 +45,7 @@ function fb_apply_filters() {
 		add_filter( 'the_content', 'fb_comments_automatic', 30 );
 		add_filter( 'comments_array', 'fb_close_wp_comments' );
 		add_filter( 'the_posts', 'fb_set_wp_comment_status' );
-		add_action( 'wp_enqueue_scripts', 'fb_hide_wp_comments' );
+		add_action( 'wp_enqueue_scripts', 'fb_hide_wp_comments', 0);
     if ( isset($options['comments']['homepage_comments']['enabled']) ) {
       add_filter( 'comments_number', 'fb_get_comments_count' );
     } else {


### PR DESCRIPTION
CSS files will be loaded with priority for the wp_enqueue_scripts action

https://github.com/facebook/wordpress/issues/194
