### PR TITLE
Fix send and show faces options for fb like in posts and widgets

### DIFF
--- a/social-plugins/fb-like.php
+++ b/social-plugins/fb-like.php
@@ -14,15 +14,15 @@
  */
 
 function fb_get_like_button($options = array()) {
-	$params = fb_build_social_plugin_params($options);
+    $params = fb_build_social_plugin_params($options, 'like');
 	
 	return '<div class="fb-like fb-social-plugin" ' . $params . ' ></div>';
 }
 
 function fb_like_button_automatic($content) {
 	$options = get_option('fb_options');
-	
-	global $post;
+    
+    global $post;
 	
 	if ( isset ( $post ) ) {
 		if ( isset($options['like']['show_on_homepage']) ) {
@@ -150,7 +150,7 @@ function fb_get_like_fields_array($placement) {
 														'help_link' => 'https://developers.facebook.com/docs/reference/plugins/like/',
 														);
 
-	$array['children'] = array(array('name' => 'send',
+	$array['children'] = array(         array('name' => 'send',
 													'type' => 'checkbox',
 													'default' => true,
 													'help_text' => __( 'Include a send button.', 'facebook' ),

--- a/social-plugins/fb-social-plugins.php
+++ b/social-plugins/fb-social-plugins.php
@@ -55,15 +55,24 @@ function fb_apply_filters() {
 }
 add_action( 'init', 'fb_apply_filters' );
 
-function fb_build_social_plugin_params($options) {
+function fb_build_social_plugin_params($options, $plugin = '' ) {
 	$params = '';
+    
+    if ( 'like' == $plugin ) {
+        if ( ! isset( $options['send'] ) || empty( $options['send'] ) ) {
+            $params .= 'data-send="false"';
+        }
+        if ( ! isset( $options['show_faces'] ) || empty( $options['show_faces'] ) ) {
+            $params .= 'data-show-faces="false"';
+        }
+    }
 
 	foreach ($options as $option => $value) {
 		$option = str_replace('_', '-', $option);
 
 		$params .= 'data-' . $option . '="' . esc_attr($value) . '" ';
-	}
-
+    }
+    
 	$params .= 'data-ref="wp" ';
 
 	return $params;


### PR DESCRIPTION
Previously show faces and send were displayed even when the options were unchecked because we did not explicitly set the values as false when constructing the widget. 
