### PR TITLE
Delete data created by plugin during uninstall

### DIFF
--- a/facebook.php
+++ b/facebook.php
@@ -38,3 +38,18 @@ require_once( $facebook_plugin_directory . '/fb-login.php' );
 require_once( $facebook_plugin_directory . '/fb-social-publisher.php' );
 require_once( $facebook_plugin_directory . '/fb-wp-helpers.php' );
 unset( $facebook_plugin_directory );
+
+register_uninstall_hook( __FILE__, 'fb_uninstall' );
+
+function fb_uninstall() {
+    
+    $meta_keys = array('state', 'code', 'access_token', 'user_id', 'fb_data');
+    
+    foreach ( $meta_keys as $meta_key ) {
+        delete_user_meta( get_current_user_id(), $meta_key );    
+    }
+    
+    delete_option( 'fb_options' );
+    delete_option( 'fb_flush_rewrite_rules' );
+}
+

--- a/includes/facebook-php-sdk/facebook.php
+++ b/includes/facebook-php-sdk/facebook.php
@@ -40,7 +40,7 @@ class WP_Facebook extends WP_BaseFacebook
   }
 
   protected static $kSupportedKeys =
-    array('state', 'code', 'access_token', 'user_id');
+    array('state', 'code', 'access_token', 'user_id', 'fb_data');
 
   /**
    * Provides the implementations of the inherited abstract

--- a/includes/facebook-php-sdk/facebook.php
+++ b/includes/facebook-php-sdk/facebook.php
@@ -40,7 +40,7 @@ class WP_Facebook extends WP_BaseFacebook
   }
 
   protected static $kSupportedKeys =
-    array('state', 'code', 'access_token', 'user_id', 'fb_data');
+    array('state', 'code', 'access_token', 'user_id');
 
   /**
    * Provides the implementations of the inherited abstract


### PR DESCRIPTION
Uses uninstall hook vs uninstall.php, not sure which would be better. Facebook class has clearAllPersistentData but is protected so I just do it manually here.
