### PR TITLE
standalone uninstall file

### DIFF
--- a/facebook.php
+++ b/facebook.php
@@ -21,7 +21,7 @@ $fb_ver = '1.0.3';
 $facebook_plugin_directory = dirname(__FILE__);
 
 // Load the textdomain for translations
-add_action('init', 'fb_load_textdomain');
+add_action( 'init', 'fb_load_textdomain' );
 function fb_load_textdomain() {
 	load_plugin_textdomain( 'facebook', false, dirname( plugin_basename( __FILE__ ) ) . '/lang/' );
 }
@@ -31,23 +31,12 @@ if ( ! class_exists( 'Facebook_WP' ) )
 	require_once( $facebook_plugin_directory . '/includes/facebook-php-sdk/class-facebook-wp.php' );
 
 require_once( $facebook_plugin_directory . '/fb-core.php' );
-require_once( $facebook_plugin_directory . '/fb-admin-menu.php');
-require_once( $facebook_plugin_directory . '/fb-open-graph.php');
-require_once( $facebook_plugin_directory . '/social-plugins/fb-social-plugins.php');
+require_once( $facebook_plugin_directory . '/fb-admin-menu.php' );
+require_once( $facebook_plugin_directory . '/fb-open-graph.php' );
+require_once( $facebook_plugin_directory . '/social-plugins/fb-social-plugins.php' );
 require_once( $facebook_plugin_directory . '/fb-login.php' );
 require_once( $facebook_plugin_directory . '/fb-social-publisher.php' );
 require_once( $facebook_plugin_directory . '/fb-wp-helpers.php' );
 unset( $facebook_plugin_directory );
 
-register_uninstall_hook( __FILE__, 'fb_uninstall' );
-
-function fb_uninstall() {
-	$meta_keys = array('state', 'code', 'access_token', 'user_id', 'fb_data');
-
-	foreach ( $meta_keys as $meta_key ) {
-		delete_user_meta( get_current_user_id(), $meta_key );
-	}
-
-	delete_option( 'fb_options' );
-	delete_option( 'fb_flush_rewrite_rules' );
-}
+?>

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Remove data written by the Facebook plugin for WordPress after an administrative user clicks "Delete" from the plugin management page in wp-admin.
+ *
+ * @since 1.0.3
+ */
+
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) )
+	exit();
+
+foreach ( array('state', 'code', 'access_token', 'user_id', 'fb_data') as $meta_key ) {
+	delete_user_meta( get_current_user_id(), $meta_key );
+}
+
+delete_option( 'fb_options' );
+delete_option( 'fb_flush_rewrite_rules' );
+?>


### PR DESCRIPTION
Use the [uninstall.php method of plugin cleanup](http://codex.wordpress.org/Function_Reference/register_uninstall_hook#uninstall.php) instead of uninstall hook.

From Codex: "Emphasis is put on using the 'uninstall.php' way of uninstalling the plugin rather than register_uninstall_hook"
