### PR TITLE
[codemod] replace rel_canonical with fb_rel_canonical

### DIFF
--- a/fb-open-graph.php
+++ b/fb-open-graph.php
@@ -73,7 +73,7 @@ function fb_add_og_protocol() {
 	} else if ( is_single() ) {
 		$post_type = get_post_type();
 		$meta_tags['http://ogp.me/ns#type'] = 'article';
-		$meta_tags['http://ogp.me/ns#url'] = apply_filters( 'rel_canonical', get_permalink() );
+		$meta_tags['http://ogp.me/ns#url'] = apply_filters( 'fb_rel_canonical', get_permalink() );
 		if ( post_type_supports( $post_type, 'title' ) )
 			$meta_tags['http://ogp.me/ns#title'] = get_the_title();
 		if ( post_type_supports( $post_type, 'excerpt' ) ) {
@@ -152,7 +152,7 @@ function fb_add_og_protocol() {
 	else if ( is_page() ) {
 		$meta_tags['http://ogp.me/ns#type'] = 'article';
 		$meta_tags['http://ogp.me/ns#title'] = get_the_title();
-		$meta_tags['http://ogp.me/ns#url'] = apply_filters( 'rel_canonical', get_permalink() );
+		$meta_tags['http://ogp.me/ns#url'] = apply_filters( 'fb_rel_canonical', get_permalink() );
 	}
 
 	$options = get_option( 'fb_options' );

--- a/fb-social-publisher.php
+++ b/fb-social-publisher.php
@@ -231,7 +231,7 @@ function fb_post_to_fb_page($post_id) {
     if ( !isset ( $post_thumbnail_url ) ) {
       $args = array('access_token' => $fan_page_info[0][3],
         'from' => $fan_page_info[0][2],
-        'link' => apply_filters( 'rel_canonical', get_permalink()),
+        'link' => apply_filters( 'fb_rel_canonical', get_permalink()),
         'name' => html_entity_decode(get_the_title(), ENT_COMPAT, 'UTF-8'),
         'caption' => strip_tags( apply_filters( 'the_excerpt', get_the_excerpt() ) ),
         'description' => strip_tags( fb_strip_and_format_desc( $post ) ), 
@@ -241,7 +241,7 @@ function fb_post_to_fb_page($post_id) {
     else {
       $args = array('access_token' => $fan_page_info[0][3],
         'from' => $fan_page_info[0][2],
-        'link' => apply_filters( 'rel_canonical', get_permalink()),
+        'link' => apply_filters( 'fb_rel_canonical', get_permalink()),
         'picture' => $post_thumbnail_url,
         'name' => html_entity_decode(get_the_title(), ENT_COMPAT, 'UTF-8'),
         'caption' => strip_tags( apply_filters( 'the_excerpt', get_the_excerpt() ) ),
@@ -350,7 +350,7 @@ function fb_post_to_author_fb_timeline($post_id) {
 			try {
 				if ( !isset ( $post_thumbnail_url ) ) {
 					$args = array(
-						'link' => apply_filters( 'rel_canonical', get_permalink()),
+						'link' => apply_filters( 'fb_rel_canonical', get_permalink()),
 						'name' => html_entity_decode(get_the_title(), ENT_COMPAT, 'UTF-8'),
 						'caption' => strip_tags( apply_filters( 'the_excerpt', get_the_excerpt() ) ),
         					'description' => strip_tags( fb_strip_and_format_desc( $post ) ), 
@@ -359,7 +359,7 @@ function fb_post_to_author_fb_timeline($post_id) {
 				}
 				else {
 					$args = array(
-						'link' => apply_filters( 'rel_canonical', get_permalink()),
+						'link' => apply_filters( 'fb_rel_canonical', get_permalink()),
 						'picture' => $post_thumbnail_url,
 						'name' => html_entity_decode(get_the_title(), ENT_COMPAT, 'UTF-8'),
 						'caption' => strip_tags( apply_filters( 'the_excerpt', get_the_excerpt() ) ),
@@ -409,7 +409,7 @@ function fb_post_to_author_fb_timeline($post_id) {
 			try {
 				if ( !isset ( $post_thumbnail_url ) ) {
 					$args = array(
-						'link' => apply_filters( 'rel_canonical', get_permalink()),
+						'link' => apply_filters( 'fb_rel_canonical', get_permalink()),
 						'name' => html_entity_decode(get_the_title(), ENT_COMPAT, 'UTF-8'),
 						'caption' => strip_tags( apply_filters( 'the_excerpt', get_the_excerpt() ) ),
         					'description' => strip_tags( fb_strip_and_format_desc( $post ) ),
@@ -418,7 +418,7 @@ function fb_post_to_author_fb_timeline($post_id) {
 				}
 				else {
 					$args = array(
-						'link' => apply_filters( 'rel_canonical', get_permalink()),
+						'link' => apply_filters( 'fb_rel_canonical', get_permalink()),
 						'picture' => $post_thumbnail_url,
 						'name' => html_entity_decode(get_the_title(), ENT_COMPAT, 'UTF-8'),
 						'caption' => strip_tags( apply_filters( 'the_excerpt', get_the_excerpt() ) ),


### PR DESCRIPTION
per issue #225 , renaming the rel_canonical filter to fb_rel_canonical
to avoid a namespace collision with the WP native rel_canonical()
