### PR TITLE
declare proper versions for bundled CSS libraries

### DIFF
--- a/fb-admin-menu.php
+++ b/fb-admin-menu.php
@@ -228,8 +228,8 @@ add_filter( 'plugin_action_links', 'fb_plugin_action_links', 10, 2 );
  */
 function fb_admin_style() {
 	wp_enqueue_style( 'fb_admin', plugins_url( 'style/style-admin.min.css', __FILE__), array(), '1.0' );
-	wp_enqueue_style( 'fb_loopj', plugins_url( 'scripts/loopj-jquery-tokeninput/styles/token-input-facebook.min.css', __FILE__ ), array(), '1.0' );
-	wp_enqueue_style( 'tipsy', plugins_url( 'style/tipsy.min.css', __FILE__) );
+	wp_enqueue_style( 'fb_loopj', plugins_url( 'scripts/loopj-jquery-tokeninput/styles/token-input-facebook.min.css', __FILE__ ), array(), '1.6.0' );
+	wp_enqueue_style( 'tipsy', plugins_url( 'style/tipsy.min.css', __FILE__), array(), '1.0.0a' );
 }
 
 /**


### PR DESCRIPTION
Use versions from CSS libraries when enqueing their styles. better than WP version for cache busting and comparison
