### PR TITLE
check for conflicts through an action

### DIFF
--- a/fb-wp-helpers.php
+++ b/fb-wp-helpers.php
@@ -320,7 +320,7 @@ function fb_option_name($field){
 	}
 }
 
-function fb_sanitize_options ($options_array) {
+function fb_sanitize_options($options_array) {
 	foreach ($options_array as $key => $value) {
 		if (is_array($value))
 			$options_array[$key] = fb_sanitize_options($value);


### PR DESCRIPTION
#225 asks for a way to get rid of the inefficiencies of `fb_notify_user_of_plugin_conflicts` if the plugin checks do not apply to the site or the site owner rather not run checks.

Pass the function through an action, then fire the action in the same place in the code as the previous function call. Advanced users who do not want the function to run in admin can unhook the action.
