### PR TITLE
Use tabs instead of spaces for PHP indentation

### DIFF
--- a/facebook.php
+++ b/facebook.php
@@ -42,14 +42,12 @@ unset( $facebook_plugin_directory );
 register_uninstall_hook( __FILE__, 'fb_uninstall' );
 
 function fb_uninstall() {
-    
-    $meta_keys = array('state', 'code', 'access_token', 'user_id', 'fb_data');
-    
-    foreach ( $meta_keys as $meta_key ) {
-        delete_user_meta( get_current_user_id(), $meta_key );    
-    }
-    
-    delete_option( 'fb_options' );
-    delete_option( 'fb_flush_rewrite_rules' );
-}
+	$meta_keys = array('state', 'code', 'access_token', 'user_id', 'fb_data');
 
+	foreach ( $meta_keys as $meta_key ) {
+		delete_user_meta( get_current_user_id(), $meta_key );
+	}
+
+	delete_option( 'fb_options' );
+	delete_option( 'fb_flush_rewrite_rules' );
+}

--- a/fb-admin-menu.php
+++ b/fb-admin-menu.php
@@ -26,150 +26,151 @@ function fb_create_menu() {
 function fb_notify_user_of_plugin_conflicts()
 {
 	//static array of potentially conflicting plugins
-  //add to this list of conflicting plugins from the big list below 
-	$og_conflicting_plugins_static = array( "http://wordpress.org/extend/plugins/facebook/", 
-		"http://wordpress.org/extend/plugins/opengraph/",
-		"http://yoast.com/wordpress/seo/#utm_source=wpadmin&utm_medium=plugin&utm_campaign=wpseoplugin", 
-  	"http://wordbooker.tty.org.uk",
-		"http://ottopress.com/wordpress-plugins/simple-facebook-connect/",
-		"http://www.whiletrue.it",
-		"http://aaroncollegeman.com/sharepress"
+	//add to this list of conflicting plugins from the big list below 
+	$og_conflicting_plugins_static = array(
+		'http://wordpress.org/extend/plugins/facebook/',
+		'http://wordpress.org/extend/plugins/opengraph/',
+		'http://yoast.com/wordpress/seo/#utm_source=wpadmin&utm_medium=plugin&utm_campaign=wpseoplugin',
+		'http://wordbooker.tty.org.uk',
+		'http://ottopress.com/wordpress-plugins/simple-facebook-connect/',
+		'http://www.whiletrue.it',
+		'http://aaroncollegeman.com/sharepress'
 	);
 
-	$og_conflicting_plugins = array (
-    "http://wordpress.org/extend/plugins/kevinjohn-gallagher-pure-web-brilliants-social-graph-control/",
-		"http://wordpress.org/extend/plugins/1-click-retweetsharelike",
-		"http://wordpress.org/extend/plugins/2-click-socialmedia-buttons",
-		"http://wordpress.org/extend/plugins/add-facebook-og-meta-tags-paulund",
-		"http://wordpress.org/extend/plugins/add-link-to-facebook",
-		"http://wordpress.org/extend/plugins/add-meta-tags",
-		"http://wordpress.org/extend/plugins/aj-wp-facebook-like-and-send",
-		"http://wordpress.org/extend/plugins/amarinfotech-downlaod-with-fb-connect",
-		"http://wordpress.org/extend/plugins/another-wordpress-classifieds-plugin",
-		"http://wordpress.org/extend/plugins/aprils-facebook-like-button",	
-		"http://wordpress.org/extend/plugins/aprils-super-functions-pack",
-		"http://wordpress.org/extend/plugins/author-hreview",
-		"http://wordpress.org/extend/plugins/bye-maridjan-seo",
-		"http://wordpress.org/extend/plugins/cd34-header",
-		"http://wordpress.org/extend/plugins/comment-juice",
-		"http://wordpress.org/extend/plugins/contentshare",
-		"http://wordpress.org/extend/plugins/custom-facebook-and-google-thumbnail",
-		"http://wordpress.org/extend/plugins/dudelols-easy-facebook-share-thumbnails",
-		"http://wordpress.org/extend/plugins/dw-fb-sendlike",
-		"http://wordpress.org/extend/plugins/easy-facebook-share-thumbnails",
-		"http://wordpress.org/extend/plugins/easy-social-media",
-    "http://wordpress.org/extend/plugins/easy-toolbox",
-    "http://wordpress.org/extend/plugins/facebook-awd",
-    "http://wordpress.org/extend/plugins/facebook-comment-for-wordpress",
-    "http://wordpress.org/extend/plugins/facebook-comments-for-wordpress",
-    "http://wordpress.org/extend/plugins/facebook-connect-plugin",
-    "http://wordpress.org/extend/plugins/facebook-ilike",
-    "http://wordpress.org/extend/plugins/facebook-image-fix",
-    "http://wordpress.org/extend/plugins/facebook-like",
-    "http://wordpress.org/extend/plugins/facebook-like-a-lot",
-    "http://wordpress.org/extend/plugins/facebook-like-and-comment",
-    "http://wordpress.org/extend/plugins/facebook-like-and-send-2-in-1",
-    "http://wordpress.org/extend/plugins/facebook-like-button",
-    "http://wordpress.org/extend/plugins/facebook-like-button-for-dummies",
-    "http://wordpress.org/extend/plugins/facebook-like-button-plugin",
-    "http://wordpress.org/extend/plugins/facebook-like-content-locker",
-    "http://wordpress.org/extend/plugins/facebook-like-for-marketers",
-    "http://wordpress.org/extend/plugins/facebook-likes-you",
-    "http://wordpress.org/extend/plugins/facebook-meta-tags",
-    "http://wordpress.org/extend/plugins/facebook-open-graph-meta",
-    "http://wordpress.org/extend/plugins/facebook-open-graph-meta-for-wordpress",
-    "http://wordpress.org/extend/plugins/facebook-open-graph-meta-in-wordpress",
-    "http://wordpress.org/extend/plugins/facebook-open-graph-widget",
-    "http://wordpress.org/extend/plugins/facebook-opengraph",
-    "http://wordpress.org/extend/plugins/facebook-optimize",
-    "http://wordpress.org/extend/plugins/facebook-page-publish",
-    "http://wordpress.org/extend/plugins/facebook-recommend-widget",
-    "http://wordpress.org/extend/plugins/facebook-revised-open-graph-meta-tag",
-    "http://wordpress.org/extend/plugins/facebook-send-button",
-    "http://wordpress.org/extend/plugins/facebook-share-new",
-    "http://wordpress.org/extend/plugins/facebook-social-plugins",
-    "http://wordpress.org/extend/plugins/facebook-tools",
-    "http://wordpress.org/extend/plugins/fanpage-connect",
-    "http://wordpress.org/extend/plugins/fatpanda-facebook-comments",
-    "http://wordpress.org/extend/plugins/fb-open-graph-actions-free",
-    "http://wordpress.org/extend/plugins/fb-thumbnail-config",
-    "http://wordpress.org/extend/plugins/fbpromotions",
-    "http://wordpress.org/extend/plugins/fbvirallike",
-    "http://wordpress.org/extend/plugins/fix-facebook-like",
-    "http://wordpress.org/extend/plugins/flexo-facebook-manager",
-    "http://wordpress.org/extend/plugins/flexo-social-gallery",
-    "http://wordpress.org/extend/plugins/foragr-activity-stream",
-    "http://wordpress.org/extend/plugins/foxyshop",
-    "http://wordpress.org/extend/plugins/fp",
-    "http://wordpress.org/extend/plugins/head-cleaner",
-    "http://wordpress.org/extend/plugins/head-meta-facebook",
-    "http://wordpress.org/extend/plugins/hyves-respect",
-    "http://wordpress.org/extend/plugins/jotlinks-button",
-    "http://wordpress.org/extend/plugins/jw-player-plugin-for-wordpress",
-    "http://wordpress.org/extend/plugins/kblog-metadata",
-    "http://wordpress.org/extend/plugins/kevinjohn-gallagher-pure-web-brilliants-social-graph-control",
-    "http://wordpress.org/extend/plugins/leenkme",
-    "http://wordpress.org/extend/plugins/like",
-    "http://wordpress.org/extend/plugins/like-button-plugin-for-wordpress",
-    "http://wordpress.org/extend/plugins/like-buttons",
-    "http://wordpress.org/extend/plugins/me-likey-a-facebook-open-graph-plugin",
-    "http://wordpress.org/extend/plugins/mediaembedder",
-    "http://wordpress.org/extend/plugins/meta-ographr",
-    "http://wordpress.org/extend/plugins/mouseover-share-buttons-by-newsgrape",
-    "http://wordpress.org/extend/plugins/multilpe-social-media",
-    "http://wordpress.org/extend/plugins/network-publisher",
-    "http://wordpress.org/extend/plugins/og-meta",
-    "http://wordpress.org/extend/plugins/ogp",
-    "http://wordpress.org/extend/plugins/only-tweet-like-share-and-google-1",
-    "http://wordpress.org/extend/plugins/open-graph",
-    "http://wordpress.org/extend/plugins/open-graph-protocol-in-posts-and-pages",
-    "http://wordpress.org/extend/plugins/open-graph-protocol-tools",
-    "http://wordpress.org/extend/plugins/opengraph-and-microdata-generator",
-    "http://wordpress.org/extend/plugins/opengraph-metatags-for-facebook",
-    "http://wordpress.org/extend/plugins/professional-share",
-    "http://wordpress.org/extend/plugins/scrolling-social-sharebar",
-    "http://wordpress.org/extend/plugins/scrolling-twitter-like-google-plusone-linkedin-and-stumbleupon",
-    "http://wordpress.org/extend/plugins/seo-facebook-comments",
-    "http://wordpress.org/extend/plugins/seopress",
-    "http://wordpress.org/extend/plugins/share-buttons",
-    "http://wordpress.org/extend/plugins/share-center-pro",
-    "http://wordpress.org/extend/plugins/shareyourcart",
-    "http://wordpress.org/extend/plugins/sharing-is-caring",
-    "http://wordpress.org/extend/plugins/shopp-facebook-like-button-sflb",
-    "http://wordpress.org/extend/plugins/shopp-open-graph-helper",
-    "http://wordpress.org/extend/plugins/shorten2ping",
-    "http://wordpress.org/extend/plugins/simple-facebook-comments-for-wordpress",
-    "http://wordpress.org/extend/plugins/simple-facebook-connect",
-    "http://wordpress.org/extend/plugins/simple-open-graph",
-    "http://wordpress.org/extend/plugins/slick-social-share-buttons",
-    "http://wordpress.org/extend/plugins/social-discussions",
-    "http://wordpress.org/extend/plugins/social-graph-protocol",
-    "http://wordpress.org/extend/plugins/social-kundi",
-    "http://wordpress.org/extend/plugins/social-maven",
-    "http://wordpress.org/extend/plugins/social-networks-auto-poster-facebook-twitter-g",
-    "http://wordpress.org/extend/plugins/social-sharing-toolkit",
-    "http://wordpress.org/extend/plugins/socialize",
-    "http://wordpress.org/extend/plugins/wonderm00ns-simple-facebook-open-graph-tags",
-    "http://wordpress.org/extend/plugins/woocommerce",
-    "http://wordpress.org/extend/plugins/wordpress-connect",
-    "http://wordpress.org/extend/plugins/wordpress-facebook-integrate",
-    "http://wordpress.org/extend/plugins/wordpress-plugin-seo-and-facebook-opengraph-and-google-schema",
-    "http://wordpress.org/extend/plugins/wordpress-seo",
-    "http://wordpress.org/extend/plugins/wordpress-social-ring",
-    "http://wordpress.org/extend/plugins/wp-facebook-like",
-    "http://wordpress.org/extend/plugins/wp-facebook-like-send-open-graph-meta",
-    "http://wordpress.org/extend/plugins/wp-facebook-like-this",
-    "http://wordpress.org/extend/plugins/wp-facebook-likebutton",
-    "http://wordpress.org/extend/plugins/wp-facebook-open-graph-protocol",
-    "http://wordpress.org/extend/plugins/wp-facebook-plugin",
-    "http://wordpress.org/extend/plugins/wp-facebookconnect",
-    "http://wordpress.org/extend/plugins/wp-fb-commerce",
-    "http://wordpress.org/extend/plugins/wp-grow-button",
-    "http://wordpress.org/extend/plugins/wp-ogp",
-    "http://wordpress.org/extend/plugins/wp-open-graph-meta",
-    "http://wordpress.org/extend/plugins/wpmu-dev-facebook-addon",
-    "http://wordpress.org/extend/plugins/wpstorecart",
-    "http://wordpress.org/extend/plugins/zoltonorg-social-plugin"
+	$og_conflicting_plugins = array(
+		'http://wordpress.org/extend/plugins/kevinjohn-gallagher-pure-web-brilliants-social-graph-control/',
+		'http://wordpress.org/extend/plugins/1-click-retweetsharelike',
+		'http://wordpress.org/extend/plugins/2-click-socialmedia-buttons',
+		'http://wordpress.org/extend/plugins/add-facebook-og-meta-tags-paulund',
+		'http://wordpress.org/extend/plugins/add-link-to-facebook',
+		'http://wordpress.org/extend/plugins/add-meta-tags',
+		'http://wordpress.org/extend/plugins/aj-wp-facebook-like-and-send',
+		'http://wordpress.org/extend/plugins/amarinfotech-downlaod-with-fb-connect',
+		'http://wordpress.org/extend/plugins/another-wordpress-classifieds-plugin',
+		'http://wordpress.org/extend/plugins/aprils-facebook-like-button',	
+		'http://wordpress.org/extend/plugins/aprils-super-functions-pack',
+		'http://wordpress.org/extend/plugins/author-hreview',
+		'http://wordpress.org/extend/plugins/bye-maridjan-seo',
+		'http://wordpress.org/extend/plugins/cd34-header',
+		'http://wordpress.org/extend/plugins/comment-juice',
+		'http://wordpress.org/extend/plugins/contentshare',
+		'http://wordpress.org/extend/plugins/custom-facebook-and-google-thumbnail',
+		'http://wordpress.org/extend/plugins/dudelols-easy-facebook-share-thumbnails',
+		'http://wordpress.org/extend/plugins/dw-fb-sendlike',
+		'http://wordpress.org/extend/plugins/easy-facebook-share-thumbnails',
+		'http://wordpress.org/extend/plugins/easy-social-media',
+		'http://wordpress.org/extend/plugins/easy-toolbox',
+		'http://wordpress.org/extend/plugins/facebook-awd',
+		'http://wordpress.org/extend/plugins/facebook-comment-for-wordpress',
+		'http://wordpress.org/extend/plugins/facebook-comments-for-wordpress',
+		'http://wordpress.org/extend/plugins/facebook-connect-plugin',
+		'http://wordpress.org/extend/plugins/facebook-ilike',
+		'http://wordpress.org/extend/plugins/facebook-image-fix',
+		'http://wordpress.org/extend/plugins/facebook-like',
+		'http://wordpress.org/extend/plugins/facebook-like-a-lot',
+		'http://wordpress.org/extend/plugins/facebook-like-and-comment',
+		'http://wordpress.org/extend/plugins/facebook-like-and-send-2-in-1',
+		'http://wordpress.org/extend/plugins/facebook-like-button',
+		'http://wordpress.org/extend/plugins/facebook-like-button-for-dummies',
+		'http://wordpress.org/extend/plugins/facebook-like-button-plugin',
+		'http://wordpress.org/extend/plugins/facebook-like-content-locker',
+		'http://wordpress.org/extend/plugins/facebook-like-for-marketers',
+		'http://wordpress.org/extend/plugins/facebook-likes-you',
+		'http://wordpress.org/extend/plugins/facebook-meta-tags',
+		'http://wordpress.org/extend/plugins/facebook-open-graph-meta',
+		'http://wordpress.org/extend/plugins/facebook-open-graph-meta-for-wordpress',
+		'http://wordpress.org/extend/plugins/facebook-open-graph-meta-in-wordpress',
+		'http://wordpress.org/extend/plugins/facebook-open-graph-widget',
+		'http://wordpress.org/extend/plugins/facebook-opengraph',
+		'http://wordpress.org/extend/plugins/facebook-optimize',
+		'http://wordpress.org/extend/plugins/facebook-page-publish',
+		'http://wordpress.org/extend/plugins/facebook-recommend-widget',
+		'http://wordpress.org/extend/plugins/facebook-revised-open-graph-meta-tag',
+		'http://wordpress.org/extend/plugins/facebook-send-button',
+		'http://wordpress.org/extend/plugins/facebook-share-new',
+		'http://wordpress.org/extend/plugins/facebook-social-plugins',
+		'http://wordpress.org/extend/plugins/facebook-tools',
+		'http://wordpress.org/extend/plugins/fanpage-connect',
+		'http://wordpress.org/extend/plugins/fatpanda-facebook-comments',
+		'http://wordpress.org/extend/plugins/fb-open-graph-actions-free',
+		'http://wordpress.org/extend/plugins/fb-thumbnail-config',
+		'http://wordpress.org/extend/plugins/fbpromotions',
+		'http://wordpress.org/extend/plugins/fbvirallike',
+		'http://wordpress.org/extend/plugins/fix-facebook-like',
+		'http://wordpress.org/extend/plugins/flexo-facebook-manager',
+		'http://wordpress.org/extend/plugins/flexo-social-gallery',
+		'http://wordpress.org/extend/plugins/foragr-activity-stream',
+		'http://wordpress.org/extend/plugins/foxyshop',
+		'http://wordpress.org/extend/plugins/fp',
+		'http://wordpress.org/extend/plugins/head-cleaner',
+		'http://wordpress.org/extend/plugins/head-meta-facebook',
+		'http://wordpress.org/extend/plugins/hyves-respect',
+		'http://wordpress.org/extend/plugins/jotlinks-button',
+		'http://wordpress.org/extend/plugins/jw-player-plugin-for-wordpress',
+		'http://wordpress.org/extend/plugins/kblog-metadata',
+		'http://wordpress.org/extend/plugins/kevinjohn-gallagher-pure-web-brilliants-social-graph-control',
+		'http://wordpress.org/extend/plugins/leenkme',
+		'http://wordpress.org/extend/plugins/like',
+		'http://wordpress.org/extend/plugins/like-button-plugin-for-wordpress',
+		'http://wordpress.org/extend/plugins/like-buttons',
+		'http://wordpress.org/extend/plugins/me-likey-a-facebook-open-graph-plugin',
+		'http://wordpress.org/extend/plugins/mediaembedder',
+		'http://wordpress.org/extend/plugins/meta-ographr',
+		'http://wordpress.org/extend/plugins/mouseover-share-buttons-by-newsgrape',
+		'http://wordpress.org/extend/plugins/multilpe-social-media',
+		'http://wordpress.org/extend/plugins/network-publisher',
+		'http://wordpress.org/extend/plugins/og-meta',
+		'http://wordpress.org/extend/plugins/ogp',
+		'http://wordpress.org/extend/plugins/only-tweet-like-share-and-google-1',
+		'http://wordpress.org/extend/plugins/open-graph',
+		'http://wordpress.org/extend/plugins/open-graph-protocol-in-posts-and-pages',
+		'http://wordpress.org/extend/plugins/open-graph-protocol-tools',
+		'http://wordpress.org/extend/plugins/opengraph-and-microdata-generator',
+		'http://wordpress.org/extend/plugins/opengraph-metatags-for-facebook',
+		'http://wordpress.org/extend/plugins/professional-share',
+		'http://wordpress.org/extend/plugins/scrolling-social-sharebar',
+		'http://wordpress.org/extend/plugins/scrolling-twitter-like-google-plusone-linkedin-and-stumbleupon',
+		'http://wordpress.org/extend/plugins/seo-facebook-comments',
+		'http://wordpress.org/extend/plugins/seopress',
+		'http://wordpress.org/extend/plugins/share-buttons',
+		'http://wordpress.org/extend/plugins/share-center-pro',
+		'http://wordpress.org/extend/plugins/shareyourcart',
+		'http://wordpress.org/extend/plugins/sharing-is-caring',
+		'http://wordpress.org/extend/plugins/shopp-facebook-like-button-sflb',
+		'http://wordpress.org/extend/plugins/shopp-open-graph-helper',
+		'http://wordpress.org/extend/plugins/shorten2ping',
+		'http://wordpress.org/extend/plugins/simple-facebook-comments-for-wordpress',
+		'http://wordpress.org/extend/plugins/simple-facebook-connect',
+		'http://wordpress.org/extend/plugins/simple-open-graph',
+		'http://wordpress.org/extend/plugins/slick-social-share-buttons',
+		'http://wordpress.org/extend/plugins/social-discussions',
+		'http://wordpress.org/extend/plugins/social-graph-protocol',
+		'http://wordpress.org/extend/plugins/social-kundi',
+		'http://wordpress.org/extend/plugins/social-maven',
+		'http://wordpress.org/extend/plugins/social-networks-auto-poster-facebook-twitter-g',
+		'http://wordpress.org/extend/plugins/social-sharing-toolkit',
+		'http://wordpress.org/extend/plugins/socialize',
+		'http://wordpress.org/extend/plugins/wonderm00ns-simple-facebook-open-graph-tags',
+		'http://wordpress.org/extend/plugins/woocommerce',
+		'http://wordpress.org/extend/plugins/wordpress-connect',
+		'http://wordpress.org/extend/plugins/wordpress-facebook-integrate',
+		'http://wordpress.org/extend/plugins/wordpress-plugin-seo-and-facebook-opengraph-and-google-schema',
+		'http://wordpress.org/extend/plugins/wordpress-seo',
+		'http://wordpress.org/extend/plugins/wordpress-social-ring',
+		'http://wordpress.org/extend/plugins/wp-facebook-like',
+		'http://wordpress.org/extend/plugins/wp-facebook-like-send-open-graph-meta',
+		'http://wordpress.org/extend/plugins/wp-facebook-like-this',
+		'http://wordpress.org/extend/plugins/wp-facebook-likebutton',
+		'http://wordpress.org/extend/plugins/wp-facebook-open-graph-protocol',
+		'http://wordpress.org/extend/plugins/wp-facebook-plugin',
+		'http://wordpress.org/extend/plugins/wp-facebookconnect',
+		'http://wordpress.org/extend/plugins/wp-fb-commerce',
+		'http://wordpress.org/extend/plugins/wp-grow-button',
+		'http://wordpress.org/extend/plugins/wp-ogp',
+		'http://wordpress.org/extend/plugins/wp-open-graph-meta',
+		'http://wordpress.org/extend/plugins/wpmu-dev-facebook-addon',
+		'http://wordpress.org/extend/plugins/wpstorecart',
+		'http://wordpress.org/extend/plugins/zoltonorg-social-plugin'
 	);
 
 	//fetch activated plugins
@@ -183,26 +184,24 @@ function fb_notify_user_of_plugin_conflicts()
 		$plugin_data = get_plugin_data(WP_PLUGIN_DIR . '/' . $val);		
 		$plugin_uri = $plugin_data['PluginURI'];
 		$plugin_name = $plugin_data['Name'];
-    
-		if( $plugin_uri == "http://wordpress.org/extend/plugins/facebook/" ) {
+
+		if( $plugin_uri == 'http://wordpress.org/extend/plugins/facebook/' ) {
 			continue;
 		}
 		
 		if( in_array($plugin_uri, $og_conflicting_plugins_static) ) {
 			$num_conflicting += 1;
-      
-			if( $num_conflicting == 1 ) {
-        array_push( $conflicting_plugins, $plugin_name);
-			}
-			else {
-        array_push( $conflicting_plugins, ", " . $plugin_name );
-			}
+
+			if( $num_conflicting == 1 )
+				array_push( $conflicting_plugins, $plugin_name);
+			else
+				array_push( $conflicting_plugins, ', ' . $plugin_name );
 		}
 	}
 
 	//if there are more than 1 plugins relying on Open Graph, warn the user on this plugins page
 	if ( $num_conflicting >= 1 ) {
-		fb_admin_dialog( sprintf( __( 'You have plugins installed that could potentially conflict with the Facebook plugin. Please consider disabling the following plugins on the %sPlugins Settings page%s:', 'facebook' ) . "</br>" . implode($conflicting_plugins), '<a href="plugins.php" aria-label="Plugins 0">', '</a>' ), true);
+		fb_admin_dialog( sprintf( __( 'You have plugins installed that could potentially conflict with the Facebook plugin. Please consider disabling the following plugins on the %sPlugins Settings page%s:', 'facebook' ) . '<br />' . implode($conflicting_plugins), '<a href="plugins.php" aria-label="Plugins 0">', '</a>' ), true);
 	}
 }
 
@@ -264,15 +263,14 @@ function fb_admin_scripts( $hook_suffix ) {
 	wp_enqueue_script( 'fb_loopj', plugins_url( 'scripts/loopj-jquery-tokeninput/jquery.tokeninput.js', __FILE__ ), array(), '1.0', true );
 	wp_enqueue_script( 'tipsy', plugins_url( 'scripts/jquery.tipsy.js', __FILE__ ), array(), '1.0', true );
 
-    wp_localize_script( 'fb_admin', 'FBNonce', array(
-    // URL to wp-admin/admin-ajax.php to process the request
-    'ajaxurl' => admin_url( 'admin-ajax.php' ),
+	wp_localize_script( 'fb_admin', 'FBNonce', array(
+		// URL to wp-admin/admin-ajax.php to process the request
+		'ajaxurl' => admin_url( 'admin-ajax.php' ),
 
-    // generate a nonce with a unique ID "myajax-post-comment-nonce"
-    // so that you can check it later when an AJAX request is sent
-    'autocompleteNonce' => wp_create_nonce( 'fb_autocomplete_nonce' ),
-    )
-  );
+		// generate a nonce with a unique ID "myajax-post-comment-nonce"
+		// so that you can check it later when an AJAX request is sent
+		'autocompleteNonce' => wp_create_nonce( 'fb_autocomplete_nonce' ),
+	) );
 }
 
 /**
@@ -295,19 +293,19 @@ function fb_admin_menu_settings() {
  */
 function fb_settings_page() {
 	global $facebook;
-  
+
 	$like_button_options = array(
-		"enabled" => "true", 
-		"send" => "true", 
-		"layout" => "button_count", 
-		"action" => "like", 
-		"colorscheme" => "light", 
-		"font" => "arial", 
-		"position" => "both", 
-		"ref" => "wp",
-		"href" => "http://developers.facebook.com/wordpress",
-  );
-	
+		'enabled' => 'true',
+		'send' => 'true',
+		'layout' => 'button_count',
+		'action' => 'like',
+		'colorscheme' => 'light',
+		'font' => 'arial',
+		'position' => 'both',
+		'ref' => 'wp',
+		'href' => 'http://developers.facebook.com/wordpress'
+	);
+
 	?>
 	<div class="wrap">
 		<div class="facebook-logo"></div>
@@ -322,19 +320,19 @@ function fb_settings_page() {
 				echo '<p><strong>' . sprintf( esc_html( __( 'If you already have a Facebook app for this website, skip to %sStep 2%s.', 'facebook' ) ), '<a href="#step-2">', '</a>' ) . '</strong></p><br>';
 				echo '<p>' . sprintf( esc_html( __( 'If you don\'t already have an app for this website, go to %s and click the "Create New App" button.	You\'ll see a dialog like the one below.	Fill this in and click "Continue".', 'facebook' ) ), '<a href="https://developers.facebook.com/apps" target="_blank">https://developers.facebook.com/apps</a>' );
 				echo '<p><img src="' . plugins_url( 'images/nux_create_app.png', __FILE__ ) . '"></p>';
-				echo "</br>Here are for some recommendations for filling this form out. </br>";
-        
-        echo "<b> App Name: </b>" . get_bloginfo('name') . "</br>";
-        echo "<b> App Namespace: </b>". strtolower(str_replace( " ", "-", get_bloginfo('name') ) ) . "</br>";
+				echo '<p>Here are for some recommendations for filling this form out.</p>';
 
-				echo '<a name="step-2"></a><h2>' . esc_html__( 'Step 2: Set up the App', 'facebook' ) . '</h2>';
+				echo '<b> App Name: </b>' . esc_html( get_bloginfo('name') ) . '<br />';
+				echo '<b> App Namespace: </b>' . esc_html( strtolower(str_replace( ' ', '-', get_bloginfo('name') ) ) ) . '<br />';
+
+				echo '<h2 id="step-2">' . esc_html__( 'Step 2: Set up the App', 'facebook' ) . '</h2>';
 				echo sprintf( esc_html( __( 'Next, set up your app so that it looks like the settings below.	Make sure you set your app\'s icon and image, too.	If you already have an app and skipped Step 1, you can view your app settings by going to %s', 'facebook' ) ), '<a href="https://developers.facebook.com/apps">https://developers.facebook.com/apps</a>.</p>' );
-				
-        echo "</br>Here are for some recommendations for filling this form out, based on where this plugin is installed.</br>";
-        echo "<b> App Domains: </b>" . parse_url(home_url('/'), PHP_URL_HOST) . "</br>";
-        echo "<b> Site URL and Mobile Web URL: </b> " .  get_bloginfo( 'wpurl' ) . "</br>";
-        
-				echo '<p><img src="' . plugins_url( 'images/nux_app_settings.png', __FILE__ ) . '" style="border: 1px solid #ccc; margin: 5px; padding: 5px;"></p>';
+
+				echo '<p>Here are for some recommendations for filling this form out, based on where this plugin is installed.</p>';
+				echo '<b> App Domains: </b>' . esc_html( parse_url( home_url('/'), PHP_URL_HOST ) ) . '<br />';
+				echo '<b> Site URL and Mobile Web URL: </b>' . esc_html( get_bloginfo( 'wpurl' ) ) . '<br />';
+
+				echo '<p><img src="' . esc_url( plugins_url( 'images/nux_app_settings.png', __FILE__ ) ) . '" style="border: 1px solid #ccc; margin: 5px; padding: 5px;"></p>';
 
 				echo '<h2>' . esc_html__( 'Step 3: WordPress settings', 'facebook' ) . '</h2>';
 				echo '<p>' . esc_html__( 'Now, based on what you entered in Step 2, fill in the settings below and Save.	Once saved, additional options will appear on this page.', 'facebook' ) . '</p>';
@@ -360,9 +358,9 @@ function fb_settings_page() {
 			}
 
 			submit_button();
-      
-      fb_get_debug_output();
-      
+
+			fb_get_debug_output();
+
 			fb_insights_admin();
 			?>
 		</form>
@@ -371,31 +369,30 @@ function fb_settings_page() {
 }
 
 function fb_insights_admin($appid = 0) {
-  $payload = json_encode(fb_get_settings($appid));
+	$payload = json_encode( fb_get_settings($appid) );
 
-	echo "<img src='http://www.facebook.com/impression.php?plugin=wordpress&payload=$payload'>";
+	echo '<img src="http://www.facebook.com/impression.php?plugin=wordpress&payload=' . $payload . '">';
 }
 
 function fb_get_debug_output($appid = 0) {
-  $bloginfo = get_bloginfo('version');
-  
-  $debug = fb_get_settings($appid);
+	$bloginfo = get_bloginfo('version');
 
-  $debug['wp_ver'] = $bloginfo;
-  
-  echo '<a href="#" id="debug-output-link" onclick="fbShowDebugInfo(); return false">debug info</a><div id="debug-output">' . json_encode($debug) . '</div>';
+	$debug = fb_get_settings($appid);
+
+	$debug['wp_ver'] = $bloginfo;
+
+	echo '<a href="#" id="debug-output-link" onclick="fbShowDebugInfo(); return false">debug info</a><div id="debug-output">' . esc_html( json_encode($debug) ) . '</div>';
 }
 
 function fb_get_settings($appid) {
-  global $fb_ver;
-  
-  $options = get_option('fb_options');
+	global $fb_ver;
 
-	if (!$appid) {
+	$options = get_option('fb_options');
+
+	if ( ! $appid )
 		$appid = $options['app_id'];
-	}
 
- 	if ( !empty( $options['social_publisher']['publish_to_fan_page'] ) )
+	if ( !empty( $options['social_publisher']['publish_to_fan_page'] ) )
 		preg_match_all("/(.*?)@@!!(.*?)@@!!(.*?)$/su", $options['social_publisher']['publish_to_fan_page'], $fan_page_info, PREG_SET_ORDER);
 
 	$options['social_publisher']['publish_to_fan_page'] = array();
@@ -444,9 +441,9 @@ function fb_get_settings($appid) {
 	}
 
 	$payload = array( 'appid' => $appid, 'version' => $fb_ver, 'domain' => $_SERVER['HTTP_HOST'] );
-  
-  $payload = array_merge($fb_sidebar_widgets, $payload, $enabled_options);
-  
+
+	$payload = array_merge($fb_sidebar_widgets, $payload, $enabled_options);
+
 	return $payload;
 }
 
@@ -581,7 +578,7 @@ function fb_options_validate_hex($value, $label, $sanitize=true) {
 	if (!preg_match('/^[0-9a-f]+$/i', $value)) {
 		$value = preg_replace('/[^0-9a-f]/', '', strtolower($value));
 		add_settings_error('fb_options', '', "$label has been converted to a hex string");
-    }
+	}
 	return $value;
 }
 
@@ -599,8 +596,8 @@ function fb_options_validate_namespace($value, $label, $sanitize=true) {
 function fb_options_validate_plugin($array, $label_prefix, $sanitize=true) {
 	// TODO desperately needs to be driven from plugin definitions
 	if ($sanitize) {
-        $array = fb_sanitize_options($array);
-    }
+		$array = fb_sanitize_options($array);
+	}
 	if (!isset($array['enabled']) || !$array['enabled']) {
 		return $array;
 	}

--- a/fb-core.php
+++ b/fb-core.php
@@ -49,27 +49,26 @@ function fb_ssl_warning() {
 /*
 function fb_rate_message() {
 	$options = get_option('fb_options');
-	
-  global $current_user;
-  
+
+	global $current_user;
+
 	$user_id = $current_user->ID;
 	
 	$page = (isset($_GET['page']) ? $_GET['page'] : null);
 
-	if ( !empty($options['app_id']) && !empty( $options['app_secret'] ) && current_user_can( 'publish_posts' ) && !get_user_meta( $user_id, 'fb_rate_message_ignore_notice', true )
-      && ( !empty( $options['social_publisher'] ) || !empty( $options['like_button'] ) || !empty( $options['subscribe_button'] ) || !empty( $options['send_button'] ) || !empty( $options['comments'] ) || !empty( $options['recommendations_bar'] ) ) ) {
-    $like_button_options = array(
-       "enabled" => "true", 
-       "send" => "true", 
-       "layout" => "button_count", 
-       "action" => "like", 
-       "colorscheme" => "light", 
-       "font" => "arial", 
-       "position" => "both", 
-       "ref" => "wp",
-       "href" => "http://developers.facebook.com/wordpress",
-    );
-    
+	if ( !empty($options['app_id']) && !empty( $options['app_secret'] ) && current_user_can( 'publish_posts' ) && !get_user_meta( $user_id, 'fb_rate_message_ignore_notice', true ) && ( !empty( $options['social_publisher'] ) || !empty( $options['like_button'] ) || !empty( $options['subscribe_button'] ) || !empty( $options['send_button'] ) || !empty( $options['comments'] ) || !empty( $options['recommendations_bar'] ) ) ) {
+		$like_button_options = array(
+			'enabled' => 'true', 
+			'send' => 'true',
+			'layout' => 'button_count',
+			'action' => 'like',
+			'colorscheme' => 'light',
+			'font' => 'arial',
+			'position' => 'both',
+			'ref' => 'wp',
+			'href' => 'http://developers.facebook.com/wordpress'
+		);
+
 		fb_admin_dialog( sprintf( __( '%1$sEnjoying the Facebook plugin? Please like it, %2$srate it,  and mark it as working%3$s! Having a problem? %4$sReport it%5$s. &nbsp;|&nbsp; %6$sDismiss%7$s' ), fb_get_like_button($like_button_options), '<a href="http://wordpress.org/extend/plugins/facebook/" target="_blank">', '</a>', '<a href="http://wordpress.org/support/plugin/facebook" target="_blank">', '</a>', '<a href="' . get_admin_url() . '?fb_rate_message_ignore=1' . '">', '</a>' ), false);
 	}
 }

--- a/fb-open-graph.php
+++ b/fb-open-graph.php
@@ -6,7 +6,6 @@
  * @param string $property whitespace separated list of CURIEs placed in a property attribute
  * @param mixed content attribute value for the given property. use an array for array property values or structured properties
  */
-
 function fb_output_og_protocol( $property, $content ) {
 	if ( empty( $property ) || empty( $content ) )
 		return;
@@ -28,11 +27,10 @@ function fb_output_og_protocol( $property, $content ) {
 }
 
 function fb_strip_and_format_desc( $post ) {
-
-	$desc_no_html = "";
+	$desc_no_html = '';
 	$desc_no_html = strip_shortcodes( $desc_no_html ); // Strip shortcodes first in case there is HTML inside the shortcode
-        $desc_no_html = wp_strip_all_tags( $desc_no_html ); // Strip all html
-        $desc_no_html = trim( $desc_no_html ); // Trim the final string, we may have stripped everything out of the post so this will make the value empty if that's the case
+	$desc_no_html = wp_strip_all_tags( $desc_no_html ); // Strip all html
+	$desc_no_html = trim( $desc_no_html ); // Trim the final string, we may have stripped everything out of the post so this will make the value empty if that's the case
 
 	// Check if empty, may be that the strip functions above made excerpt empty, doubhtful but we want to be 100% sure.
 	if( empty($desc_no_html) ) {
@@ -77,7 +75,7 @@ function fb_add_og_protocol() {
 		if ( post_type_supports( $post_type, 'title' ) )
 			$meta_tags['http://ogp.me/ns#title'] = get_the_title();
 		if ( post_type_supports( $post_type, 'excerpt' ) ) {
-			// thanks to Angelo Mandato (http://wordpress.org/support/topic/plugin-facebook-plugin-conflicts-with-powerpress?replies=16)
+			// thanks to Angelo Mandato (http://wordpress.org/support/topic/plugin-facebook-plugin-conflicts-with-powerpress)
 			// Strip and format the wordpress way, but don't apply any other filters which adds junk that ends up getitng stripped back out
 			if ( !post_password_required($post) ) {
 				// First lets get the post excerpt (shouldn't have any html, but anyone can enter anything...)

--- a/fb-social-publisher-mentioning.php
+++ b/fb-social-publisher-mentioning.php
@@ -4,124 +4,116 @@ add_filter( 'the_content', 'fb_social_publisher_mentioning_output', 30 );
 add_action( 'wp_ajax_my_action', 'fb_friend_page_autocomplete' );
 
 function fb_friend_page_autocomplete() {
+	global $facebook;
+
 	$output = array();
+	$nonce = '';
 
-  $nonce = '';
+	if (isset($_GET) && isset($_GET['autocompleteNonce']))
+		$nonce = $_GET['autocompleteNonce'];
 
-  if (isset($_GET) && isset($_GET['autocompleteNonce']))
-    $nonce = $_GET['autocompleteNonce'];
+	// check to see if the submitted nonce matches with the
+	// generated nonce we created earlier
+	if ( wp_verify_nonce( $nonce, 'fb_autocomplete_nonce' ) ) {
+		if ( ! empty($_GET['fb-friends']) ) {
+			if ( ! isset( $facebook ) )
+				return;
 
-  // check to see if the submitted nonce matches with the
-  // generated nonce we created earlier
-  if ( wp_verify_nonce( $nonce, 'fb_autocomplete_nonce' ) ) {
-    if (!empty($_GET['fb-friends'])) {
-      global $facebook;
+			if ( false === ( $friends = get_transient( 'fb_friends_' . $facebook->getUser() ) ) ) {
+				try {
+					$friends = $facebook->api('/me/friends', 'GET', array('ref' => 'fbwpp'));
+				}
+				catch (WP_FacebookApiException $e) {}
 
-      if ( ! isset( $facebook ) )
-        return;
+				set_transient( 'fb_friends_' . $facebook->getUser(), $friends, 60*15 );
+			}
 
-      if ( false === ( $friends = get_transient( 'fb_friends_' . $facebook->getUser() ) ) ) {
-        try {
-          $friends = $facebook->api('/me/friends', 'GET', array('ref' => 'fbwpp'));
-        }
-        catch (WP_FacebookApiException $e) {
-        }
+			foreach($friends['data'] as $friend) {
+				$friends_clean[$friend['name']] = $friend['id'];
+			}
 
-        set_transient( 'fb_friends_' . $facebook->getUser(), $friends, 60*15 );
-      }
+			if (isset($_GET['q']) && isset($friends_clean)) {
+				$q = strtolower($_GET['q']);
 
-      foreach($friends['data'] as $friend) {
-        $friends_clean[$friend['name']] = $friend['id'];
-      }
+				if ($q) {
+					foreach ($friends_clean as $key => $value) {
+						if ( strpos( strtolower($key), $q ) !== false )
+							$results[] = array($key, $value);
+					}
+				}
+			}
 
-      if (isset($_GET['q']) && isset($friends_clean)) {
-        $q = strtolower($_GET['q']);
+			if ( ! empty($results) ) {
+				$count = 0;
 
-        if ($q) {
-          foreach ($friends_clean as $key => $value) {
-            if (strpos(strtolower($key), $q) !== false) {
-              $results[] = array($key, $value);
-            }
-          }
-        }
-      }
+				foreach ($results as $result) {
+					$output[$count]['id'] = '[' . esc_attr($result[1]) . '|' . esc_attr($result[0]) . ']';
+					$output[$count]['name'] = '<img src="' . esc_url( 'http://graph.facebook.com/' . $result[1] . '/picture/' ) . '" width="25" height="25"> &nbsp;' . esc_html($result[0]);
 
-      if (!empty($results)) {
-        $count = 0;
+					$count++;
+				}
+			}
 
-        foreach ($results as $result) {
-          $output[$count]['id'] = '[' . esc_attr($result[1]) . '|' . esc_attr($result[0]) . ']';
-          $output[$count]['name'] = '<img src="' . esc_url( 'http://graph.facebook.com/' . $result[1] . '/picture/' ) . '" width="25" height="25"> &nbsp;' . esc_attr($result[0]);
+			echo json_encode($output);
+			exit;
+		}
 
-          $count++;
-        }
-      }
+		if ( ! empty( $_GET['fb-pages'] ) ) {
+			if ( ! isset( $facebook ) )
+				return;
 
-      print json_encode($output);
-      exit;
-    }
+			if ( false === ( $pages = get_transient( 'fb_pages_' . $_GET['q']) ) ) {
+				try {
+					$pages = $facebook->api( '/search', 'GET', array( 'access_token' => '', 'q' => $_GET['q'], 'type' => 'page', 'fields' => 'picture,name,id,likes', 'ref' => 'fbwpp' ) );
+				}
+				catch (WP_FacebookApiException $e) {}
+				set_transient( 'fb_pages_' . $_GET['q'], $pages, 60*60 );
+			}
 
+			if ( isset($pages['data']) ) {
+				foreach($pages['data'] as $page) {
+					if (isset($page['name']) && isset($page['picture']) && isset($page['id']) && isset($page['likes']))
+						$pages_clean[$page['name']] = array($page['picture'], $page['name'], $page['id'], $page['likes']);
+				}
+			} else {
+				echo 'Error returning results.';
+				exit;
+			}
 
-    if (!empty($_GET['fb-pages'])) {
-      global $facebook;
+			if ( isset($_GET['q']) ) {
+				$q = strtolower($_GET['q']);
 
-      if ( ! isset( $facebook ) )
-        return;
+				if ( $q && isset($pages_clean) ) {
+					foreach ($pages_clean as $key => $value) {
+						if (strpos(strtolower($key), $q) !== false)
+							$results[] = array($key, $value);
+					}
+				}
+			}
 
-      if ( false === ( $pages = get_transient( 'fb_pages_' . $_GET['q']) ) ) {
-        try {
-          $pages = $facebook->api( '/search', 'GET', array( 'access_token' => '', 'q' => $_GET['q'], 'type' => 'page', 'fields' => 'picture,name,id,likes', 'ref' => 'fbwpp' ) );
-        }
-        catch (WP_FacebookApiException $e) {
-        }
-        set_transient( 'fb_pages_' . $_GET['q'], $pages, 60*60 );
-      }
+			if ( ! empty($results) ) {
+				$count = 0;
 
+				foreach ($results as $result) {
+					$output[$count]['id'] = '[' . esc_attr($result[1][2]) . '|' . esc_attr($result[1][1]) . ']';
+					$output[$count]['name'] = '<img src="' . esc_url($result[1][0]) . '" width="25" height="25"> &nbsp;' . esc_attr($result[1][1]) . ' (' . fb_short_number(esc_attr($result[1][3])) . ' likes)';
 
-      if ( isset($pages['data']) ) {
-        foreach($pages['data'] as $page) {
-          if (isset($page['name']) && isset($page['picture']) && isset($page['id']) && isset($page['likes'])) {
-            $pages_clean[$page['name']] = array($page['picture'], $page['name'], $page['id'], $page['likes']);
-          }
-        }
-      }
-      else {
-        echo 'Error returning results.';
-        exit;
-      }
+					$count++;
+				}
+			}
 
-      if (isset($_GET['q'])) {
-        $q = strtolower($_GET['q']);
-
-        if ($q && isset($pages_clean)) {
-          foreach ($pages_clean as $key => $value) {
-            if (strpos(strtolower($key), $q) !== false) {
-              $results[] = array($key, $value);
-            }
-          }
-        }
-      }
-
-      if (!empty($results)) {
-        $count = 0;
-
-        foreach ($results as $result) {
-          $output[$count]['id'] = '[' . esc_attr($result[1][2]) . '|' . esc_attr($result[1][1]) . ']';
-          $output[$count]['name'] = '<img src="' . esc_url($result[1][0]) . '" width="25" height="25"> &nbsp;' . esc_attr($result[1][1]) . ' (' . fb_short_number(esc_attr($result[1][3])) . ' likes)';
-
-          $count++;
-        }
-      }
-
-      print json_encode($output);
-      exit;
-    }
-  }
+			echo json_encode($output);
+			exit;
+		}
+	}
 }
 
+
 function fb_short_number($num) {
-	if($num>1000000) return round(($num/1000000),0).'m';
-	else if($num>1000) return round(($num/1000),0).'k';
+	if( $num > 1000000 )
+		return round(($num/1000000),0) . 'm';
+	else if( $num > 1000 )
+		return round(($num/1000),0).'k';
 
 	return number_format_i18n($num);
 }
@@ -137,27 +129,27 @@ function fb_add_page_mention_box() {
 	if ($post->post_status == 'publish')
 		return;
 
-    if ( isset( $options['social_publisher']['enabled'] ) ) {
-        $post_types = get_post_types(array('public' => true));
-        unset($post_types['attachment']);
-        $post_types = array_values($post_types);
+	if ( isset( $options['social_publisher']['enabled'] ) ) {
+		$post_types = get_post_types(array('public' => true));
+		unset($post_types['attachment']);
+		$post_types = array_values($post_types);
 
-        foreach ( $post_types as $post_type ) {
-            add_meta_box(
-                'fb_page_mention_box_id',
-                __( 'Mention Facebook Pages', 'facebook' ),
-                'fb_add_page_mention_box_content',
-                $post_type,
-                'side'
-          );
-        }
-    }
+		foreach ( $post_types as $post_type ) {
+			add_meta_box(
+				'fb_page_mention_box_id',
+				__( 'Mention Facebook Pages', 'facebook' ),
+				'fb_add_page_mention_box_content',
+				$post_type,
+				'side'
+			);
+		}
+	}
 }
 
 function fb_add_page_mention_box_content( $post ) {
-	wp_enqueue_script('suggest');
-
 	global $facebook;
+
+	wp_enqueue_script('suggest');
 
 	// Use nonce for verification
 	wp_nonce_field( plugin_basename( __FILE__ ), 'fb_page_mention_box_noncename' );
@@ -175,7 +167,7 @@ function fb_add_page_mention_box_content( $post ) {
 		echo '</label> ';
 		echo '<input type="text" class="widefat" id="suggest-pages" autocomplete="off" name="fb_page_mention_box_autocomplete" value="" size="44" placeholder="' . esc_attr__('Type to find a page.', 'facebook') . '" />';
 		echo '<label for="fb_page_mention_box_message">';
-		_e("Message", 'facebook' );
+		_e('Message', 'facebook' );
 		echo '</label> ';
 		echo '<input type="text" class="widefat" id="pages-mention-message" name="fb_page_mention_box_message" value="" size="44" placeholder="'.esc_attr__('Write something...').'" />';
 		echo '<p class="howto">';
@@ -185,8 +177,7 @@ function fb_add_page_mention_box_content( $post ) {
 			_e('This will add the post and message to the Timeline of each Facebook Page mentioned. They will also appear in the contents of the post.', 'facebook');
 		}
 		echo '</p>';
-	}
-	else {
+	} else {
 		echo '<p>Facebook social publishing is enabled.</p><p><strong><a href="#" onclick="authFacebook(); return false;">Link your Facebook account to your WordPress account</a></strong> to get full functionality, including adding new Posts to your Timeline and mentioning friends Facebook Pages.</p>';
 	}
 }
@@ -220,29 +211,29 @@ function fb_add_page_mention_box_save( $post_id ) {
 	}
 
 	// OK, we're authenticated: we need to find and save the data
-  if ( isset ( $_POST ) && isset( $_POST['fb_page_mention_box_autocomplete'] ) ) {
-    $autocomplete_data = $_POST['fb_page_mention_box_autocomplete'];
+	if ( isset ( $_POST ) && isset( $_POST['fb_page_mention_box_autocomplete'] ) ) {
+		$autocomplete_data = $_POST['fb_page_mention_box_autocomplete'];
 
-    preg_match_all(
-      "/\[(.*?)\|(.*?)\]/su",
-      $autocomplete_data,
-      $page_details,
-      PREG_SET_ORDER // formats data into an array of posts
-    );
+		preg_match_all(
+			'/\[(.*?)\|(.*?)\]/su',
+			$autocomplete_data,
+			$page_details,
+			PREG_SET_ORDER // formats data into an array of posts
+		);
 
-    // probably using add_post_meta(), update_post_meta(), or
-    // a custom table (see Further Reading section below)
+		// probably using add_post_meta(), update_post_meta(), or
+		// a custom table (see Further Reading section below)
 
-    $pages_details_meta = array();
+		$pages_details_meta = array();
 
-    foreach($page_details as $page_detail) {
-      $pages_details_meta[] = array('id' => sanitize_text_field($page_detail[1]), 'name' => sanitize_text_field($page_detail[2]));
-    }
+		foreach($page_details as $page_detail) {
+			$pages_details_meta[] = array('id' => sanitize_text_field($page_detail[1]), 'name' => sanitize_text_field($page_detail[2]));
+		}
 
-    update_post_meta($post_id, 'fb_mentioned_pages', $pages_details_meta );
+		update_post_meta($post_id, 'fb_mentioned_pages', $pages_details_meta );
 
-    update_post_meta($post_id, 'fb_mentioned_pages_message', sanitize_text_field($_POST['fb_page_mention_box_message']) );
-  }
+		update_post_meta($post_id, 'fb_mentioned_pages_message', sanitize_text_field($_POST['fb_page_mention_box_message']) );
+	}
 }
 
 add_action( 'add_meta_boxes', 'fb_add_friend_mention_box' );
@@ -256,22 +247,21 @@ function fb_add_friend_mention_box() {
 	if ($post->post_status == 'publish')
 		return;
 
-    if ( isset( $options['social_publisher']['enabled'] ) ) {
-        $post_types = get_post_types(array('public' => true));
-        unset($post_types['attachment']);
-        $post_types = array_values($post_types);
+	if ( isset( $options['social_publisher']['enabled'] ) ) {
+		$post_types = get_post_types(array('public' => true));
+		unset($post_types['attachment']);
+		$post_types = array_values($post_types);
 
-        foreach ( $post_types as $post_type ) {
-
-            add_meta_box(
-                'fb_friend_mention_box_id',
-                __( 'Mention Facebook Friends', 'facebook' ),
-                'fb_add_friend_mention_box_content',
-                $post_type,
-                'side'
-            );
-        }
-    }
+		foreach ( $post_types as $post_type ) {
+			add_meta_box(
+				'fb_friend_mention_box_id',
+				__( 'Mention Facebook Friends', 'facebook' ),
+				'fb_add_friend_mention_box_content',
+				$post_type,
+				'side'
+			);
+		}
+	}
 }
 
 function fb_add_friend_mention_box_content( $post ) {
@@ -284,9 +274,8 @@ function fb_add_friend_mention_box_content( $post ) {
 
 	$fb_user = fb_get_current_user();
 
-	if ( isset( $fb_user ) ) {
-    $perms = $facebook->api('/me/permissions', 'GET', array('ref' => 'fbwpp'));
-  }
+	if ( isset( $fb_user ) )
+		$perms = $facebook->api('/me/permissions', 'GET', array('ref' => 'fbwpp'));
 
 	if ( isset ( $fb_user ) && isset($perms['data'][0]['manage_pages']) && isset($perms['data'][0]['publish_actions']) && isset($perms['data'][0]['publish_stream'])) {
 		// The actual fields for data entry
@@ -295,7 +284,7 @@ function fb_add_friend_mention_box_content( $post ) {
 		echo '</label> ';
 		echo '<input type="text" class="widefat" id="suggest-friends" autocomplete="off" name="fb_friend_mention_box_autocomplete" value="" size="44" placeholder="Type to find a friend." />';
 		echo '<label for="fb_friend_mention_box_message">';
-		_e("Message", 'facebook' );
+		_e('Message', 'facebook' );
 		echo '</label> ';
 		echo '<input type="text" class="widefat" id="friends-mention-message" name="fb_friend_mention_box_message" value="" size="44" placeholder="Write something..." />';
 
@@ -306,8 +295,7 @@ function fb_add_friend_mention_box_content( $post ) {
 			_e('This will add the post and message to the Timeline of each friend mentioned. They will also appear in the contents of the post.', 'facebook');
 		}
 		echo '</p>';
-	}
-	else {
+	} else {
 		echo '<p>'.__('Facebook social publishing is enabled.', 'facebook') .'</p>';
 		echo '<p>'.sprintf(__('<strong>%sLink your Facebook account to your WordPress account</a></strong> to get full functionality, including adding new Posts to your Timeline and mentioning friends Facebook Pages.', 'facebook'), '<a href="#" onclick="authFacebook(); return false;">' ) .'</p>';
 	}
@@ -342,31 +330,30 @@ function fb_add_friend_mention_box_save( $post_id ) {
 	}
 
 	// OK, we're authenticated: we need to find and save the data
-  if ( isset ($_POST) && isset( $_POST['fb_page_mention_box_autocomplete'] ) ) {
-    $autocomplete_data = $_POST['fb_friend_mention_box_autocomplete'];
+	if ( isset ($_POST) && isset( $_POST['fb_page_mention_box_autocomplete'] ) ) {
+		$autocomplete_data = $_POST['fb_friend_mention_box_autocomplete'];
 
-    preg_match_all(
-      "/\[(.*?)\|(.*?)\]/su",
-      $autocomplete_data,
-      $friend_details,
-      PREG_SET_ORDER // formats data into an array of posts
-    );
+		preg_match_all(
+			'/\[(.*?)\|(.*?)\]/su',
+			$autocomplete_data,
+			$friend_details,
+			PREG_SET_ORDER // formats data into an array of posts
+		);
 
-    // probably using add_post_meta(), update_post_meta(), or
-    // a custom table (see Further Reading section below)
+		// probably using add_post_meta(), update_post_meta(), or
+		// a custom table (see Further Reading section below)
 
-    $friends_details_meta = array();
+		$friends_details_meta = array();
 
-    foreach($friend_details as $friend_detail) {
-      $friends_details_meta[] = array('id' => sanitize_text_field($friend_detail[1]), 'name' => sanitize_text_field($friend_detail[2]));
-    }
+		foreach($friend_details as $friend_detail) {
+			$friends_details_meta[] = array('id' => sanitize_text_field($friend_detail[1]), 'name' => sanitize_text_field($friend_detail[2]));
+		}
 
-    update_post_meta($post_id, 'fb_mentioned_friends', $friends_details_meta);
+		update_post_meta($post_id, 'fb_mentioned_friends', $friends_details_meta);
 
-    update_post_meta($post_id, 'fb_mentioned_friends_message', sanitize_text_field($_POST['fb_friend_mention_box_message']));
-  }
+		update_post_meta($post_id, 'fb_mentioned_friends_message', sanitize_text_field($_POST['fb_friend_mention_box_message']));
+	}
 }
-
 
 
 function fb_social_publisher_mentioning_output($content) {
@@ -374,54 +361,52 @@ function fb_social_publisher_mentioning_output($content) {
 
 	$options = get_option('fb_options');
 
-  if( $post ) {
-    $fb_mentioned_pages	 = get_post_meta($post->ID, 'fb_mentioned_pages', true);
-    $fb_mentioned_friends = get_post_meta($post->ID, 'fb_mentioned_friends', true);
+	if( $post ) {
+		$fb_mentioned_pages	 = get_post_meta($post->ID, 'fb_mentioned_pages', true);
+		$fb_mentioned_friends = get_post_meta($post->ID, 'fb_mentioned_friends', true);
 
-    $mentions_entities = '';
+		$mentions_entities = '';
 
-    if (!empty($fb_mentioned_friends)){
-      foreach( $fb_mentioned_friends as $fb_mentioned_friend ) {
-        $mentions_entities .= '<a target="_blank" href="http://www.facebook.com/' . esc_attr($fb_mentioned_friend['id']) . '" title="'.sprintf(esc_attr__('Click to visit %s\'s profile on Facebook.','facebook'), esc_attr($fb_mentioned_friend['name'])) .'"><img src="http://graph.facebook.com/' . esc_attr($fb_mentioned_friend['id']) . '/picture" width="16" height="16"> ' . esc_html($fb_mentioned_friend['name']) . '</a> ';
-      }
-    }
+		if ( ! empty($fb_mentioned_friends) ){
+			foreach( $fb_mentioned_friends as $fb_mentioned_friend ) {
+				$mentions_entities .= '<a target="_blank" href="http://www.facebook.com/' . esc_attr($fb_mentioned_friend['id']) . '" title="'.sprintf(esc_attr__('Click to visit %s\'s profile on Facebook.','facebook'), esc_attr($fb_mentioned_friend['name'])) .'"><img src="http://graph.facebook.com/' . esc_attr($fb_mentioned_friend['id']) . '/picture" width="16" height="16"> ' . esc_html($fb_mentioned_friend['name']) . '</a> ';
+			}
+		}
 
-    if (!empty($fb_mentioned_pages)){
-      foreach( $fb_mentioned_pages as $fb_mentioned_page ) {
-        $mentions_entities .= '<a target="_blank" href="http://www.facebook.com/' . esc_attr($fb_mentioned_page['id']) . '" title="'.sprintf(esc_attr__('Click to visit %s\'s profile on Facebook.','facebook'), esc_attr($fb_mentioned_page['name'])).'"><img src="http://graph.facebook.com/' . esc_attr($fb_mentioned_page['id']) . '/picture" width="16" height="16"> ' . esc_html($fb_mentioned_page['name']) . '</a> ';
-      }
-    }
+		if ( ! empty($fb_mentioned_pages) ) {
+			foreach( $fb_mentioned_pages as $fb_mentioned_page ) {
+				$mentions_entities .= '<a target="_blank" href="http://www.facebook.com/' . esc_attr($fb_mentioned_page['id']) . '" title="'.sprintf(esc_attr__('Click to visit %s\'s profile on Facebook.','facebook'), esc_attr($fb_mentioned_page['name'])).'"><img src="http://graph.facebook.com/' . esc_attr($fb_mentioned_page['id']) . '/picture" width="16" height="16"> ' . esc_html($fb_mentioned_page['name']) . '</a> ';
+			}
+		}
 
-    if ($mentions_entities) {
-      $mentions = '<div class="fb-mentions entry-meta">' . $mentions_entities . 'mentioned.</div>';
+		if ($mentions_entities) {
+			$mentions = '<div class="fb-mentions entry-meta">' . $mentions_entities . 'mentioned.</div>';
 
-      $new_content = '';
+			$new_content = '';
 
-      if ( isset($options['social_publisher']) ) {
-        switch ($options['social_publisher']['mentions_position']) {
-          case 'top':
-            $new_content = $mentions . $content;
-            break;
-          case 'bottom':
-            $new_content = $content . $mentions;
-            break;
-          case 'both':
-            $new_content = $mentions . $content;
-            $new_content .= $mentions;
-            break;
-          default:
-            $new_content = $content;
-        }
+			if ( isset($options['social_publisher']) ) {
+				switch ($options['social_publisher']['mentions_position']) {
+					case 'top':
+						$new_content = $mentions . $content;
+						break;
+					case 'bottom':
+						$new_content = $content . $mentions;
+						break;
+					case 'both':
+						$new_content = $mentions . $content;
+						$new_content .= $mentions;
+						break;
+					default:
+						$new_content = $content;
+				}
 
-        if ( empty( $options['social_publisher']['mentions_show_on_homepage'] ) && is_singular() ) {
-          $content = $new_content;
-        }
-        elseif ( isset($options['social_publisher']['mentions_show_on_homepage']) ) {
-          $content = $new_content;
-        }
-      }
-    }
-  }
+				if ( empty( $options['social_publisher']['mentions_show_on_homepage'] ) && is_singular() )
+					$content = $new_content;
+				else if ( isset($options['social_publisher']['mentions_show_on_homepage']) )
+					$content = $new_content;
+			}
+		}
+	}
 
 
 	return $content;

--- a/fb-social-publisher.php
+++ b/fb-social-publisher.php
@@ -16,7 +16,7 @@ if ( isset($options['social_publisher']) && isset($options['social_publisher']['
 
 /**
  * Add meta boxes for a custom Status that is used when posting to an Author's Timeline
- *5
+ *
  * @since 1.0
  */
 function fb_add_author_message_box() {
@@ -26,58 +26,56 @@ function fb_add_author_message_box() {
 	if ($post->post_status == 'publish')
 		return;
 
-    if ( isset( $options['social_publisher']['enabled'] ) ) {
+	if ( isset( $options['social_publisher']['enabled'] ) ) {
 
-        $post_types = get_post_types( array('public' => true) );
+		$post_types = get_post_types( array('public' => true) );
 
-        foreach( $post_types as $post_type ) {
-            if ( isset( $options['social_publisher']['publish_for'][ $post_type ] ) ) {
-
-                add_meta_box(
-                    'fb_author_message_box_id',
-                    __( 'Facebook Status on Your Timeline', 'facebook' ),
-                    'fb_add_author_message_box_content',
-                    $post_type
-                );
-            }
-        }
-    }
+		foreach( $post_types as $post_type ) {
+			if ( isset( $options['social_publisher']['publish_for'][ $post_type ] ) ) {
+				add_meta_box(
+					'fb_author_message_box_id',
+					__( 'Facebook Status on Your Timeline', 'facebook' ),
+					'fb_add_author_message_box_content',
+					$post_type
+				);
+			}
+		}
+	}
 }
+
 /**
  * Add meta boxes for a custom Status that is used when posting to an Author's Timeline
  *
  * @since 1.0
  */
 function fb_add_author_message_box_content( $post ) {
-  global $facebook;
+	global $facebook;
 
-  if ( ! isset( $facebook ) )
+	if ( ! isset( $facebook ) )
 		return;
 
-	// Use nonce for verification
-	wp_nonce_field( plugin_basename( __FILE__ ), 'fb_author_message_box_noncename' );
+		// Use nonce for verification
+		wp_nonce_field( plugin_basename( __FILE__ ), 'fb_author_message_box_noncename' );
 
-	// The actual fields for data entry
-	/*
-	echo '<label for="fb_author_message_box_message">';
-			 _ e("Message", 'facebook' );
-	echo '</label> ';
-	*/
+		// The actual fields for data entry
+		/*
+		echo '<label for="fb_author_message_box_message">';
+		_ e("Message", 'facebook' );
+		echo '</label> ';
+		*/
 
-  $fb_user = fb_get_current_user();
+		$fb_user = fb_get_current_user();
 
-	if ( isset( $fb_user ) ) {
-    $perms = $facebook->api('/me/permissions', 'GET', array('ref' => 'fbwpp'));
-  }
+		if ( isset( $fb_user ) )
+			$perms = $facebook->api('/me/permissions', 'GET', array('ref' => 'fbwpp'));
 
-	if ( isset ( $fb_user ) && isset($perms['data'][0]['manage_pages']) && isset($perms['data'][0]['publish_actions']) && isset($perms['data'][0]['publish_stream'])) {
-		echo '<input type="text" class="widefat" id="friends-mention-message" name="fb_author_message_box_message" value="" size="44" placeholder="What\'s on your mind?" />';
-    echo '<p class="howto">'. __('This message will show as part of the story on your Facebook Timeline.', 'facebook' ) .'</p>';
-	}
-	else {
-		echo '<p>'.__('Facebook social publishing is enabled.', 'facebook') .'</p>';
-		echo '<p>'.sprintf(__('<strong>%sLink your Facebook account to your WordPress account</a></strong> to get full functionality, including adding new Posts to your Timeline and mentioning friends Facebook Pages.', 'facebook'), '<a href="#" onclick="authFacebook(); return false;">' ) .'</p>';
-	}
+		if ( isset ( $fb_user ) && isset($perms['data'][0]['manage_pages']) && isset($perms['data'][0]['publish_actions']) && isset($perms['data'][0]['publish_stream'])) {
+			echo '<input type="text" class="widefat" id="friends-mention-message" name="fb_author_message_box_message" value="" size="44" placeholder="What\'s on your mind?" />';
+			echo '<p class="howto">'. __('This message will show as part of the story on your Facebook Timeline.', 'facebook' ) .'</p>';
+		} else {
+			echo '<p>' . __('Facebook social publishing is enabled.', 'facebook') .'</p>';
+			echo '<p>' . sprintf(__('<strong>%sLink your Facebook account to your WordPress account</a></strong> to get full functionality, including adding new Posts to your Timeline and mentioning friends Facebook Pages.', 'facebook'), '<a href="#" onclick="authFacebook(); return false;">' ) . '</p>';
+		}
 }
 
 /**
@@ -127,21 +125,20 @@ function fb_add_fan_page_message_box() {
 	if ($post->post_status == 'publish')
 		return;
 
-    if ( isset( $options['social_publisher']['enabled'] ) && isset( $fan_page_info ) && isset( $fan_page_info[0] ) && isset( $fan_page_info[0][2] ) ) {
-        $post_types = get_post_types( array('public' => true) );
+	if ( isset( $options['social_publisher']['enabled'] ) && isset( $fan_page_info ) && isset( $fan_page_info[0] ) && isset( $fan_page_info[0][2] ) ) {
+		$post_types = get_post_types( array('public' => true) );
 
-        foreach( $post_types as $post_type ) {
-            if ( isset( $options['social_publisher']['publish_for'][ $post_type ] ) ) {
-
-                add_meta_box(
-                    'fb_fan_page_message_box_id',
-                    sprintf( __( 'Facebook Status on %s\'s Timeline', 'facebook' ), $fan_page_info[0][1] ),
-                    'fb_add_fan_page_message_box_content',
-                    $post_type
-                );
-            }
-        }
-    }
+		foreach( $post_types as $post_type ) {
+			if ( isset( $options['social_publisher']['publish_for'][ $post_type ] ) ) {
+				add_meta_box(
+					'fb_fan_page_message_box_id',
+					sprintf( __( 'Facebook Status on %s\'s Timeline', 'facebook' ), $fan_page_info[0][1] ),
+					'fb_add_fan_page_message_box_content',
+					$post_type
+				);
+			}
+		}
+	}
 }
 
 /**
@@ -187,11 +184,10 @@ function fb_add_fan_page_message_box_save( $post_id ) {
 
 	// Check permissions
 
-    if ( 'page' == $_POST['post_type'] ) {
-		if ( !current_user_can( 'edit_page', $post_id ) )
+	if ( 'page' == $_POST['post_type'] ) {
+		if ( ! current_user_can( 'edit_page', $post_id ) )
 			return;
-	}
-	else {
+	} else {
 		if ( !current_user_can( 'edit_post', $post_id ) )
 			return;
 	}
@@ -208,14 +204,14 @@ function fb_add_fan_page_message_box_save( $post_id ) {
  * @param int $post_id The post ID that will be posted
  */
 function fb_post_to_fb_page($post_id) {
-  global $facebook;
+	global $facebook;
 	global $post;
 
-  // thanks to Tareq Hasan on http://wordpress.org/support/topic/plugin-facebook-bug-problems-when-publishing-to-a-page
-  if ( isset ( $post_id ) ) {
-    $post = get_post( $post_id );
-    setup_postdata( $post );
-  }
+	// thanks to Tareq Hasan on http://wordpress.org/support/topic/plugin-facebook-bug-problems-when-publishing-to-a-page
+	if ( isset ( $post_id ) ) {
+		$post = get_post( $post_id );
+		setup_postdata( $post );
+	}
 
 	$options = get_option('fb_options');
 
@@ -224,76 +220,75 @@ function fb_post_to_fb_page($post_id) {
 
 	preg_match_all("/(.*?)@@!!(.*?)@@!!(.*?)$/su", $options['social_publisher']['publish_to_fan_page'], $fan_page_info, PREG_SET_ORDER);
 
-  if ( isset( $fan_page_info ) && isset( $fan_page_info[0] ) && isset( $fan_page_info[0][2] ) ) {
-    // does current post type and the current theme support post thumbnails?
-    if ( post_type_supports( $post->post_type, 'thumbnail' ) && function_exists( 'has_post_thumbnail' ) && has_post_thumbnail() ) {
-      list( $post_thumbnail_url, $post_thumbnail_width, $post_thumbnail_height ) = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' );
-    }
+	if ( isset( $fan_page_info ) && isset( $fan_page_info[0] ) && isset( $fan_page_info[0][2] ) ) {
+		// does current post type and the current theme support post thumbnails?
+		if ( post_type_supports( $post->post_type, 'thumbnail' ) && function_exists( 'has_post_thumbnail' ) && has_post_thumbnail() ) {
+			list( $post_thumbnail_url, $post_thumbnail_width, $post_thumbnail_height ) = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' );
+		}
 
-    $fan_page_message = get_post_meta($post_id, 'fb_fan_page_message', true);
+		$fan_page_message = get_post_meta($post_id, 'fb_fan_page_message', true);
 
-    if ( !isset ( $post_thumbnail_url ) ) {
-      $args = array('access_token' => $fan_page_info[0][3],
-        'from' => $fan_page_info[0][2],
-        'link' => apply_filters( 'fb_rel_canonical', get_permalink()),
-        'name' => html_entity_decode(get_the_title(), ENT_COMPAT, 'UTF-8'),
-        'caption' => strip_tags( apply_filters( 'the_excerpt', get_the_excerpt() ) ),
-        'description' => strip_tags( fb_strip_and_format_desc( $post ) ),
-        'message' => $fan_page_message,
-      );
-    }
-    else {
-      $args = array('access_token' => $fan_page_info[0][3],
-        'from' => $fan_page_info[0][2],
-        'link' => apply_filters( 'fb_rel_canonical', get_permalink()),
-        'picture' => $post_thumbnail_url,
-        'name' => html_entity_decode(get_the_title(), ENT_COMPAT, 'UTF-8'),
-        'caption' => strip_tags( apply_filters( 'the_excerpt', get_the_excerpt() ) ),
-        'description' => strip_tags( fb_strip_and_format_desc( $post ) ),
-        'message' => $fan_page_message,
-      );
-    }
+		if ( !isset ( $post_thumbnail_url ) ) {
+			$args = array(
+				'access_token' => $fan_page_info[0][3],
+				'from' => $fan_page_info[0][2],
+				'link' => apply_filters( 'fb_rel_canonical', get_permalink()),
+				'name' => html_entity_decode(get_the_title(), ENT_COMPAT, 'UTF-8'),
+				'caption' => strip_tags( apply_filters( 'the_excerpt', get_the_excerpt() ) ),
+				'description' => strip_tags( fb_strip_and_format_desc( $post ) ),
+				'message' => $fan_page_message
+			);
+		} else {
+			$args = array(
+				'access_token' => $fan_page_info[0][3],
+				'from' => $fan_page_info[0][2],
+				'link' => apply_filters( 'fb_rel_canonical', get_permalink()),
+				'picture' => $post_thumbnail_url,
+				'name' => html_entity_decode(get_the_title(), ENT_COMPAT, 'UTF-8'),
+				'caption' => strip_tags( apply_filters( 'the_excerpt', get_the_excerpt() ) ),
+				'description' => strip_tags( fb_strip_and_format_desc( $post ) ),
+				'message' => $fan_page_message
+			);
+		}
 
-    $args['ref'] = 'fbwpp';
+		$args['ref'] = 'fbwpp';
 
-    if ( ! isset( $facebook ) )
-      return;
+		if ( ! isset( $facebook ) )
+			return;
 
-    $status_messages = array();
+		$status_messages = array();
 
-    try {
-      $publish_result = $facebook->api('/' . $fan_page_info[0][2] . '/feed', 'POST', $args);
+		try {
+			$publish_result = $facebook->api('/' . $fan_page_info[0][2] . '/feed', 'POST', $args);
 
-      update_post_meta($post_id, 'fb_fan_page_post_id', sanitize_text_field($publish_result['id']));
-    }
-    catch (WP_FacebookApiException $e) {
-      $error_result = $e->getResult();
+			update_post_meta( $post_id, 'fb_fan_page_post_id', sanitize_text_field($publish_result['id']) );
+		} catch (WP_FacebookApiException $e) {
+			$error_result = $e->getResult();
 
-      if ($e->getCode() == 190) {
-        $options['social_publisher']['publish_to_fan_page'] = false;
+			if ($e->getCode() == 190) {
+				$options['social_publisher']['publish_to_fan_page'] = false;
 
-        update_option( 'fb_options', $options );
+				update_option( 'fb_options', $options );
 
-        $status_messages[] = array( 'message' => sprintf( __( 'Failed posting to ' . $fan_page_info[0][1] . '\'s Timeline because the access token expired.  To reactivate publishing, visit the Facebook settings page and re-enable the "Publish to fan page" setting. Full error: ' . json_encode ( $error_result['error'] ), true ) ), 'error' => true);
-      }
-      else {
-        $status_messages[] = array( 'message' => sprintf( __( 'Failed posting to ' . $fan_page_info[0][1] . '\'s Timeline. Error: ' . json_encode ( $error_result['error'] ), true ) ), 'error' => true);
-      }
-    }
+				$status_messages[] = array( 'message' => sprintf( __( 'Failed posting to ' . $fan_page_info[0][1] . '\'s Timeline because the access token expired.  To reactivate publishing, visit the Facebook settings page and re-enable the "Publish to fan page" setting. Full error: ' . json_encode ( $error_result['error'] ), true ) ), 'error' => true);
+			} else {
+				$status_messages[] = array( 'message' => sprintf( __( 'Failed posting to ' . $fan_page_info[0][1] . '\'s Timeline. Error: ' . json_encode ( $error_result['error'] ), true ) ), 'error' => true);
+			}
+		}
 
-    if ( isset( $publish_result ) && isset( $publish_result['id'] ) ) {
-      $status_messages[] = array( 'message' => sprintf( __( 'Posted to <a href="' . fb_get_permalink_from_feed_publish_id( sanitize_text_field( $publish_result['id'] ) ) . '" target="_blank">' . $fan_page_info[0][1] . '\'s Facebook Timeline</a>' . ( ! empty( $fan_page_message ) ? ' with message "' . $fan_page_message . '"' : '' ), true ) ), 'error' => false);
-    }
+		if ( isset( $publish_result ) && isset( $publish_result['id'] ) ) {
+			$status_messages[] = array( 'message' => sprintf( __( 'Posted to <a href="' . fb_get_permalink_from_feed_publish_id( sanitize_text_field( $publish_result['id'] ) ) . '" target="_blank">' . $fan_page_info[0][1] . '\'s Facebook Timeline</a>' . ( ! empty( $fan_page_message ) ? ' with message "' . $fan_page_message . '"' : '' ), true ) ), 'error' => false);
+		}
 
-    $existing_status_messages = get_post_meta($post_id, 'fb_status_messages', true);
+		$existing_status_messages = get_post_meta($post_id, 'fb_status_messages', true);
 
-    if ( !empty( $existing_status_messages ) ) {
-      $status_messages = array_merge($existing_status_messages, $status_messages);
-    }
+		if ( ! empty( $existing_status_messages ) ) {
+			$status_messages = array_merge($existing_status_messages, $status_messages);
+		}
 
-    update_post_meta( $post->ID, 'fb_status_messages', $status_messages );
-    add_filter( 'redirect_post_location', 'fb_add_new_post_location' );
-  }
+		update_post_meta( $post->ID, 'fb_status_messages', $status_messages );
+		add_filter( 'redirect_post_location', 'fb_add_new_post_location' );
+	}
 }
 
 
@@ -329,7 +324,7 @@ function fb_post_to_author_fb_timeline($post_id) {
 	global $post;
 	global $facebook;
 
-  $status_messages = array();
+	$status_messages = array();
 
 	if ( ! isset( $facebook ) )
 		return;
@@ -360,8 +355,7 @@ function fb_post_to_author_fb_timeline($post_id) {
 						'description' => strip_tags( fb_strip_and_format_desc( $post ) ),
 						'message' => $mentioned_friends_message,
 					);
-				}
-				else {
+				} else {
 					$args = array(
 						'link' => apply_filters( 'fb_rel_canonical', get_permalink()),
 						'picture' => $post_thumbnail_url,
@@ -379,39 +373,37 @@ function fb_post_to_author_fb_timeline($post_id) {
 				$publish_ids_friends[] = sanitize_text_field( $publish_result['id'] );
 
 				$friends_posts .= '<a href="' . esc_url( fb_get_permalink_from_feed_publish_id( $publish_result['id'] ) ) . '" target="_blank"><img src="' . esc_url( 'http://graph.facebook.com/' . $friend['id'] . '/picture' ) . '" width="15"></a> ';
-			}
-			catch (WP_FacebookApiException $e) {
-        $error_result = $e->getResult();
+			} catch (WP_FacebookApiException $e) {
+				$error_result = $e->getResult();
 
-        if ($e->getCode() == 210) {
-          $status_messages[] = array( 'message' => sprintf( __( 'Failed posting to mentioned friend\'s Facebook Timeline. <img src="' . esc_url( 'http://graph.facebook.com/' . $friend['id'] . '/picture' ) . '" width="15"> Error: Page doesn\'t allow posts from other Facebook users. Full error: ' . json_encode ( $error_result['error'] ), true ) ), 'error' => true );
-        }
-        else {
-          $status_messages[] = array( 'message' => sprintf( __( 'Failed posting to mentioned friend\'s Facebook Timeline. <img src="' . esc_url( 'http://graph.facebook.com/' . $friend['id'] . '/picture' ) . '" width="15"> Error: ' . json_encode ( $error_result['error'] ), true ) ), 'error' => true );
-        }
+				if ( $e->getCode() == 210) {
+					$status_messages[] = array( 'message' => sprintf( __( 'Failed posting to mentioned friend\'s Facebook Timeline. <img src="' . esc_url( 'http://graph.facebook.com/' . $friend['id'] . '/picture' ) . '" width="15"> Error: Page doesn\'t allow posts from other Facebook users. Full error: ' . json_encode ( $error_result['error'] ), true ) ), 'error' => true );
+				} else {
+					$status_messages[] = array( 'message' => sprintf( __( 'Failed posting to mentioned friend\'s Facebook Timeline. <img src="' . esc_url( 'http://graph.facebook.com/' . $friend['id'] . '/picture' ) . '" width="15"> Error: ' . json_encode ( $error_result['error'] ), true ) ), 'error' => true );
+				}
 			}
 		}
 
 		update_post_meta($post_id, 'fb_mentioned_friends_post_ids', $publish_ids_friends);
 
-		if ( !empty( $publish_ids_friends ) ) {
-      $status_messages[] = array( 'message' => sprintf( __( 'Posted to mentioned friends\' Facebook Timelines. ' . $friends_posts ) ), 'error' => false );
+		if ( ! empty( $publish_ids_friends ) ) {
+			$status_messages[] = array( 'message' => sprintf( __( 'Posted to mentioned friends\' Facebook Timelines. ' . $friends_posts ) ), 'error' => false );
 		}
 	}
 
 	$fb_mentioned_pages = get_post_meta($post_id, 'fb_mentioned_pages', true);
 
-  $pages_posts = '';
+	$pages_posts = '';
 
-	if ( !empty( $fb_mentioned_pages ) ) {
+	if ( ! empty( $fb_mentioned_pages ) ) {
 
 		$mentioned_pages_message = get_post_meta($post_id, 'fb_mentioned_pages_message', true);
 
 		$publish_ids_pages = array();
 
-		foreach($fb_mentioned_pages as $page) {
+		foreach( $fb_mentioned_pages as $page ) {
 			try {
-				if ( !isset ( $post_thumbnail_url ) ) {
+				if ( ! isset ( $post_thumbnail_url ) ) {
 					$args = array(
 						'link' => apply_filters( 'fb_rel_canonical', get_permalink()),
 						'name' => html_entity_decode(get_the_title(), ENT_COMPAT, 'UTF-8'),
@@ -419,8 +411,7 @@ function fb_post_to_author_fb_timeline($post_id) {
 						'description' => strip_tags( fb_strip_and_format_desc( $post ) ),
 						'message' => $mentioned_pages_message,
 					);
-				}
-				else {
+				} else {
 					$args = array(
 						'link' => apply_filters( 'fb_rel_canonical', get_permalink()),
 						'picture' => $post_thumbnail_url,
@@ -439,76 +430,68 @@ function fb_post_to_author_fb_timeline($post_id) {
 
 				$pages_posts .= '<a href="' . sanitize_text_field( fb_get_permalink_from_feed_publish_id ( $publish_result['id'] ) ) . '" target="_blank"><img src="http://graph.facebook.com/' . $page['id'] . '/picture" width="15" target="_blank"></a> ';
 
-			}
-			catch (WP_FacebookApiException $e) {
-        $error_result = $e->getResult();
+			} catch (WP_FacebookApiException $e) {
+				$error_result = $e->getResult();
 
-        if ($e->getCode() == 210) {
-          $status_messages[] = array( 'message' => sprintf( __( 'Failed posting to mentioned page\'s Facebook Timeline. <img src="http://graph.facebook.com/' . $page['id'] . '/picture" width="15"> Error: Page doesn\'t allow posts from other Facebook users. Full error: ' . json_encode ( $error_result['error'] ), true ) ), 'error' => true );
-        }
-        else {
-         $status_messages[] = array( 'message' => sprintf( __( 'Failed posting to mentioned page\'s Facebook Timeline. <img src="http://graph.facebook.com/' . $page['id'] . '/picture" width="15"> Error: ' . json_encode ( $error_result['error'] ), true ) ), 'error' => true );
-        }
+				if ( $e->getCode() == 210 ) {
+					$status_messages[] = array( 'message' => sprintf( __( 'Failed posting to mentioned page\'s Facebook Timeline. <img src="http://graph.facebook.com/' . $page['id'] . '/picture" width="15"> Error: Page doesn\'t allow posts from other Facebook users. Full error: ' . json_encode ( $error_result['error'] ), true ) ), 'error' => true );
+				} else {
+					$status_messages[] = array( 'message' => sprintf( __( 'Failed posting to mentioned page\'s Facebook Timeline. <img src="http://graph.facebook.com/' . $page['id'] . '/picture" width="15"> Error: ' . json_encode ( $error_result['error'] ), true ) ), 'error' => true );
+				}
 			}
 		}
 
 		update_post_meta($post_id, 'fb_mentioned_pages_post_ids', $publish_ids_pages);
 
-		if ( !empty( $publish_ids_pages ) ) {
-      $status_messages[] = array( 'message' => sprintf( __( 'Posted to mentioned pages\' Facebook Timelines. ' . $pages_posts ) ), 'error' => false );
+		if ( !empty( $publish_ids_pages ) )
+			$status_messages[] = array( 'message' => sprintf( __( 'Posted to mentioned pages\' Facebook Timelines. ' . $pages_posts ) ), 'error' => false );
+	}
+
+	$fb_user = fb_get_current_user();
+
+	if ( isset( $fb_user ) )
+		$perms = $facebook->api('/me/permissions', 'GET', array('ref' => 'fbwpp'));
+
+	if ( isset ( $fb_user ) && isset($perms['data'][0]['manage_pages']) && isset($perms['data'][0]['publish_actions']) && isset($perms['data'][0]['publish_stream']) ) {
+		$author_message = get_post_meta($post_id, 'fb_author_message', true);
+
+		try {
+			//POST https://graph.facebook.com/me/news.reads?article=[article object URL]
+			$publish_result = $facebook->api('/me/news.publishes', 'POST', array('message' => $author_message, 'article' => get_permalink($post_id)));
+
+			update_post_meta($post_id, 'fb_author_post_id', sanitize_text_field($publish_result['id']));
+		} catch (WP_FacebookApiException $e) {
+			$error_result = $e->getResult();
+
+			//Unset the option to publish to an author's Timeline, since the likely failure is because the admin didn't set up the proper OG action and object in their App Settings
+			//if it's a token issue, it's because the Author hasn't auth'd the WP site yet, so don't unset the option (since that will turn it off for all authors)
+			/*if ($e->getType() != 'OAuthException') {
+				$options['social_publisher']['publish_to_authors_facebook_timeline'] = false;
+
+				update_option( 'fb_options', $options );
+			}*/
+
+			$status_messages[] = array( 'message' => sprintf( __( 'Failed posting to your Facebook Timeline. Error: ' . json_encode ( $error_result['error'] ), true ) ), 'error' => true );
 		}
 	}
 
-  $fb_user = fb_get_current_user();
 
-	if ( isset( $fb_user ) ) {
-    $perms = $facebook->api('/me/permissions', 'GET', array('ref' => 'fbwpp'));
-  }
+	if ( isset( $publish_result ) && isset( $publish_result['id'] ) )
+		$status_messages[] = array( 'message' => sprintf( __( 'Posted to <a href="http://www.facebook.com/' . sanitize_text_field( $publish_result['id'] ) . '" target="_blank">your Facebook Timeline</a>' . ( ! empty( $author_message ) ? ' with message "' . $author_message . '"' : '' ), false ) ), 'error' => false );
 
-  if ( isset ( $fb_user ) && isset($perms['data'][0]['manage_pages']) && isset($perms['data'][0]['publish_actions']) && isset($perms['data'][0]['publish_stream'])) {
-    $author_message = get_post_meta($post_id, 'fb_author_message', true);
+	$existing_status_messages = get_post_meta($post_id, 'fb_status_messages', true);
 
-    try {
-      //POST https://graph.facebook.com/me/news.reads?article=[article object URL]
-      $publish_result = $facebook->api('/me/news.publishes', 'POST', array('message' => $author_message, 'article' => get_permalink($post_id)));
+	if ( ! empty( $existing_status_messages ) )
+		$status_messages = array_merge($existing_status_messages, $status_messages);
 
-      update_post_meta($post_id, 'fb_author_post_id', sanitize_text_field($publish_result['id']));
-
-    }
-    catch (WP_FacebookApiException $e) {
-      $error_result = $e->getResult();
-
-      //Unset the option to publish to an author's Timeline, since the likely failure is because the admin didn't set up the proper OG action and object in their App Settings
-      //if it's a token issue, it's because the Author hasn't auth'd the WP site yet, so don't unset the option (since that will turn it off for all authors)
-      /*if ($e->getType() != 'OAuthException') {
-        $options['social_publisher']['publish_to_authors_facebook_timeline'] = false;
-
-        update_option( 'fb_options', $options );
-      }*/
-
-      $status_messages[] = array( 'message' => sprintf( __( 'Failed posting to your Facebook Timeline. Error: ' . json_encode ( $error_result['error'] ), true ) ), 'error' => true );
-    }
-
-
-    if ( isset( $publish_result ) && isset( $publish_result['id'] ) ) {
-      $status_messages[] = array( 'message' => sprintf( __( 'Posted to <a href="http://www.facebook.com/' . sanitize_text_field( $publish_result['id'] ) . '" target="_blank">your Facebook Timeline</a>' . ( ! empty( $author_message ) ? ' with message "' . $author_message . '"' : '' ), false ) ), 'error' => false );
-    }
-  }
-
-  $existing_status_messages = get_post_meta($post_id, 'fb_status_messages', true);
-
-  if ( !empty( $existing_status_messages ) ) {
-    $status_messages = array_merge($existing_status_messages, $status_messages);
-  }
-
-  update_post_meta( $post->ID, 'fb_status_messages', $status_messages );
-  add_filter( 'redirect_post_location', 'fb_add_new_post_location' );
+	update_post_meta( $post->ID, 'fb_status_messages', $status_messages );
+	add_filter( 'redirect_post_location', 'fb_add_new_post_location' );
 }
 
 function fb_get_permalink_from_feed_publish_id( $id ) {
-  preg_match_all("/(.*?)_(.*?)$/su", $id, $ids, PREG_SET_ORDER);
+	preg_match_all("/(.*?)_(.*?)$/su", $id, $ids, PREG_SET_ORDER);
 
-  return 'http://www.facebook.com/' . $ids[0][2];
+	return 'http://www.facebook.com/' . $ids[0][2];
 }
 
 function fb_get_social_publisher_fields() {
@@ -517,50 +500,48 @@ function fb_get_social_publisher_fields() {
 	if ( ! isset( $facebook ) )
 		return;
 
-  $fan_page_option = array();
+	$fan_page_option = array();
 
-  if (!$facebook->getUser() ) {
-    $fan_page_option = array(
+	if (!$facebook->getUser() ) {
+		$fan_page_option = array(
 			'name' => 'publish_to_fan_page',
 			'type' => 'disabled_text',
 			'disabled_text' => '<a href="#" onclick="authFacebook(); return false;">'.__('Link your Facebook account to your WordPress account to enable.','facebook').'</a>',
 			'help_text' => __( 'All new posts will be automatically published to this Facebook Page.', 'facebook' ),
-			);
-  }
-	else {
-    $accounts = fb_get_user_pages();
+		);
+	} else {
+		$accounts = fb_get_user_pages();
 
-    $accounts_options = array('disabled' => '[Disabled]');
+		$accounts_options = array('disabled' => '[Disabled]');
 
-    $options = get_option('fb_options');
+		$options = get_option('fb_options');
 
-    if (isset($options['social_publisher']) && isset($options['social_publisher']['publish_to_fan_page']) && $options['social_publisher']['publish_to_fan_page'] != 'disabled') {
-      preg_match_all("/(.*?)@@!!(.*?)@@!!(.*?)$/su", $options['social_publisher']['publish_to_fan_page'], $fan_page_info, PREG_SET_ORDER);
-    }
+		if (isset($options['social_publisher']) && isset($options['social_publisher']['publish_to_fan_page']) && $options['social_publisher']['publish_to_fan_page'] != 'disabled') {
+			preg_match_all("/(.*?)@@!!(.*?)@@!!(.*?)$/su", $options['social_publisher']['publish_to_fan_page'], $fan_page_info, PREG_SET_ORDER);
+		}
 
-    foreach($accounts as $account) {
-      if (isset($account['name']) && isset($account['category']) && $account['category'] != 'Application') {
-        $account_options_key = $account['name'] . "@@!!" . $account['id'] . "@@!!" . $account['access_token'];
-        $accounts_options[$account_options_key] = $account['name'];
+		foreach( $accounts as $account ) {
+			if (isset($account['name']) && isset($account['category']) && $account['category'] != 'Application') {
+				$account_options_key = $account['name'] . "@@!!" . $account['id'] . "@@!!" . $account['access_token'];
+				$accounts_options[$account_options_key] = $account['name'];
 
-        if ( isset( $fan_page_info ) && isset( $fan_page_info[0] ) && isset( $fan_page_info[0][2] ) ) {
-          if ($account['id'] == $fan_page_info[0][2]) {
-            $options['social_publisher']['publish_to_fan_page'] = $account_options_key;
+				if ( isset( $fan_page_info ) && isset( $fan_page_info[0] ) && isset( $fan_page_info[0][2] ) ) {
+					if ($account['id'] == $fan_page_info[0][2]) {
+						$options['social_publisher']['publish_to_fan_page'] = $account_options_key;
 
-            update_option( 'fb_options', $options );
-          }
-        }
-      }
-    }
+						update_option( 'fb_options', $options );
+					}
+				}
+			}
+		}
 
-    $fan_page_option = array(
-      'name' => 'publish_to_fan_page',
-      'type' => 'dropdown',
-      'options' => $accounts_options,
-      'help_text' => __( 'New posts will be publish to this Facebook Page.', 'facebook' ),
-      );
-
-  }
+		$fan_page_option = array(
+			'name' => 'publish_to_fan_page',
+			'type' => 'dropdown',
+			'options' => $accounts_options,
+			'help_text' => __( 'New posts will be publish to this Facebook Page.', 'facebook' )
+		);
+	}
 
 	$parent = array(
 		'name' => 'social_publisher',
@@ -570,9 +551,9 @@ function fb_get_social_publisher_fields() {
 		'help_link' => 'http://developers.facebook.com/wordpress',
 		'image' => plugins_url( 'images/settings_social_publisher.png', __FILE__)
 	);
-    $post_types = get_post_types(array('public' => true));
-    unset($post_types['attachment']);
-    $children = array(
+	$post_types = get_post_types(array('public' => true));
+	unset($post_types['attachment']);
+	$children = array(
 		array(
 			'name' => 'publish_to_authors_facebook_timeline',
 			'label' => "Publish to author's Timeline",
@@ -580,29 +561,29 @@ function fb_get_social_publisher_fields() {
 			'default' => true,
 			'onclick' => "window.open(\"http://developers.facebook.com/wordpress#author-og-setup\", \"Open Graph Setup\", \"fullscreen=no\");",
 			'help_text' => __( 'Publish new posts to the author\'s Facebook Timeline and allow mentioning friends. You must setup Open Graph in your App Settings. Enable the feature to learn how.', 'facebook' ),
-			'help_link' => 'http://developers.facebook.com/wordpress#author-og-setup',
+			'help_link' => 'http://developers.facebook.com/wordpress#author-og-setup'
 		),
 		$fan_page_option,
 		array(
 			'name' => 'mentions_show_on_homepage',
 			'type' => 'checkbox',
 			'default' => true,
-			'help_text' => __( 'Authors can mentions Facebook friends and pages in posts.	Enable this to show mentions on the homepage, as part of the post and page previews.', 'facebook' ),
+			'help_text' => __( 'Authors can mentions Facebook friends and pages in posts.	Enable this to show mentions on the homepage, as part of the post and page previews.', 'facebook' )
 		),
 		array(
 			'name' => 'mentions_position',
 			'type' => 'dropdown',
 			'default' => 'both',
 			'options' => array('top' => 'top', 'bottom' => 'bottom', 'both' => 'both'),
-			'help_text' => __( 'Authors can mentions Facebook friends and pages in posts.	This controls where mentions will be displayed in the posts.', 'facebook' ),
-        ),
-        array('name' => 'publish_for',
-            'type' => 'checkbox',
-            'default' => array_fill_keys(array_keys($post_types) , 'true'),
-            'options' => $post_types,
-            'help_text' => __( 'Control which post types are published to Facebook.', 'facebook' ),
-        ),
-
+			'help_text' => __( 'Authors can mentions Facebook friends and pages in posts.	This controls where mentions will be displayed in the posts.', 'facebook' )
+		),
+		array(
+			'name' => 'publish_for',
+			'type' => 'checkbox',
+			'default' => array_fill_keys(array_keys($post_types) , 'true'),
+			'options' => $post_types,
+			'help_text' => __( 'Control which post types are published to Facebook.', 'facebook' )
+		)
 	);
 
 	fb_construct_fields('settings', $children, $parent);
@@ -610,19 +591,19 @@ function fb_get_social_publisher_fields() {
 
 add_action( 'transition_post_status', 'fb_publish_later', 10, 3);
 function fb_publish_later($new_status, $old_status, $post) {
-  $options = get_option('fb_options');
+	$options = get_option('fb_options');
 
 	// check that the new status is "publish" and that the old status was not "publish"
 	if ($new_status == 'publish' && $old_status != 'publish') {
 		// only publish "public" post types
-        if ( isset( $options['social_publisher']['enabled'] ) && isset( $options['social_publisher']['publish_for'] ) && isset( $options['social_publisher']['publish_for'][$post->post_type] ) ) {
-            fb_post_to_fb_page($post->ID);
+		if ( isset( $options['social_publisher']['enabled'] ) && isset( $options['social_publisher']['publish_for'] ) && isset( $options['social_publisher']['publish_for'][$post->post_type] ) ) {
+			fb_post_to_fb_page($post->ID);
 
-            if (isset($options['social_publisher']['publish_to_authors_facebook_timeline'])) {
-                fb_post_to_author_fb_timeline($post->ID);
-            }
-        }
-    }
+			if ( isset($options['social_publisher']['publish_to_authors_facebook_timeline']) ) {
+				fb_post_to_author_fb_timeline($post->ID);
+			}
+		}
+	}
 }
 
 add_action('before_delete_post', 'fb_delete_social_posts', 10);
@@ -701,8 +682,7 @@ function fb_get_user_pages() {
 
 	try {
 		$accounts = $facebook->api('/me/accounts', 'GET', array('ref' => 'fbwpp'));
-	}
-	catch (WP_FacebookApiException $e) {
+	} catch (WP_FacebookApiException $e) {
 		return $accounts;
 	}
 

--- a/fb-wp-helpers.php
+++ b/fb-wp-helpers.php
@@ -1,11 +1,9 @@
 <?php
 function fb_admin_dialog($message, $error = false) {
-	if ($error) {
+	if ( $error )
 		$class = 'error';
-	}
-	else {
+	else
 		$class = 'updated';
-	}
 
 	echo '<div ' . ( $error ? 'id="facebook_warning" ' : '') . 'class="' . $class . ' fade' . '"><p>'. $message . '</p></div>';
 }
@@ -68,10 +66,9 @@ function fb_construct_fields_children($place, $fields, $parent = null, $object =
 			$field['name'] = $object->get_field_name( $field['name'] );
 			$fields[$c] = $field;
 		}
-	}
-    elseif ($place == 'settings') {
+	} else if ($place == 'settings') {
 		foreach ($fields as $c => $field) {
-            if ($parent) {
+			if ($parent) {
 				$value = fb_array_default(
 					$options, $parent['name'], $field['name'], (
 						empty($options[$parent['name']]['enabled']) ?
@@ -91,7 +88,7 @@ function fb_construct_fields_children($place, $fields, $parent = null, $object =
 				$parent_js_array = '[' . $parent['name'] . ']';
 			}
 
-            $field['value'] = $value;
+			$field['value'] = $value;
 			$field['name'] = "fb_options$parent_js_array"."[" . $field['name'] ."]";
 			$fields[$c] = $field;
 		}
@@ -102,17 +99,17 @@ function fb_construct_fields_children($place, $fields, $parent = null, $object =
 function fb_array_default() { // $array, $keys..., $default
 	$keys = func_get_args();
 	$array = array_shift($keys);
-    $default = array_pop($keys);
-    $key = array_shift($keys);
+	$default = array_pop($keys);
+	$key = array_shift($keys);
 	if (!isset($array[$key])) {
 		return $default;
 	}
 	$array = $array[$key];
 	if (sizeof($keys)>0) {
 		array_unshift($keys, $array);
-        array_push($keys, $default);
+		array_push($keys, $default);
 		return call_user_func_array('fb_array_default', $keys);
-    }
+	}
 	return $array;
 }
 
@@ -199,28 +196,28 @@ function fb_field_checkbox($field, $place='settings') {
 		$onclick = $field['onclick'];
 	}
 
-    if (isset($field['options'])) {
+	if (isset($field['options'])) {
 		foreach ($field['options'] as $option_value => $option_label) {
 			if ( !isset( $field['value'][$option_value] ) ) {
 				$field['value'][$option_label] = '';
 			}
-            $buffer .= sprintf(
-                '<label for="%2$s">%1$s</label><input type="checkbox" class="multicheckbox" id="%2$s" name="%2$s" onclick="%3$s" value="true" %4$s />',
-                esc_html($option_label),
-                esc_attr($field['name'] . "[$option_label]"),
-                esc_js( $onclick ),
-                checked($field['value'][$option_label], 'true', false)
-            );
-        }
-        return $buffer;
-    } else {
-        return sprintf(
-            '<input type="checkbox" id="%1$s" name="%1$s" onclick="%2$s" value="true" %3$s />',
-            esc_attr($field['name']),
-            esc_js( $onclick ),
-            checked($field['value'], 'true', false)
-        );
-    }
+			$buffer .= sprintf(
+				'<label for="%2$s">%1$s</label><input type="checkbox" class="multicheckbox" id="%2$s" name="%2$s" onclick="%3$s" value="true" %4$s />',
+				esc_html($option_label),
+				esc_attr($field['name'] . "[$option_label]"),
+				esc_js( $onclick ),
+				checked($field['value'][$option_label], 'true', false)
+			);
+		}
+		return $buffer;
+	} else {
+		return sprintf(
+			'<input type="checkbox" id="%1$s" name="%1$s" onclick="%2$s" value="true" %3$s />',
+			esc_attr($field['name']),
+			esc_js( $onclick ),
+			checked($field['value'], 'true', false)
+		);
+	}
 }
 
 function fb_field_dropdown($field, $place='settings') {
@@ -308,14 +305,13 @@ function fb_option_name($field){
 }
 
 function fb_sanitize_options ($options_array) {
-    foreach ($options_array as $key => $value) {
-        if (is_array($value)) {
-            $options_array[$key] = fb_sanitize_options($value);
-        } else {
-            $options_array[$key] = sanitize_text_field($value);
-        }
-    }
-    return $options_array;
+	foreach ($options_array as $key => $value) {
+		if (is_array($value))
+			$options_array[$key] = fb_sanitize_options($value);
+		else
+			$options_array[$key] = sanitize_text_field($value);
+	}
+	return $options_array;
 }
 
 

--- a/social-plugins/fb-comments.php
+++ b/social-plugins/fb-comments.php
@@ -52,16 +52,15 @@ function fb_comments_automatic($content) {
 		if ( comments_open( get_the_ID() ) && post_type_supports( get_post_type(), 'comments' ) ) {
 			$options = get_option('fb_options');
 			$show_indiv = get_post_meta( $post->ID, 'fb_social_plugin_settings_box_comments', true );
-            if ( ! is_home() && ( 'default' == $show_indiv || empty( $show_indiv ) ) && isset( $options['comments']['show_on'] ) && isset( $options['comments']['show_on'][$post->post_type] ) ) {
-                foreach( $options['comments'] as $param => $val ) {
-                    $param = str_replace( '_', '-', $param );
+			if ( ! is_home() && ( 'default' == $show_indiv || empty( $show_indiv ) ) && isset( $options['comments']['show_on'] ) && isset( $options['comments']['show_on'][$post->post_type] ) ) {
+				foreach( $options['comments'] as $param => $val ) {
+					$param = str_replace( '_', '-', $param );
 
-                    $params[$param] = $val;
-                }
+					$params[$param] = $val;
+				}
 
-                $content .= fb_get_comments( $params );
-			}
-			elseif ( 'show' == $show_indiv || ( ( ! isset( $options['comments']['show_on'] ) ) && ( 'default' == $show_indiv || empty( $show_indiv ) ) ) ) {
+				$content .= fb_get_comments( $params );
+			} else if ( 'show' == $show_indiv || ( ( ! isset( $options['comments']['show_on'] ) ) && ( 'default' == $show_indiv || empty( $show_indiv ) ) ) ) {
 				foreach( $options['comments'] as $param => $val ) {
 					$param = str_replace( '_', '-', $param );
 
@@ -131,45 +130,52 @@ function fb_get_comments_fields($placement = 'settings', $object = null) {
 }
 
 function fb_get_comments_fields_array() {
-	$array['parent'] = array('name' => 'comments',
-									'type' => 'checkbox',
-									'label' => 'Comments',
-									'description' => 'The Comments Box is a social plugin that enables user commenting on your site. Features include moderation tools and distribution.',
-									'help_link' => 'https://developers.facebook.com/docs/reference/plugins/comments/',
-									'image' => plugins_url( '/images/settings_comments.png', dirname(__FILE__))
-									);
-    $post_types = get_post_types(array('public' => true));
-	$array['children'] = array(array('name' => 'num_posts',
-													'label' => 'Number of posts',
-													'type' => 'text',
-													'default' => 20,
-													'help_text' => 'The number of posts to display by default.',
-													),
-										array('name' => 'width',
-													'type' => 'text',
-													'default' => '470',
-													'help_text' => 'The width of the plugin, in pixels.',
-													),
-										array('name' => 'colorscheme',
-													'label' => 'Color scheme',
-													'type' => 'dropdown',
-													'default' => 'light',
-													'options' => array('light' => 'light', 'dark' => 'dark'),
-													'help_text' => 'The color scheme of the plugin.',
-													),
-										array('name' => 'show_on',
-													'type' => 'checkbox',
-													'default' => array_fill_keys(array_keys($post_types) , 'true'),
-													'options' => $post_types,
-													'help_text' => __( 'Whether the plugin will appear on all posts or pages by default. If "individual posts and pages" is selected, you must explicitly set each post and page to display the plugin.', 'facebook' ),
-                         ),
-                    array('name' => 'homepage_comments',
-                          'label' => 'Show comment counts on the homepage',
-                          'type' => 'checkbox',
-                          'default' => 'true',
-                          'help_text' => __('Whether the plugin will display a comment count for each post on the homepage.'),
-                         )
-										);
+	$array['parent'] = array(
+		'name' => 'comments',
+		'type' => 'checkbox',
+		'label' => 'Comments',
+		'description' => 'The Comments Box is a social plugin that enables user commenting on your site. Features include moderation tools and distribution.',
+		'help_link' => 'https://developers.facebook.com/docs/reference/plugins/comments/',
+		'image' => plugins_url( '/images/settings_comments.png', dirname(__FILE__))
+	);
+	$post_types = get_post_types(array('public' => true));
+	$array['children'] = array(
+		array(
+			'name' => 'num_posts',
+			'label' => 'Number of posts',
+			'type' => 'text',
+			'default' => 20,
+			'help_text' => 'The number of posts to display by default.',
+		),
+		array(
+			'name' => 'width',
+			'type' => 'text',
+			'default' => '470',
+			'help_text' => 'The width of the plugin, in pixels.',
+		),
+		array(
+			'name' => 'colorscheme',
+			'label' => 'Color scheme',
+			'type' => 'dropdown',
+			'default' => 'light',
+			'options' => array('light' => 'light', 'dark' => 'dark'),
+			'help_text' => 'The color scheme of the plugin.',
+		),
+		array(
+			'name' => 'show_on',
+			'type' => 'checkbox',
+			'default' => array_fill_keys(array_keys($post_types) , 'true'),
+			'options' => $post_types,
+			'help_text' => __( 'Whether the plugin will appear on all posts or pages by default. If "individual posts and pages" is selected, you must explicitly set each post and page to display the plugin.', 'facebook' ),
+		),
+		array(
+			'name' => 'homepage_comments',
+			'label' => 'Show comment counts on the homepage',
+			'type' => 'checkbox',
+			'default' => 'true',
+			'help_text' => __('Whether the plugin will display a comment count for each post on the homepage.', 'facebook'),
+		)
+	);
 
 	return $array;
 }

--- a/social-plugins/fb-like.php
+++ b/social-plugins/fb-like.php
@@ -14,20 +14,17 @@
  */
 
 function fb_get_like_button($options = array()) {
-    $params = fb_build_social_plugin_params($options, 'like');
-
-	return '<div class="fb-like fb-social-plugin" ' . $params . ' ></div>';
+	return '<div class="fb-like fb-social-plugin" ' . fb_build_social_plugin_params( $options, 'like' ) . ' ></div>';
 }
 
 function fb_like_button_automatic($content) {
+	global $post;
+
 	$options = get_option('fb_options');
 
-    global $post;
-
 	if ( isset ( $post ) ) {
-		if ( isset($options['like']['show_on_homepage']) ) {
+		if ( isset($options['like']['show_on_homepage']) )
 			$options['like']['href'] = get_permalink($post->ID);
-		}
 
 		$new_content = '';
 
@@ -48,11 +45,9 @@ function fb_like_button_automatic($content) {
 		
 		if ( is_home() && isset ( $options['like']['show_on_homepage'] ) && isset ( $options['like']['show_on'] ) && isset( $options['like']['show_on'][ $post->post_type ] ) ) {
 			$content = $new_content;
-		}
-		elseif ( !is_home() && ( 'default' == $show_indiv || empty( $show_indiv ) ) && isset ( $options['like']['show_on'] ) && isset( $options['like']['show_on'][ $post->post_type ]) ) {
-            $content = $new_content;
-		}
-		elseif ( !is_home() && ('show' == $show_indiv || ( ( ! isset( $options['like']['show_on'] ) ) && ( 'default' == $show_indiv || empty( $show_indiv ) ) ) )) {
+		} else if ( !is_home() && ( 'default' == $show_indiv || empty( $show_indiv ) ) && isset ( $options['like']['show_on'] ) && isset( $options['like']['show_on'][ $post->post_type ]) ) {
+			$content = $new_content;
+		} else if ( !is_home() && ('show' == $show_indiv || ( ( ! isset( $options['like']['show_on'] ) ) && ( 'default' == $show_indiv || empty( $show_indiv ) ) ) )) {
 			$content = $new_content;
 		}
 	}
@@ -140,91 +135,126 @@ function fb_get_like_fields($placement = 'settings', $object = null) {
 }
 
 function fb_get_like_fields_array($placement) {
-	$array['parent'] = array('name' => 'like',
-														'label' => 'Like Button',
-														'image' => plugins_url( '/images/settings_like_button.png', dirname(__FILE__)),
-														'description' => 'The Like Button lets a user share your content with friends on Facebook. When the user clicks the Like button on your site, a story appears in the user\'s friends\' News Feed with a link back to your website.',
-														'help_link' => 'https://developers.facebook.com/docs/reference/plugins/like/',
-														);
+	$array['parent'] = array(
+		'name' => 'like',
+		'label' => 'Like Button',
+		'image' => plugins_url( '/images/settings_like_button.png', dirname(__FILE__)),
+		'description' => 'The Like Button lets a user share your content with friends on Facebook. When the user clicks the Like button on your site, a story appears in the user\'s friends\' News Feed with a link back to your website.',
+		'help_link' => 'https://developers.facebook.com/docs/reference/plugins/like/',
+	);
 
-	$array['children'] = array(         array('name' => 'send',
-													'type' => 'checkbox',
-													'default' => true,
-													'help_text' => __( 'Include a send button.', 'facebook' ),
-													),
-										array('name' => 'show_faces',
-													'type' => 'checkbox',
-													'default' => true,
-													'help_text' => __( 'Show profile pictures below the button.  Applicable to standard layout only.', 'facebook' ),
-													),
-										array('name' => 'layout',
-													'type' => 'dropdown',
-													'default' => 'standard',
-													'options' => array('standard' => 'standard', 'button_count' => 'button_count', 'box_count' => 'box_count'),
-													'help_text' => __( 'Determines the size and amount of social context at the bottom.', 'facebook' ),
-													),
-										array('name' => 'width',
-													'type' => 'text',
-													'default' => '450',
-													'help_text' => __( 'The width of the plugin, in pixels.', 'facebook' ),
-													'sanitization_callback' => 'intval',
-													),
-										array('name' => 'action',
-													'type' => 'dropdown',
-													'default' => 'like',
-													'options' => array('like' => 'like', 'recommend' => 'recommend'),
-													'help_text' => __( 'The verb to display in the button.', 'facebook' ),
-													),
-										array('name' => 'colorscheme',
-													'label' => 'Color scheme',
-													'type' => 'dropdown',
-													'default' => 'light',
-													'options' => array('light' => 'light', 'dark' => 'dark'),
-													'help_text' => __( 'The color scheme of the button.', 'facebook' ),
-													),
-										array('name' => 'font',
-													'type' => 'dropdown',
-													'default' => 'lucida grande',
-													'options' => array('arial' => 'arial', 'lucida grande' => 'lucida grande', 'segoe ui' => 'segoe ui', 'tahoma' => 'tahoma', 'trebuchet ms' => 'trebuchet ms', 'verdana' => 'verdana'),
-													'help_text' => __( 'The font of the button.', 'facebook' ),
-													),
-										);
+	$array['children'] = array(
+		array(
+			'name' => 'send',
+			'type' => 'checkbox',
+			'default' => true,
+			'help_text' => __( 'Include a send button.', 'facebook' )
+		),
+		array(
+			'name' => 'show_faces',
+			'type' => 'checkbox',
+			'default' => true,
+			'help_text' => __( 'Show profile pictures below the button.  Applicable to standard layout only.', 'facebook' )
+		),
+		array(
+			'name' => 'layout',
+			'type' => 'dropdown',
+			'default' => 'standard',
+			'options' => array(
+				'standard' => 'standard',
+				'button_count' => 'button_count',
+				'box_count' => 'box_count'
+			),
+			'help_text' => __( 'Determines the size and amount of social context at the bottom.', 'facebook' )
+		),
+		array(
+			'name' => 'width',
+			'type' => 'text',
+			'default' => '450',
+			'help_text' => __( 'The width of the plugin, in pixels.', 'facebook' ),
+			'sanitization_callback' => 'intval'
+		),
+		array(
+			'name' => 'action',
+			'type' => 'dropdown',
+			'default' => 'like',
+			'options' => array(
+				'like' => 'like',
+				'recommend' => 'recommend'
+			),
+			'help_text' => __( 'The verb to display in the button.', 'facebook' )
+		),
+		array(
+			'name' => 'colorscheme',
+			'label' => 'Color scheme',
+			'type' => 'dropdown',
+			'default' => 'light',
+			'options' => array(
+				'light' => 'light',
+				'dark' => 'dark'
+			),
+			'help_text' => __( 'The color scheme of the button.', 'facebook' )
+		),
+		array(
+			'name' => 'font',
+			'type' => 'dropdown',
+			'default' => 'lucida grande',
+			'options' => array(
+				'arial' => 'arial',
+				'lucida grande' => 'lucida grande',
+				'segoe ui' => 'segoe ui',
+				'tahoma' => 'tahoma',
+				'trebuchet ms' => 'trebuchet ms',
+				'verdana' => 'verdana'
+			),
+			'help_text' => __( 'The font of the button.', 'facebook' )
+		)
+	);
 
-	if ($placement == 'settings') {
-		$array['children'][] = array('name' => 'position',
-													'type' => 'dropdown',
-													'default' => 'both',
-													'options' => array('top' => 'top', 'bottom' => 'bottom', 'both' => 'both'),
-													'help_text' => __( 'Where the button will display on the page or post.', 'facebook' ),
-                                                );
-        $post_types = get_post_types(array('public' => true));
-        //unset($post_types['attachment']);
-        //$post_types = array_values($post_types);
-		$array['children'][] = array('name' => 'show_on',
-													'type' => 'checkbox',
-													'default' => array_fill_keys(array_keys($post_types) , 'true'),
-													'options' => $post_types,
-													'help_text' => __( 'Whether the plugin will appear on all posts or pages by default. If "individual posts and pages" is selected, you must explicitly set each post and page to display the plugin.', 'facebook' ),
-													);
-		$array['children'][] = array('name' => 'show_on_homepage',
-													'type' => 'checkbox',
-													'default' => true,
-													'help_text' => __( 'If the plugin should appear on the homepage as part of the Post previews.  If unchecked, the plugin will only display on the Post itself.', 'facebook' ),
-													);
+	if ( $placement == 'settings' ) {
+		$array['children'][] = array(
+			'name' => 'position',
+			'type' => 'dropdown',
+			'default' => 'both',
+			'options' => array(
+				'top' => 'top',
+				'bottom' => 'bottom',
+				'both' => 'both'
+			),
+			'help_text' => __( 'Where the button will display on the page or post.', 'facebook' )
+		);
+		$post_types = get_post_types(array('public' => true));
+		//unset($post_types['attachment']);
+		//$post_types = array_values($post_types);
+		$array['children'][] = array(
+			'name' => 'show_on',
+			'type' => 'checkbox',
+			'default' => array_fill_keys(array_keys($post_types) , 'true'),
+			'options' => $post_types,
+			'help_text' => __( 'Whether the plugin will appear on all posts or pages by default. If "individual posts and pages" is selected, you must explicitly set each post and page to display the plugin.', 'facebook' )
+		);
+		$array['children'][] = array(
+			'name' => 'show_on_homepage',
+			'type' => 'checkbox',
+			'default' => true,
+			'help_text' => __( 'If the plugin should appear on the homepage as part of the Post previews.  If unchecked, the plugin will only display on the Post itself.', 'facebook' )
+		);
 	}
 
 	if ($placement == 'widget') {
-		$title_array = array('name' => 'title',
-													'type' => 'text',
-													'help_text' => __( 'The title above the button.', 'facebook' ),
-													);
-		$text_array = array('name' => 'href',
-													'label' => 'URL',
-													'type' => 'text',
-													'default' => get_site_url(),
-													'help_text' => __( 'The URL the Like button will point to.', 'facebook' ),
-													'sanitization_callback' => 'esc_url_raw',
-													);
+		$title_array = array(
+			'name' => 'title',
+			'type' => 'text',
+			'help_text' => __( 'The title above the button.', 'facebook' )
+		);
+		$text_array = array(
+			'name' => 'href',
+			'label' => 'URL',
+			'type' => 'text',
+			'default' => get_site_url(),
+			'help_text' => __( 'The URL the Like button will point to.', 'facebook' ),
+			'sanitization_callback' => 'esc_url_raw'
+		);
 
 		array_unshift($array['children'], $title_array, $text_array);
 	}

--- a/social-plugins/fb-recommendations-bar.php
+++ b/social-plugins/fb-recommendations-bar.php
@@ -1,8 +1,6 @@
 <?php
 function fb_get_recommendations_bar($options = array()) {
-	$params = fb_build_social_plugin_params($options);
-
-	return '<div class="fb-recommendations-bar fb-social-plugin" ' . $params . '></div>';
+	return '<div class="fb-recommendations-bar fb-social-plugin" ' . fb_build_social_plugin_params($options) . '></div>';
 }
 
 function fb_recommendations_bar_automatic( $content ) {
@@ -13,8 +11,7 @@ function fb_recommendations_bar_automatic( $content ) {
 
 	if ( !is_home() && ( 'default' == $show_indiv || empty( $show_indiv ) ) && isset( $options['recommendations_bar']['show_on']) && isset( $options['recommendations_bar']['show_on'][$post->post_type] ) )  {
 		$content .= fb_get_recommendations_bar( $options['recommendations_bar'] );
-	}
-	elseif ( !is_home() && ( 'show' == $show_indiv || ( ( ! isset( $options['recommendations_bar']['show_on'] ) ) && ( 'default' == $show_indiv || empty( $show_indiv ) ) ) ) ) {
+	} else if ( !is_home() && ( 'show' == $show_indiv || ( ( ! isset( $options['recommendations_bar']['show_on'] ) ) && ( 'default' == $show_indiv || empty( $show_indiv ) ) ) ) ) {
 		$content .= fb_get_recommendations_bar( $options['recommendations_bar'] );
 	}
 	//elseif ( 'no' == $show_indiv ) {
@@ -31,42 +28,56 @@ function fb_get_recommendations_bar_fields($placement = 'settings', $object = nu
 }
 
 function fb_get_recommendations_bar_fields_array() {
-	$array['parent'] = array('name' => 'recommendations_bar',
-													 'label' => 'Recommendations Bar',
-														'help_link' => 'https://developers.facebook.com/docs/reference/plugins/recommendationsbar/',
-														'description' => 'The Recommendations Bar allows users to click to start getting recommendations, Like content, and add what they\'re reading to Timeline as they go.',
-														'image' => plugins_url( '/images/settings_recommendations_bar.png', dirname(__FILE__))
-									);
-    $post_types = get_post_types(array('public' => true));
-	$array['children'] = array(array('name' => 'trigger',
-													'type' => 'text',
-													'default' => '50',
-													'help_text' => __( 'This specifies the percent of the page the user must scroll down before the plugin is expanded.', 'facebook' ),
-													),
-										array('name' => 'read_time',
-													'type' => 'text',
-													'default' => '20',
-													'help_text' => __( 'The number of seconds the plugin will wait until it expands.', 'facebook' ),
-													),
-										array('name' => 'action',
-													'type' => 'dropdown',
-													'default' => 'like',
-													'options' => array('like' => 'like', 'recommend' => 'recommend'),
-													'help_text' => __( 'The verb to display in the button.', 'facebook' ),
-													),
-										array('name' => 'side',
-													'type' => 'dropdown',
-													'default' => 'right',
-													'options' => array('left' => 'left', 'right' => 'right'),
-													'help_text' => __( 'The side of the window that the plugin will display.', 'facebook' ),
-													),
-										array('name' => 'show_on',
-                                                    'type' => 'checkbox',
-                                                    'default' => array_fill_keys(array_keys($post_types) , 'true'),
-                                                    'options' => $post_types,
-                                                    'help_text' => __( 'Whether the plugin will appear on all posts or pages by default. If "individual posts and pages" is selected, you must explicitly set each post and page to display the plugin.', 'facebook' ),
-													)
-										);
+	$array['parent'] = array(
+		'name' => 'recommendations_bar',
+		'label' => 'Recommendations Bar',
+		'help_link' => 'https://developers.facebook.com/docs/reference/plugins/recommendationsbar/',
+		'description' => 'The Recommendations Bar allows users to click to start getting recommendations, Like content, and add what they\'re reading to Timeline as they go.',
+		'image' => plugins_url( '/images/settings_recommendations_bar.png', dirname(__FILE__) )
+	);
+
+	$post_types = get_post_types(array('public' => true));
+	$array['children'] = array(
+		array(
+			'name' => 'trigger',
+			'type' => 'text',
+			'default' => '50',
+			'help_text' => __( 'This specifies the percent of the page the user must scroll down before the plugin is expanded.', 'facebook' )
+		),
+		array(
+			'name' => 'read_time',
+			'type' => 'text',
+			'default' => '20',
+			'help_text' => __( 'The number of seconds the plugin will wait until it expands.', 'facebook' )
+		),
+		array(
+			'name' => 'action',
+			'type' => 'dropdown',
+			'default' => 'like',
+			'options' => array(
+				'like' => 'like',
+				'recommend' => 'recommend'
+			),
+			'help_text' => __( 'The verb to display in the button.', 'facebook' )
+		),
+		array(
+			'name' => 'side',
+			'type' => 'dropdown',
+			'default' => 'right',
+			'options' => array(
+				'left' => 'left',
+				'right' => 'right'
+			),
+			'help_text' => __( 'The side of the window that the plugin will display.', 'facebook' )
+		),
+		array(
+			'name' => 'show_on',
+			'type' => 'checkbox',
+			'default' => array_fill_keys(array_keys($post_types) , 'true'),
+			'options' => $post_types,
+			'help_text' => __( 'Whether the plugin will appear on all posts or pages by default. If "individual posts and pages" is selected, you must explicitly set each post and page to display the plugin.', 'facebook' )
+		)
+	);
 
 	return $array;
 }

--- a/social-plugins/fb-recommendations.php
+++ b/social-plugins/fb-recommendations.php
@@ -1,12 +1,9 @@
 <?php
 function fb_get_recommendations_box($options = array()) {
-	if (empty($options['header'])) {
+	if ( empty( $options['header'] ) )
 		$options['header'] = 'false';
-	}
 
-	$params = fb_build_social_plugin_params($options);
-
-	return '<div class="fb-recommendations fb-social-plugin" ' . $params . '></div>';
+	return '<div class="fb-recommendations fb-social-plugin" ' . fb_build_social_plugin_params($options) . '></div>';
 }
 
 /**
@@ -91,48 +88,66 @@ function fb_get_recommendations_box_fields($placement = 'settings', $object = nu
 }
 
 function fb_get_recommendations_box_fields_array($placement) {
-	$array['children'] = array(array('name' => 'width',
-													'type' => 'text',
-													'default' => '300',
-													'help_text' => __( 'The width of the plugin, in pixels.', 'facebook' ),
-													'sanitization_callback' => 'intval',
-													),
-										array('name' => 'height',
-													'type' => 'text',
-													'default' => '300',
-													'help_text' => __( 'The height of the plugin, in pixels.', 'facebook' ),
-													'sanitization_callback' => 'intval',
-													),
-										array('name' => 'colorscheme',
-													'label' => 'Color scheme',
-													'type' => 'dropdown',
-													'default' => 'light',
-													'options' => array('light' => 'light', 'dark' => 'dark'),
-													'help_text' => __( 'The color scheme of the plugin.', 'facebook' ),
-													),
-										array('name' => 'border_color',
-													'type' => 'text',
-													'default' => '#aaa',
-													'help_text' => __( 'The border color scheme of the plugin (hex or text value).', 'facebook' ),
-													),
-										array('name' => 'font',
-													'type' => 'dropdown',
-													'default' => 'lucida grande',
-													'options' => array('arial' => 'arial', 'lucida grande' => 'lucida grande', 'segoe ui' => 'segoe ui', 'tahoma' => 'tahoma', 'trebuchet ms' => 'trebuchet ms', 'verdana' => 'verdana'),
-													'help_text' => __( 'The font of the plugin.', 'facebook' ),
-													),
-										);
+	$array['children'] = array(
+		array(
+			'name' => 'width',
+			'type' => 'text',
+			'default' => '300',
+			'help_text' => __( 'The width of the plugin, in pixels.', 'facebook' ),
+			'sanitization_callback' => 'intval'
+		),
+		array(
+			'name' => 'height',
+			'type' => 'text',
+			'default' => '300',
+			'help_text' => __( 'The height of the plugin, in pixels.', 'facebook' ),
+			'sanitization_callback' => 'intval'
+		),
+		array(
+			'name' => 'colorscheme',
+			'label' => 'Color scheme',
+			'type' => 'dropdown',
+			'default' => 'light',
+			'options' => array(
+				'light' => 'light',
+				'dark' => 'dark'
+			),
+			'help_text' => __( 'The color scheme of the plugin.', 'facebook' )
+		),
+		array(
+			'name' => 'border_color',
+			'type' => 'text',
+			'default' => '#aaa',
+			'help_text' => __( 'The border color scheme of the plugin (hex or text value).', 'facebook' )
+		),
+		array(
+			'name' => 'font',
+			'type' => 'dropdown',
+			'default' => 'lucida grande',
+			'options' => array(
+				'arial' => 'arial',
+				'lucida grande' => 'lucida grande',
+				'segoe ui' => 'segoe ui',
+				'tahoma' => 'tahoma',
+				'trebuchet ms' => 'trebuchet ms',
+				'verdana' => 'verdana'
+			),
+			'help_text' => __( 'The font of the plugin.', 'facebook' )
+		)
+	);
 
 	if ($placement == 'widget') {
-		$title_array = array('name' => 'title',
-													'type' => 'text',
-													'help_text' => 'The title above the button.',
-													);
-		$header_array = array('name' => 'header',
-													'type' => 'checkbox',
-													'default' => true,
-													'help_text' => 'Show the default Facebook title header.',
-													);
+		$title_array = array(
+			'name' => 'title',
+			'type' => 'text',
+			'help_text' => __( 'The title above the button.', 'facebook' )
+		);
+		$header_array = array(
+			'name' => 'header',
+			'type' => 'checkbox',
+			'default' => true,
+			'help_text' => __( 'Show the default Facebook title header.', 'facebook' )
+		);
 
 		array_unshift($array['children'], $title_array, $header_array);
 	}

--- a/social-plugins/fb-send.php
+++ b/social-plugins/fb-send.php
@@ -1,14 +1,12 @@
 <?php
 function fb_get_send_button($options = array()) {
-	$params = fb_build_social_plugin_params($options);
-
-	return '<div class="fb-send fb-social-plugin" ' . $params . '></div>';
+	return '<div class="fb-send fb-social-plugin" ' . fb_build_social_plugin_params($options) . '></div>';
 }
 
 function fb_send_button_automatic($content) {
-	$options = get_option('fb_options');
-	
 	global $post;
+
+	$options = get_option('fb_options');
 	
 	if ( isset( $post ) ) {
 		if ( isset( $options['send']['show_on_homepage'] ) ) {
@@ -34,16 +32,12 @@ function fb_send_button_automatic($content) {
 		
 		if ( is_home() && isset ( $options['send']['show_on_homepage'] ) && isset( $options['send']['show_on'] ) && isset( $options['send']['show_on'][$post->post_type] ) ) {
 			$content = $new_content;
-		}
-		elseif ( !is_home() && ( 'default' == $show_indiv || empty( $show_indiv ) ) && isset ( $options['send']['show_on'] ) && isset( $options['send']['show_on'][$post->post_type] ) ) {		
-            $content = $new_content;
-		}
-		elseif ( !is_home() && ('show' == $show_indiv || ( ( ! isset( $options['send']['show_on'] ) ) && ( 'default' == $show_indiv || empty( $show_indiv ) ) ) ) ) {
+		} else if ( !is_home() && ( 'default' == $show_indiv || empty( $show_indiv ) ) && isset ( $options['send']['show_on'] ) && isset( $options['send']['show_on'][$post->post_type] ) ) {
+			$content = $new_content;
+		} else if ( !is_home() && ('show' == $show_indiv || ( ( ! isset( $options['send']['show_on'] ) ) && ( 'default' == $show_indiv || empty( $show_indiv ) ) ) ) ) {
 			$content = $new_content;
 		}
-		
 	}
-	
 
 	return $content;
 }
@@ -131,63 +125,82 @@ function fb_get_send_fields($placement = 'settings', $object = null) {
 }
 
 function fb_get_send_fields_array($placement) {
-	$array['parent'] = array('name' => 'send',
-									'type' => 'checkbox',
-									'label' => 'Send Button',
-									'description' => 'The Send Button allows users to easily send content to their friends. People will have the option to send your URL in a message to their Facebook friends, to the group wall of one of their Facebook groups, and as an email to any email address.',
-									'help_link' => 'https://developers.facebook.com/docs/reference/plugins/send/',
-									'image' => plugins_url( '/images/settings_send_button.png', dirname(__FILE__))
-									);
+	$array['parent'] = array(
+		'name' => 'send',
+		'type' => 'checkbox',
+		'label' => 'Send Button',
+		'description' => __( 'The Send Button allows users to easily send content to their friends. People will have the option to send your URL in a message to their Facebook friends, to the group wall of one of their Facebook groups, and as an email to any email address.', 'facebook' ),
+		'help_link' => 'https://developers.facebook.com/docs/reference/plugins/send/',
+		'image' => plugins_url( '/images/settings_send_button.png', dirname(__FILE__) )
+	);
 
-	$array['children'] = array(array('name' => 'colorscheme',
-													'label' => 'Color scheme',
-													'type' => 'dropdown',
-													'default' => 'light',
-													'options' => array('light' => 'light', 'dark' => 'dark'),
-													'help_text' => __( 'The color scheme of the plugin.', 'facebook' ),
-													),
-										array('name' => 'font',
-													'type' => 'dropdown',
-													'default' => 'lucida grande',
-													'options' => array('arial' => 'arial', 'lucida grande' => 'lucida grande', 'segoe ui' => 'segoe ui', 'tahoma' => 'tahoma', 'trebuchet ms' => 'trebuchet ms', 'verdana' => 'verdana'),
-													'help_text' => __( 'The font of the plugin.', 'facebook' ),
-													),
-										);
+	$array['children'] = array(
+		array(
+			'name' => 'colorscheme',
+			'label' => 'Color scheme',
+			'type' => 'dropdown',
+			'default' => 'light',
+			'options' => array(
+				'light' => 'light',
+				'dark' => 'dark'
+			),
+			'help_text' => __( 'The color scheme of the plugin.', 'facebook' )
+		),
+		array(
+			'name' => 'font',
+			'type' => 'dropdown',
+			'default' => 'lucida grande',
+			'options' => array(
+				'arial' => 'arial',
+				'lucida grande' => 'lucida grande',
+				'segoe ui' => 'segoe ui',
+				'tahoma' => 'tahoma',
+				'trebuchet ms' => 'trebuchet ms',
+				'verdana' => 'verdana'
+			),
+			'help_text' => __( 'The font of the plugin.', 'facebook' ),
+		)
+	);
 
 	if ($placement == 'settings') {
-		$array['children'][] = array('name' => 'position',
-													'type' => 'dropdown',
-													'default' => 'both',
-													'options' => array('top' => 'top', 'bottom' => 'bottom', 'both' => 'both'),
-													'help_text' => __( 'Where the button will display on the page or post.', 'facebook' ),
-													);
-        
-        $post_types = get_post_types(array('public' => true));
-        $array['children'][] = array('name' => 'show_on',
-													'type' => 'checkbox',
-                                                    'default' => array_fill_keys(array_keys($post_types) , 'true'),
-                                                    'options' => $post_types,
-                                                    'help_text' => __( 'Whether the plugin will appear on all posts or pages by default. If "individual posts and pages" is selected, you must explicitly set each post and page to display the plugin.', 'facebook' ),
-													);
-		$array['children'][] = array('name' => 'show_on_homepage',
-													'type' => 'checkbox',
-													'default' => true,
-													'help_text' => __( 'If the plugin should appear on the homepage as part of the Post previews.  If unchecked, the plugin will only display on the Post itself.', 'facebook' ),
-													);
+		$array['children'][] = array(
+			'name' => 'position',
+			'type' => 'dropdown',
+			'default' => 'both',
+			'options' => array('top' => 'top', 'bottom' => 'bottom', 'both' => 'both'),
+			'help_text' => __( 'Where the button will display on the page or post.', 'facebook' )
+		);
+
+		$post_types = get_post_types(array('public' => true));
+		$array['children'][] = array(
+			'name' => 'show_on',
+			'type' => 'checkbox',
+			'default' => array_fill_keys(array_keys($post_types) , 'true'),
+			'options' => $post_types,
+			'help_text' => __( 'Whether the plugin will appear on all posts or pages by default. If "individual posts and pages" is selected, you must explicitly set each post and page to display the plugin.', 'facebook' )
+		);
+		$array['children'][] = array(
+			'name' => 'show_on_homepage',
+			'type' => 'checkbox',
+			'default' => true,
+			'help_text' => __( 'If the plugin should appear on the homepage as part of the Post previews.  If unchecked, the plugin will only display on the Post itself.', 'facebook' )
+		);
 	}
 
 	if ($placement == 'widget') {
-		$title_array = array('name' => 'title',
-													'type' => 'text',
-													'help_text' => __( 'The title above the button.', 'facebook' ),
-													);
-		$text_array = array('name' => 'href',
-													'label' => 'URL',
-													'type' => 'text',
-													'default' => get_site_url(),
-													'help_text' => __( 'The URL the Send button will point to.', 'facebook' ),
-													'sanitization_callback' => 'esc_url_raw',
-													);
+		$title_array = array(
+			'name' => 'title',
+			'type' => 'text',
+			'help_text' => __( 'The title above the button.', 'facebook' )
+		);
+		$text_array = array(
+			'name' => 'href',
+			'label' => 'URL',
+			'type' => 'text',
+			'default' => get_site_url(),
+			'help_text' => __( 'The URL the Send button will point to.', 'facebook' ),
+			'sanitization_callback' => 'esc_url_raw'
+		);
 
 		array_unshift($array['children'], $title_array, $text_array);
 	}

--- a/social-plugins/fb-subscribe.php
+++ b/social-plugins/fb-subscribe.php
@@ -1,8 +1,6 @@
 <?php
 function fb_get_subscribe_button($options = array()) {
-	$params = fb_build_social_plugin_params($options);
-
-	return '<div class="fb-subscribe fb-social-plugin" ' . $params . '></div>';
+	return '<div class="fb-subscribe fb-social-plugin" ' . fb_build_social_plugin_params($options) . '></div>';
 }
 
 function fb_subscribe_button_automatic($content) {
@@ -143,78 +141,107 @@ function fb_get_subscribe_fields($placement = 'settings', $object = null) {
 }
 
 function fb_get_subscribe_fields_array($placement) {
-	$array['parent'] = array('name' => 'subscribe',
-									'label' => 'Subscribe Button',
-									'description' => 'The Subscribe Button lets a user subscribe to your public updates on Facebook.  Each WordPress author must authenticate with Facebook in order for the Subscribe button to appear on their pages and posts.',
-									'type' => 'checkbox',
-									'help_link' => 'https://developers.facebook.com/docs/reference/plugins/subscribe/',
-									'image' => plugins_url( '/images/settings_subscribe_button.png', dirname(__FILE__))
-									);
+	$array['parent'] = array(
+		'name' => 'subscribe',
+		'label' => 'Subscribe Button',
+		'description' => 'The Subscribe Button lets a user subscribe to your public updates on Facebook.  Each WordPress author must authenticate with Facebook in order for the Subscribe button to appear on their pages and posts.',
+		'type' => 'checkbox',
+		'help_link' => 'https://developers.facebook.com/docs/reference/plugins/subscribe/',
+		'image' => plugins_url( '/images/settings_subscribe_button.png', dirname(__FILE__))
+	);
 
-	$array['children'] = array(array('name' => 'layout',
-													'type' => 'dropdown',
-													'default' => 'standard',
-													'options' => array('standard' => 'standard', 'button_count' => 'button_count', 'box_count' => 'box_count'),
-													'help_text' => __( 'Determines the size and amount of social context at the bottom.', 'facebook' ),
-													),
-										array('name' => 'width',
-													'type' => 'text',
-													'default' => '450',
-													'help_text' => __( 'The width of the plugin, in pixels.', 'facebook' ),
-													'sanitization_callback' => 'intval',
-													),
-										array('name' => 'show_faces',
-													'type' => 'checkbox',
-													'default' => true,
-													'help_text' => __( 'Show profile pictures below the button.  Applicable to standard layout only.', 'facebook' ),
-													),
-										array('name' => 'colorscheme',
-													'label' => 'Color scheme',
-													'type' => 'dropdown',
-													'default' => 'light',
-													'options' => array('light' => 'light', 'dark' => 'dark'),
-													'help_text' => __( 'The color scheme of the plugin.', 'facebook' ),
-													),
-										array('name' => 'font',
-													'type' => 'dropdown',
-													'default' => 'lucida grande',
-													'options' => array('arial' => 'arial', 'lucida grande' => 'lucida grande', 'segoe ui' => 'segoe ui', 'tahoma' => 'tahoma', 'trebuchet ms' => 'trebuchet ms', 'verdana' => 'verdana'),
-													'help_text' => __( 'The font of the plugin.', 'facebook' ),
-													),
-										);
+	$array['children'] = array(
+		array(
+			'name' => 'layout',
+			'type' => 'dropdown',
+			'default' => 'standard',
+			'options' => array(
+				'standard' => 'standard',
+				'button_count' => 'button_count',
+				'box_count' => 'box_count'
+			),
+			'help_text' => __( 'Determines the size and amount of social context at the bottom.', 'facebook' )
+		),
+		array(
+			'name' => 'width',
+			'type' => 'text',
+			'default' => '450',
+			'help_text' => __( 'The width of the plugin, in pixels.', 'facebook' ),
+			'sanitization_callback' => 'intval'
+		),
+		array(
+			'name' => 'show_faces',
+			'type' => 'checkbox',
+			'default' => true,
+			'help_text' => __( 'Show profile pictures below the button.  Applicable to standard layout only.', 'facebook' )
+		),
+		array(
+			'name' => 'colorscheme',
+			'label' => 'Color scheme',
+			'type' => 'dropdown',
+			'default' => 'light',
+			'options' => array(
+				'light' => 'light',
+				'dark' => 'dark'
+			),
+			'help_text' => __( 'The color scheme of the plugin.', 'facebook' )
+		),
+		array(
+			'name' => 'font',
+			'type' => 'dropdown',
+			'default' => 'lucida grande',
+			'options' => array(
+				'arial' => 'arial',
+				'lucida grande' => 'lucida grande',
+				'segoe ui' => 'segoe ui',
+				'tahoma' => 'tahoma',
+				'trebuchet ms' => 'trebuchet ms',
+				'verdana' => 'verdana'
+			),
+			'help_text' => __( 'The font of the plugin.', 'facebook' )
+		)
+	);
 
 	if ($placement == 'settings') {
-		$array['children'][] = array('name' => 'position',
-													'type' => 'dropdown',
-													'default' => 'both',
-													'options' => array('top' => 'top', 'bottom' => 'bottom', 'both' => 'both'),
-													'help_text' => __( 'Where the button will display on the page or post.', 'facebook' ),
-                                                );
+		$array['children'][] = array(
+			'name' => 'position',
+			'type' => 'dropdown',
+			'default' => 'both',
+			'options' => array(
+				'top' => 'top',
+				'bottom' => 'bottom',
+				'both' => 'both'
+			),
+			'help_text' => __( 'Where the button will display on the page or post.', 'facebook' )
+		);
         $post_types = get_post_types(array('public' => true));
-		$array['children'][] = array('name' => 'show_on',
-                                                    'type' => 'checkbox',
-                                                    'default' => array_fill_keys(array_keys($post_types) , 'true'),
-                                                    'options' => $post_types,
-                                                    'help_text' => __( 'Whether the plugin will appear on all posts or pages by default. If "individual posts and pages" is selected, you must explicitly set each post and page to display the plugin.', 'facebook' ),
-													);
-		$array['children'][] = array('name' => 'show_on_homepage',
-													'type' => 'checkbox',
-													'default' => true,
-													'help_text' => __( 'If the plugin should appear on the homepage as part of the Post previews.  If unchecked, the plugin will only display on the Post itself.', 'facebook' ),
-													);
-
+		$array['children'][] = array(
+			'name' => 'show_on',
+			'type' => 'checkbox',
+			'default' => array_fill_keys(array_keys($post_types) , 'true'),
+			'options' => $post_types,
+			'help_text' => __( 'Whether the plugin will appear on all posts or pages by default. If "individual posts and pages" is selected, you must explicitly set each post and page to display the plugin.', 'facebook' )
+		);
+		$array['children'][] = array(
+			'name' => 'show_on_homepage',
+			'type' => 'checkbox',
+			'default' => true,
+			'help_text' => __( 'If the plugin should appear on the homepage as part of the Post previews.  If unchecked, the plugin will only display on the Post itself.', 'facebook' )
+		);
 	}
 
-	if ($placement == 'widget') {
-		$title_array = array('name' => 'title',
-													'type' => 'text',
-													'help_text' => __( 'The title above the button.', 'facebook' ),
-													);
-		$text_array = array('name' => 'href',
-													'type' => 'text',
-													'default' => get_site_url(),
-													'help_text' => __( 'The URL the Subscribe button will point to.', 'facebook' ),
-													);
+	if ( $placement == 'widget' ) {
+		$title_array = array(
+			'name' => 'title',
+			'type' => 'text',
+			'help_text' => __( 'The title above the button.', 'facebook' )
+		);
+		$text_array = array(
+			'name' => 'href',
+			'type' => 'text',
+			'default' => get_site_url(),
+			'help_text' => __( 'The URL the Subscribe button will point to.', 'facebook' )
+		);
 
 		array_unshift($array['children'], $title_array, $text_array);
 	}


### PR DESCRIPTION
Current code uses both spaces and tabs for indentation. Switch to tabs-only to match [WordPress Coding Standards](http://make.wordpress.org/core/handbook/coding-standards/#indentation)

Use single-quoted static strings instead of double-quoted dynamic strings if a string was close to where an indent change was made. List of plugin URIs was the biggest change in quoted strings.
