### PR TITLE
fix spacing for social plugins microdata options

### DIFF
--- a/social-plugins/fb-like.php
+++ b/social-plugins/fb-like.php
@@ -14,7 +14,7 @@
  */
 
 function fb_get_like_button($options = array()) {
-	return '<div class="fb-like fb-social-plugin" ' . fb_build_social_plugin_params( $options, 'like' ) . ' ></div>';
+	return '<div class="fb-like fb-social-plugin" ' . fb_build_social_plugin_params( $options, 'like' ) . '></div>';
 }
 
 function fb_like_button_automatic($content) {

--- a/social-plugins/fb-social-plugins.php
+++ b/social-plugins/fb-social-plugins.php
@@ -60,10 +60,10 @@ function fb_build_social_plugin_params($options, $plugin = '' ) {
 
     if ( 'like' == $plugin ) {
         if ( ! isset( $options['send'] ) || empty( $options['send'] ) ) {
-            $params .= 'data-send="false"';
+            $params .= 'data-send="false" ';
         }
         if ( ! isset( $options['show_faces'] ) || empty( $options['show_faces'] ) ) {
-            $params .= 'data-show-faces="false"';
+            $params .= 'data-show-faces="false" ';
         }
     }
 
@@ -73,9 +73,10 @@ function fb_build_social_plugin_params($options, $plugin = '' ) {
 		$params .= 'data-' . $option . '="' . esc_attr($value) . '" ';
     }
 
-	$params .= 'data-ref="wp" ';
+    if ( ! array_key_exists( 'ref', $options ) )
+		$params .= 'data-ref="wp" ';
 
-	return $params;
+	return rtrim( $params, ' ' );
 }
 
 if ( true ) {

--- a/social-plugins/fb-social-plugins.php
+++ b/social-plugins/fb-social-plugins.php
@@ -73,7 +73,7 @@ function fb_build_social_plugin_params($options, $plugin = '' ) {
 		$params .= 'data-' . $option . '="' . esc_attr($value) . '" ';
     }
 
-    if ( ! array_key_exists( 'ref', $options ) )
+	if ( ! array_key_exists( 'ref', $options ) )
 		$params .= 'data-ref="wp" ';
 
 	return rtrim( $params, ' ' );


### PR DESCRIPTION
Social plugin options are defined through microdata on the target element. The `send` and `show-faces` options for the Like button receive special treatment outside of the microdata options builder.

Add a trailing space to the `send` and `show-faces` options for consistency with the microdata string builder. Check for an existing `ref` option passed to the function before outputting a duplicate attribute. Trim trailing whitespace before returning attribute string.
