### PR TITLE
Change controls to checkboxes and support custom post types

### DIFF
--- a/fb-admin-menu.php
+++ b/fb-admin-menu.php
@@ -579,7 +579,7 @@ function fb_options_validate_hex($value, $label, $sanitize=true) {
 	if (!preg_match('/^[0-9a-f]+$/i', $value)) {
 		$value = preg_replace('/[^0-9a-f]/', '', strtolower($value));
 		add_settings_error('fb_options', '', "$label has been converted to a hex string");
-	}
+    }
 	return $value;
 }
 
@@ -597,10 +597,8 @@ function fb_options_validate_namespace($value, $label, $sanitize=true) {
 function fb_options_validate_plugin($array, $label_prefix, $sanitize=true) {
 	// TODO desperately needs to be driven from plugin definitions
 	if ($sanitize) {
-		foreach($array as $key=>$value) {
-			$array[$key] = sanitize_text_field( $value );
-		}
-	}
+        $array = fb_sanitize_options($array);
+    }
 	if (!isset($array['enabled']) || !$array['enabled']) {
 		return $array;
 	}

--- a/fb-core.php
+++ b/fb-core.php
@@ -4,19 +4,7 @@ add_action( 'admin_notices', 'fb_install_warning' );
 add_action( 'admin_notices', 'fb_ssl_warning' );
 //add_action( 'admin_notices', 'fb_rate_message' );
 add_action( 'wp_enqueue_scripts', 'fb_style', 0);
-add_action( 'init', 'create_post_type' );
-function create_post_type() {
-    register_post_type( 'acme_product',
-        array(
-            'labels' => array(
-                'name' => __( 'Products' ),
-                'singular_name' => __( 'Product' )
-            ),
-            'public' => true,
-            'has_archive' => true,
-        )
-    );
-}
+
 /**
  * Display an admin-facing warning if the current user hasn't authenticated with Facebook yet
  *

--- a/fb-core.php
+++ b/fb-core.php
@@ -4,7 +4,19 @@ add_action( 'admin_notices', 'fb_install_warning' );
 add_action( 'admin_notices', 'fb_ssl_warning' );
 //add_action( 'admin_notices', 'fb_rate_message' );
 add_action( 'wp_enqueue_scripts', 'fb_style', 0);
-
+add_action( 'init', 'create_post_type' );
+function create_post_type() {
+    register_post_type( 'acme_product',
+        array(
+            'labels' => array(
+                'name' => __( 'Products' ),
+                'singular_name' => __( 'Product' )
+            ),
+            'public' => true,
+            'has_archive' => true,
+        )
+    );
+}
 /**
  * Display an admin-facing warning if the current user hasn't authenticated with Facebook yet
  *

--- a/fb-social-publisher-mentioning.php
+++ b/fb-social-publisher-mentioning.php
@@ -137,22 +137,21 @@ function fb_add_page_mention_box() {
 	if ($post->post_status == 'publish')
 		return;
 
-  if ( isset( $options['social_publisher']['enabled'] ) ) {
-    add_meta_box(
-        'fb_page_mention_box_id',
-        __( 'Mention Facebook Pages', 'facebook' ),
-        'fb_add_page_mention_box_content',
-        'post',
-        'side'
-    );
-    add_meta_box(
-        'fb_page_mention_box_id',
-        __( 'Mention Facebook Pages', 'facebook' ),
-        'fb_add_page_mention_box_content',
-        'page',
-        'side'
-    );
-  }
+    if ( isset( $options['social_publisher']['enabled'] ) ) {
+        $post_types = get_post_types(array('public' => true));
+        unset($post_types['attachment']);
+        $post_types = array_values($post_types);
+
+        foreach ( $post_types as $post_type ) {
+            add_meta_box(
+                'fb_page_mention_box_id',
+                __( 'Mention Facebook Pages', 'facebook' ),
+                'fb_add_page_mention_box_content',
+                $post_type,
+                'side'
+          );
+        }
+    }
 }
 
 function fb_add_page_mention_box_content( $post ) {
@@ -257,22 +256,22 @@ function fb_add_friend_mention_box() {
 	if ($post->post_status == 'publish')
 		return;
 
-  if ( isset( $options['social_publisher']['enabled'] ) ) {
-    add_meta_box(
-        'fb_friend_mention_box_id',
-        __( 'Mention Facebook Friends', 'facebook' ),
-        'fb_add_friend_mention_box_content',
-        'post',
-        'side'
-    );
-    add_meta_box(
-        'fb_friend_mention_box_id',
-        __( 'Mention Facebook Friends', 'facebook' ),
-        'fb_add_friend_mention_box_content',
-        'page',
-        'side'
-    );
-  }
+    if ( isset( $options['social_publisher']['enabled'] ) ) {
+        $post_types = get_post_types(array('public' => true));
+        unset($post_types['attachment']);
+        $post_types = array_values($post_types);
+
+        foreach ( $post_types as $post_type ) {
+
+            add_meta_box(
+                'fb_friend_mention_box_id',
+                __( 'Mention Facebook Friends', 'facebook' ),
+                'fb_add_friend_mention_box_content',
+                $post_type,
+                'side'
+            );
+        }
+    }
 }
 
 function fb_add_friend_mention_box_content( $post ) {

--- a/fb-wp-helpers.php
+++ b/fb-wp-helpers.php
@@ -69,9 +69,9 @@ function fb_construct_fields_children($place, $fields, $parent = null, $object =
 			$fields[$c] = $field;
 		}
 	}
-	elseif ($place == 'settings') {
+    elseif ($place == 'settings') { 
 		foreach ($fields as $c => $field) {
-			if ($parent) {
+            if ($parent) {
 				$value = fb_array_default(
 					$options, $parent['name'], $field['name'], (
 						empty($options[$parent['name']]['enabled']) ?
@@ -91,30 +91,28 @@ function fb_construct_fields_children($place, $fields, $parent = null, $object =
 				$parent_js_array = '[' . $parent['name'] . ']';
 			}
 
-			$field['value'] = $value;
+            $field['value'] = $value;
 			$field['name'] = "fb_options$parent_js_array"."[" . $field['name'] ."]";
 			$fields[$c] = $field;
-
 		}
 	}
-
 	return fb_fields($fields, $place);
 }
 
 function fb_array_default() { // $array, $keys..., $default
 	$keys = func_get_args();
 	$array = array_shift($keys);
-	$default = array_pop($keys);
-	$key = array_shift($keys);
+    $default = array_pop($keys);
+    $key = array_shift($keys);
 	if (!isset($array[$key])) {
 		return $default;
 	}
 	$array = $array[$key];
 	if (sizeof($keys)>0) {
 		array_unshift($keys, $array);
-		array_push($keys, $default);
+        array_push($keys, $default);
 		return call_user_func_array('fb_array_default', $keys);
-	}
+    }
 	return $array;
 }
 
@@ -199,13 +197,26 @@ function fb_field_checkbox($field, $place='settings') {
 	if (isset($field['onclick'])) {
 		$onclick = $field['onclick'];
 	}
-		
-	return sprintf(
-		'<input type="checkbox" id="%1$s" name="%1$s" onclick="%2$s" value="true" %3$s />',
-		esc_attr($field['name']),
-		esc_js( $onclick ),
-		checked($field['value'], 'true', false)
-	);
+
+    if (isset($field['options'])) {
+        foreach ($field['options'] as $option_value => $option_label) {
+            $buffer .= sprintf(
+                '<label for="%2$s">%1$s</label><input type="checkbox" class="multicheckbox" id="%2$s" name="%2$s" onclick="%3$s" value="true" %4$s />',
+                esc_html($option_label),
+                esc_attr($field['name'] . "[$option_label]"),
+                esc_js( $onclick ),
+                checked($field['value'][$option_label], 'true', false)
+            );
+        }
+        return $buffer;
+    } else {
+        return sprintf(
+            '<input type="checkbox" id="%1$s" name="%1$s" onclick="%2$s" value="true" %3$s />',
+            esc_attr($field['name']),
+            esc_js( $onclick ),
+            checked($field['value'], 'true', false)
+        );
+    }
 }
 
 function fb_field_dropdown($field, $place='settings') {
@@ -291,5 +302,17 @@ function fb_option_name($field){
 			break;
 	}
 }
+
+function fb_sanitize_options ($options_array) {
+    foreach ($options_array as $key => $value) {
+        if (is_array($value)) {
+            $options_array[$key] = fb_sanitize_options($value);
+        } else {
+            $options_array[$key] = sanitize_text_field($value);
+        }
+    }
+    return $options_array;
+}
+
 
 ?>

--- a/social-plugins/fb-comments.php
+++ b/social-plugins/fb-comments.php
@@ -52,18 +52,14 @@ function fb_comments_automatic($content) {
 		if ( comments_open( get_the_ID() ) && post_type_supports( get_post_type(), 'comments' ) ) {
 			$options = get_option('fb_options');
 			$show_indiv = get_post_meta( $post->ID, 'fb_social_plugin_settings_box_comments', true );
-			if ( ! is_home() && ( 'default' == $show_indiv || empty( $show_indiv ) ) && isset( $options['comments']['show_on'] ) ) {
-				if ( ( is_page() && ( $options['comments']['show_on'] == 'all pages' || $options['comments']['show_on'] == 'all posts and pages' ) )
-						or ( is_single() &&  ( $options['comments']['show_on'] == 'all posts' || $options['comments']['show_on'] == 'all posts and pages' ) ) )
-				{
-					foreach( $options['comments'] as $param => $val ) {
-						$param = str_replace( '_', '-', $param );
+            if ( ! is_home() && ( 'default' == $show_indiv || empty( $show_indiv ) ) && isset( $options['comments']['show_on'] ) && isset( $options['comments']['show_on'][$post->post_type] ) ) {
+                foreach( $options['comments'] as $param => $val ) {
+                    $param = str_replace( '_', '-', $param );
 
-						$params[$param] = $val;
-					}
+                    $params[$param] = $val;
+                }
 
-					$content .= fb_get_comments( $params );
-				}
+                $content .= fb_get_comments( $params );
 			}
 			elseif ( 'show' == $show_indiv || ( ( ! isset( $options['comments']['show_on'] ) ) && ( 'default' == $show_indiv || empty( $show_indiv ) ) ) ) {
 				foreach( $options['comments'] as $param => $val ) {
@@ -142,7 +138,9 @@ function fb_get_comments_fields_array() {
 									'help_link' => 'https://developers.facebook.com/docs/reference/plugins/comments/',
 									'image' => plugins_url( '/images/settings_comments.png', dirname(__FILE__))
 									);
-
+    $post_types = get_post_types(array('public' => true));
+    unset($post_types['attachment']);
+    $post_types = array_values($post_types);
 	$array['children'] = array(array('name' => 'num_posts',
 													'label' => 'Number of posts',
 													'type' => 'text',
@@ -162,10 +160,10 @@ function fb_get_comments_fields_array() {
 													'help_text' => 'The color scheme of the plugin.',
 													),
 										array('name' => 'show_on',
-													'type' => 'dropdown',
-													'default' => 'all posts and pages',
-													'options' => array('all posts' => 'all posts', 'all pages' => 'all pages', 'all posts and pages' => 'all posts and pages', 'individual posts and pages' => 'individual posts and pages' ),
-													'help_text' => __( 'Whether the plugin will appear on all posts or pages by default. If "individual posts and pages" is selected, you must explicitly set each post and page to display the plugin.', 'facebook' ),
+													'type' => 'checkbox',
+                                                    'default' => array_fill_keys(array_keys($post_types) , 'true'),
+                                                    'options' => $post_types,
+                                                    'help_text' => __( 'Whether the plugin will appear on all posts or pages by default. If "individual posts and pages" is selected, you must explicitly set each post and page to display the plugin.', 'facebook' ),
                          ),
                     array('name' => 'homepage_comments',
                           'label' => 'Show comment counts on the homepage',

--- a/social-plugins/fb-comments.php
+++ b/social-plugins/fb-comments.php
@@ -139,8 +139,6 @@ function fb_get_comments_fields_array() {
 									'image' => plugins_url( '/images/settings_comments.png', dirname(__FILE__))
 									);
     $post_types = get_post_types(array('public' => true));
-    unset($post_types['attachment']);
-    $post_types = array_values($post_types);
 	$array['children'] = array(array('name' => 'num_posts',
 													'label' => 'Number of posts',
 													'type' => 'text',

--- a/social-plugins/fb-like.php
+++ b/social-plugins/fb-like.php
@@ -46,10 +46,10 @@ function fb_like_button_automatic($content) {
 	
 		$show_indiv = get_post_meta( $post->ID, 'fb_social_plugin_settings_box_like', true );
 		
-		if ( is_home() && isset ( $options['like']['show_on_homepage'] ) && isset($options['like']['show_on'][$post->post_type]) ) {
+		if ( is_home() && isset ( $options['like']['show_on_homepage'] ) && isset ( $options['like']['show_on'] ) && isset( $options['like']['show_on'][ $post->post_type ] ) ) {
 			$content = $new_content;
 		}
-		elseif ( !is_home() && ( 'default' == $show_indiv || empty( $show_indiv ) ) && isset ( $options['like']['show_on'] ) && isset($options['like']['show_on'][$post->post_type]) ) {		
+		elseif ( !is_home() && ( 'default' == $show_indiv || empty( $show_indiv ) ) && isset ( $options['like']['show_on'] ) && isset( $options['like']['show_on'][ $post->post_type ]) ) {		
             $content = $new_content;
 		}
 		elseif ( !is_home() && ('show' == $show_indiv || ( ( ! isset( $options['like']['show_on'] ) ) && ( 'default' == $show_indiv || empty( $show_indiv ) ) ) )) {
@@ -198,8 +198,8 @@ function fb_get_like_fields_array($placement) {
 													'help_text' => __( 'Where the button will display on the page or post.', 'facebook' ),
                                                 );
         $post_types = get_post_types(array('public' => true));
-        unset($post_types['attachment']);
-        $post_types = array_values($post_types);
+        //unset($post_types['attachment']);
+        //$post_types = array_values($post_types);
 		$array['children'][] = array('name' => 'show_on',
 													'type' => 'checkbox',
 													'default' => array_fill_keys(array_keys($post_types) , 'true'),

--- a/social-plugins/fb-like.php
+++ b/social-plugins/fb-like.php
@@ -46,16 +46,13 @@ function fb_like_button_automatic($content) {
 	
 		$show_indiv = get_post_meta( $post->ID, 'fb_social_plugin_settings_box_like', true );
 		
-		if ( is_home() && isset ( $options['like']['show_on_homepage'] ) ) {
+		if ( is_home() && isset ( $options['like']['show_on_homepage'] ) && isset($options['like']['show_on'][$post->post_type]) ) {
 			$content = $new_content;
 		}
-		elseif ( ( 'default' == $show_indiv || empty( $show_indiv ) ) && isset ( $options['like']['show_on'] ) ) {		
-			if ( is_page() && ( $options['like']['show_on'] == 'all pages' || $options['like']['show_on'] == 'all posts and pages' ) )
-				$content = $new_content;
-			elseif ( is_single() && ( $options['like']['show_on'] == 'all posts' || $options['like']['show_on'] == 'all posts and pages' ) )
-				$content = $new_content;
+		elseif ( !is_home() && ( 'default' == $show_indiv || empty( $show_indiv ) ) && isset ( $options['like']['show_on'] ) && isset($options['like']['show_on'][$post->post_type]) ) {		
+            $content = $new_content;
 		}
-		elseif ( 'show' == $show_indiv || ( ( ! isset( $options['like']['show_on'] ) ) && ( 'default' == $show_indiv || empty( $show_indiv ) ) ) ) {
+		elseif ( !is_home() && ('show' == $show_indiv || ( ( ! isset( $options['like']['show_on'] ) ) && ( 'default' == $show_indiv || empty( $show_indiv ) ) ) )) {
 			$content = $new_content;
 		}
 	}
@@ -199,11 +196,14 @@ function fb_get_like_fields_array($placement) {
 													'default' => 'both',
 													'options' => array('top' => 'top', 'bottom' => 'bottom', 'both' => 'both'),
 													'help_text' => __( 'Where the button will display on the page or post.', 'facebook' ),
-													);
+                                                );
+        $post_types = get_post_types(array('public' => true));
+        unset($post_types['attachment']);
+        $post_types = array_values($post_types);
 		$array['children'][] = array('name' => 'show_on',
-													'type' => 'dropdown',
-													'default' => 'all posts and pages',
-													'options' => array('all posts' => 'all posts', 'all pages' => 'all pages', 'all posts and pages' => 'all posts and pages', 'individual posts and pages' => 'individual posts and pages' ),
+													'type' => 'checkbox',
+													'default' => array_fill_keys(array_keys($post_types) , 'true'),
+													'options' => $post_types, 
 													'help_text' => __( 'Whether the plugin will appear on all posts or pages by default. If "individual posts and pages" is selected, you must explicitly set each post and page to display the plugin.', 'facebook' ),
 													);
 		$array['children'][] = array('name' => 'show_on_homepage',

--- a/social-plugins/fb-recommendations-bar.php
+++ b/social-plugins/fb-recommendations-bar.php
@@ -9,12 +9,8 @@ function fb_recommendations_bar_automatic( $content ) {
 	global $post;
 	$show_indiv = get_post_meta( $post->ID, 'fb_social_plugin_settings_box_recommendations_bar', true );
 	$options = get_option('fb_options');
-	if ( ! is_home() && ( 'default' == $show_indiv || empty( $show_indiv ) ) && isset( $options['recommendations_bar']['show_on'] ) ) {
-		if ( ( is_page() && ( $options['recommendations_bar']['show_on'] == 'all pages' || $options['recommendations_bar']['show_on'] == 'all posts and pages' ) )
-				or ( is_single() &&  ( $options['recommendations_bar']['show_on'] == 'all posts' || $options['recommendations_bar']['show_on'] == 'all posts and pages' ) ) )
-		{
-			$content .= fb_get_recommendations_bar( $options['recommendations_bar'] );
-		}
+	if ( ! is_home() && ( 'default' == $show_indiv || empty( $show_indiv ) ) && isset( $options['recommendations_bar']['show_on']) && isset( $options['recommendations_bar']['show_on'][$post->post_type] ) )  {
+        $content .= fb_get_recommendations_bar( $options['recommendations_bar'] );
 	}
 	elseif ( 'show' == $show_indiv || ( ( ! isset( $options['recommendations_bar']['show_on'] ) ) && ( 'default' == $show_indiv || empty( $show_indiv ) ) ) ) {
 		$content .= fb_get_recommendations_bar( $options['recommendations_bar'] );
@@ -39,7 +35,9 @@ function fb_get_recommendations_bar_fields_array() {
 														'description' => 'The Recommendations Bar allows users to click to start getting recommendations, Like content, and add what they\'re reading to Timeline as they go.',
 														'image' => plugins_url( '/images/settings_recommendations_bar.png', dirname(__FILE__))
 									);
-
+    $post_types = get_post_types(array('public' => true));
+    unset($post_types['attachment']);
+    $post_types = array_values($post_types);
 	$array['children'] = array(array('name' => 'trigger',
 													'type' => 'text',
 													'default' => '50',
@@ -63,10 +61,10 @@ function fb_get_recommendations_bar_fields_array() {
 													'help_text' => __( 'The side of the window that the plugin will display.', 'facebook' ),
 													),
 										array('name' => 'show_on',
-													'type' => 'dropdown',
-													'default' => 'all posts and pages',
-													'options' => array('all posts' => 'all posts', 'all pages' => 'all pages', 'all posts and pages' => 'all posts and pages', 'individual posts and pages' => 'individual posts and pages' ),
-													'help_text' => __( 'Whether the plugin will appear on all posts or pages by default. If "individual posts and pages" is selected, you must explicitly set each post and page to display the plugin.', 'facebook' ),
+                                                    'type' => 'checkbox',
+                                                    'default' => array_fill_keys(array_keys($post_types) , 'true'),
+                                                    'options' => $post_types,
+                                                    'help_text' => __( 'Whether the plugin will appear on all posts or pages by default. If "individual posts and pages" is selected, you must explicitly set each post and page to display the plugin.', 'facebook' ),
 													)
 										);
 

--- a/social-plugins/fb-recommendations-bar.php
+++ b/social-plugins/fb-recommendations-bar.php
@@ -36,8 +36,6 @@ function fb_get_recommendations_bar_fields_array() {
 														'image' => plugins_url( '/images/settings_recommendations_bar.png', dirname(__FILE__))
 									);
     $post_types = get_post_types(array('public' => true));
-    unset($post_types['attachment']);
-    $post_types = array_values($post_types);
 	$array['children'] = array(array('name' => 'trigger',
 													'type' => 'text',
 													'default' => '50',

--- a/social-plugins/fb-send.php
+++ b/social-plugins/fb-send.php
@@ -32,10 +32,10 @@ function fb_send_button_automatic($content) {
 		
 		$show_indiv = get_post_meta( $post->ID, 'fb_social_plugin_settings_box_send', true );
 		
-		if ( is_home() && isset ( $options['send']['show_on_homepage'] ) && isset($options['send']['show_on'][$post->post_type]) ) {
+		if ( is_home() && isset ( $options['send']['show_on_homepage'] ) && isset( $options['send']['show_on'] ) && isset( $options['send']['show_on'][$post->post_type] ) ) {
 			$content = $new_content;
 		}
-		elseif ( !is_home() && ( 'default' == $show_indiv || empty( $show_indiv ) ) && isset ( $options['send']['show_on'] ) && isset($options['send']['show_on'][$post->post_type]) ) {		
+		elseif ( !is_home() && ( 'default' == $show_indiv || empty( $show_indiv ) ) && isset ( $options['send']['show_on'] ) && isset( $options['send']['show_on'][$post->post_type] ) ) {		
             $content = $new_content;
 		}
 		elseif ( !is_home() && ('show' == $show_indiv || ( ( ! isset( $options['send']['show_on'] ) ) && ( 'default' == $show_indiv || empty( $show_indiv ) ) ) ) ) {
@@ -163,8 +163,6 @@ function fb_get_send_fields_array($placement) {
 													);
         
         $post_types = get_post_types(array('public' => true));
-        unset($post_types['attachment']);
-        $post_types = array_values($post_types);
         $array['children'][] = array('name' => 'show_on',
 													'type' => 'checkbox',
                                                     'default' => array_fill_keys(array_keys($post_types) , 'true'),

--- a/social-plugins/fb-send.php
+++ b/social-plugins/fb-send.php
@@ -32,16 +32,13 @@ function fb_send_button_automatic($content) {
 		
 		$show_indiv = get_post_meta( $post->ID, 'fb_social_plugin_settings_box_send', true );
 		
-		if ( is_home() && isset ( $options['send']['show_on_homepage'] ) ) {
+		if ( is_home() && isset ( $options['send']['show_on_homepage'] ) && isset($options['send']['show_on'][$post->post_type]) ) {
 			$content = $new_content;
 		}
-		elseif ( ( 'default' == $show_indiv || empty( $show_indiv ) ) && isset ( $options['send']['show_on'] ) ) {		
-			if ( is_page() && ( $options['send']['show_on'] == 'all pages' || $options['send']['show_on'] == 'all posts and pages' ) )
-				$content = $new_content;
-			elseif ( is_single() && ( $options['send']['show_on'] == 'all posts' || $options['send']['show_on'] == 'all posts and pages' ) )
-				$content = $new_content;
+		elseif ( !is_home() && ( 'default' == $show_indiv || empty( $show_indiv ) ) && isset ( $options['send']['show_on'] ) && isset($options['send']['show_on'][$post->post_type]) ) {		
+            $content = $new_content;
 		}
-		elseif ( 'show' == $show_indiv || ( ( ! isset( $options['send']['show_on'] ) ) && ( 'default' == $show_indiv || empty( $show_indiv ) ) ) ) {
+		elseif ( !is_home() && ('show' == $show_indiv || ( ( ! isset( $options['send']['show_on'] ) ) && ( 'default' == $show_indiv || empty( $show_indiv ) ) ) ) ) {
 			$content = $new_content;
 		}
 		
@@ -164,11 +161,15 @@ function fb_get_send_fields_array($placement) {
 													'options' => array('top' => 'top', 'bottom' => 'bottom', 'both' => 'both'),
 													'help_text' => __( 'Where the button will display on the page or post.', 'facebook' ),
 													);
-		$array['children'][] = array('name' => 'show_on',
-													'type' => 'dropdown',
-													'default' => 'all posts and pages',
-													'options' => array('all posts' => 'all posts', 'all pages' => 'all pages', 'all posts and pages' => 'all posts and pages', 'individual posts and pages' => 'individual posts and pages' ),
-													'help_text' => __( 'Whether the plugin will appear on all posts or pages by default. If "individual posts and pages" is selected, you must explicitly set each post and page to display the plugin.', 'facebook' ),
+        
+        $post_types = get_post_types(array('public' => true));
+        unset($post_types['attachment']);
+        $post_types = array_values($post_types);
+        $array['children'][] = array('name' => 'show_on',
+													'type' => 'checkbox',
+                                                    'default' => array_fill_keys(array_keys($post_types) , 'true'),
+                                                    'options' => $post_types,
+                                                    'help_text' => __( 'Whether the plugin will appear on all posts or pages by default. If "individual posts and pages" is selected, you must explicitly set each post and page to display the plugin.', 'facebook' ),
 													);
 		$array['children'][] = array('name' => 'show_on_homepage',
 													'type' => 'checkbox',

--- a/social-plugins/fb-social-plugins.php
+++ b/social-plugins/fb-social-plugins.php
@@ -114,7 +114,7 @@ function fb_add_social_plugin_settings_box_content( $post ) {
 				. ( $value == 'show' ? 'checked="checked" ' : '' ) . "/>Show</label></td> <td><label><input type=\"radio\" name=\"fb_social_plugin_settings_box_$feature\" value =\"hide\" "
 				. ( $value == 'hide'  ? 'checked="checked" ' : '' ) . "/>Hide</label></td> </tr>" ;
 		}
-	}
+    }
 	echo '</table><p class="howto"> If \'Default\' is selected, the Social Plugin will appear based on the global setting, set on the Facebook Settings page.  If you choose "Show" or "Hide", the Social Plugin will ignore the global setting for this ' . $post->post_type . '.</p>';
 }
 

--- a/social-plugins/fb-social-plugins.php
+++ b/social-plugins/fb-social-plugins.php
@@ -83,18 +83,15 @@ function fb_add_social_plugin_settings_box() {
 	global $post;
 	$options = get_option('fb_options');
 
-	if ( true ) {
+    $post_types = get_post_types(array('public' => true));
+    unset($post_types['attachment']);
+    $post_types = array_values($post_types);
+    foreach ( $post_types as $post_type ) {
 		add_meta_box(
 				'fb_social_plugin_settings_box_id',
 				__( 'Facebook Social Plugins', 'facebook' ),
 				'fb_add_social_plugin_settings_box_content',
-				'post'
-		);
-		add_meta_box(
-				'fb_social_plugin_settings_box_id',
-				__( 'Facebook Social Plugins', 'facebook' ),
-				'fb_add_social_plugin_settings_box_content',
-				'page'
+				$post_type
 		);
 	}
 }
@@ -111,14 +108,14 @@ function fb_add_social_plugin_settings_box_content( $post ) {
 	echo '<table><p>Change the settings below to show or hide particular Social Plugins. </p>';
 	foreach ( $features as $feature ) {
 		if ( isset ( $options[ $feature ]['enabled'] ) ) {
-			$value = get_post_meta($post->ID,"fb_social_plugin_settings_box_$feature",true);
+            $value = get_post_meta($post->ID,"fb_social_plugin_settings_box_$feature",true);
 			echo '<tr><td>' . fb_option_name( $feature ) . "</td> <td><label><input type = \"radio\" name=\"fb_social_plugin_settings_box_$feature\" value=\"default\" "
-				. ( $value == 'default' || empty($value) ? 'checked="checked" ' : '' ) . "/>Default (" . $options[$feature]['show_on'] . ")</label></td> <td><label><input type=\"radio\" name=\"fb_social_plugin_settings_box_$feature\" value =\"show\" "
+				. ( $value == 'default' || empty($value) ? 'checked="checked" ' : '' ) . "/>Default (" . (isset($options[$feature]['show_on']) && isset($options[$feature]['show_on'][$post->post_type]) ? 'Show' : 'Hide') . ")</label></td> <td><label><input type=\"radio\" name=\"fb_social_plugin_settings_box_$feature\" value =\"show\" "
 				. ( $value == 'show' ? 'checked="checked" ' : '' ) . "/>Show</label></td> <td><label><input type=\"radio\" name=\"fb_social_plugin_settings_box_$feature\" value =\"hide\" "
 				. ( $value == 'hide'  ? 'checked="checked" ' : '' ) . "/>Hide</label></td> </tr>" ;
 		}
 	}
-	echo '</table><p class="howto"> If \'Default\' is selected, the Social Plugin will appear based on the global setting, set on the Facebook Settings page.  If you choose "Show" or "Hide", the Social Plugin will ignore the global setting for this ' . ( $post->post_type == 'page' ? 'page' : 'post' ) . '.</p>';
+	echo '</table><p class="howto"> If \'Default\' is selected, the Social Plugin will appear based on the global setting, set on the Facebook Settings page.  If you choose "Show" or "Hide", the Social Plugin will ignore the global setting for this ' . $post->post_type . '.</p>';
 }
 
 function fb_add_social_plugin_settings_box_save( $post_id ) {

--- a/social-plugins/fb-subscribe.php
+++ b/social-plugins/fb-subscribe.php
@@ -43,10 +43,10 @@ function fb_subscribe_button_automatic($content) {
 	
 		$show_indiv = get_post_meta( $post->ID, 'fb_social_plugin_settings_box_subscribe', true );
 		
-		if ( is_home() && isset ( $options['subscribe']['show_on_homepage'] ) && isset($options['subscribe']['show_on'][$post->post_type])) {
+		if ( is_home() && isset ( $options['subscribe']['show_on_homepage'] ) && isset( $options['subscribe']['show_on'] ) && isset( $options['subscribe']['show_on'][$post->post_type] ) ) {
 			$content = $new_content;
 		}
-		elseif ( !is_home() && ( 'default' == $show_indiv || empty( $show_indiv ) ) && isset ( $options['subscribe']['show_on'] ) && isset($options['subscribe']['show_on'][$post->post_type]) ) {		
+		elseif ( !is_home() && ( 'default' == $show_indiv || empty( $show_indiv ) ) && isset ( $options['subscribe']['show_on'] ) && isset( $options['subscribe']['show_on'][$post->post_type] ) ) {		
             $content = $new_content;
 		}
 		elseif ( !is_home() && ('show' == $show_indiv || ( ( ! isset( $options['subscribe']['show_on'] ) ) && ( 'default' == $show_indiv || empty( $show_indiv ) ) ) ) ) {
@@ -191,8 +191,6 @@ function fb_get_subscribe_fields_array($placement) {
 													'help_text' => __( 'Where the button will display on the page or post.', 'facebook' ),
                                                 );
         $post_types = get_post_types(array('public' => true));
-        unset($post_types['attachment']);
-        $post_types = array_values($post_types);
 		$array['children'][] = array('name' => 'show_on',
                                                     'type' => 'checkbox',
                                                     'default' => array_fill_keys(array_keys($post_types) , 'true'),

--- a/social-plugins/fb-subscribe.php
+++ b/social-plugins/fb-subscribe.php
@@ -43,16 +43,13 @@ function fb_subscribe_button_automatic($content) {
 	
 		$show_indiv = get_post_meta( $post->ID, 'fb_social_plugin_settings_box_subscribe', true );
 		
-		if ( is_home() && isset ( $options['subscribe']['show_on_homepage'] ) ) {
+		if ( is_home() && isset ( $options['subscribe']['show_on_homepage'] ) && isset($options['subscribe']['show_on'][$post->post_type])) {
 			$content = $new_content;
 		}
-		elseif ( ( 'default' == $show_indiv || empty( $show_indiv ) ) && isset ( $options['subscribe']['show_on'] ) ) {		
-			if ( is_page() && ( $options['subscribe']['show_on'] == 'all pages' || $options['subscribe']['show_on'] == 'all posts and pages' ) )
-				$content = $new_content;
-			elseif ( is_single() && ( $options['subscribe']['show_on'] == 'all posts' || $options['subscribe']['show_on'] == 'all posts and pages' ) )
-				$content = $new_content;
+		elseif ( !is_home() && ( 'default' == $show_indiv || empty( $show_indiv ) ) && isset ( $options['subscribe']['show_on'] ) && isset($options['subscribe']['show_on'][$post->post_type]) ) {		
+            $content = $new_content;
 		}
-		elseif ( 'show' == $show_indiv || ( ( ! isset( $options['subscribe']['show_on'] ) ) && ( 'default' == $show_indiv || empty( $show_indiv ) ) ) ) {
+		elseif ( !is_home() && ('show' == $show_indiv || ( ( ! isset( $options['subscribe']['show_on'] ) ) && ( 'default' == $show_indiv || empty( $show_indiv ) ) ) ) ) {
 			$content = $new_content;
 		}
 	}
@@ -192,12 +189,15 @@ function fb_get_subscribe_fields_array($placement) {
 													'default' => 'both',
 													'options' => array('top' => 'top', 'bottom' => 'bottom', 'both' => 'both'),
 													'help_text' => __( 'Where the button will display on the page or post.', 'facebook' ),
-													);
+                                                );
+        $post_types = get_post_types(array('public' => true));
+        unset($post_types['attachment']);
+        $post_types = array_values($post_types);
 		$array['children'][] = array('name' => 'show_on',
-													'type' => 'dropdown',
-													'default' => 'all posts and pages',
-													'options' => array('all posts' => 'all posts', 'all pages' => 'all pages', 'all posts and pages' => 'all posts and pages', 'individual posts and pages' => 'individual posts and pages' ),
-													'help_text' => __( 'Whether the plugin will appear on all posts or pages by default. If "individual posts and pages" is selected, you must explicitly set each post and page to display the plugin.', 'facebook' ),
+                                                    'type' => 'checkbox',
+                                                    'default' => array_fill_keys(array_keys($post_types) , 'true'),
+                                                    'options' => $post_types,
+                                                    'help_text' => __( 'Whether the plugin will appear on all posts or pages by default. If "individual posts and pages" is selected, you must explicitly set each post and page to display the plugin.', 'facebook' ),
 													);
 		$array['children'][] = array('name' => 'show_on_homepage',
 													'type' => 'checkbox',

--- a/style/style-admin.css
+++ b/style/style-admin.css
@@ -77,3 +77,7 @@ body.toplevel_page_facebook-settings .wp_help_hover {
     margin: 0 10px 0 5px !important;
     vertical-align: middle !important;
 }
+#fb_social_plugin_settings_box_id input[type="radio"] {
+    margin: 0 5px;
+}
+

--- a/style/style-admin.css
+++ b/style/style-admin.css
@@ -73,3 +73,7 @@ body.toplevel_page_facebook-settings .wp_help_hover {
 .updated img {
   border: 1px solid;
 }
+.multicheckbox {
+    margin: 0 10px 0 5px !important;
+    vertical-align: middle !important;
+}


### PR DESCRIPTION
Changed the drop down controls to checkboxes and also added support for custom post types. Right now  custom post types can not display a custom fb fan page message or author timeline message without the revisions option for that content type turned on. This is because custom content types go through the hook 'save_post' before 'transition_post_status' so the message meta data cannot be added before we post to Facebook. Content types with revisions turned on go through each hook twice so they work fine.
