### PR TITLE
update Facebook PHP SDK to 3.2

### DIFF
--- a/includes/facebook-php-sdk/facebook.php
+++ b/includes/facebook-php-sdk/facebook.php
@@ -25,22 +25,75 @@ if ( ! class_exists( 'WP_Facebook' ) ):
  */
 class WP_Facebook extends WP_BaseFacebook
 {
+  const FBSS_COOKIE_NAME = 'fbss';
+
+  // We can set this to a high number because the main session
+  // expiration will trump this.
+  const FBSS_COOKIE_EXPIRE = 31556926; // 1 year
+
+  // Stores the shared session ID if one is set.
+  protected $sharedSessionID;
+
   /**
    * Identical to the parent constructor, except that
    * we start a PHP session to store the user ID and
    * access token if during the course of execution
    * we discover them.
    *
-   * @param Array $config the application configuration.
+   * @param Array $config the application configuration. Additionally
+   * accepts "sharedSession" as a boolean to turn on a secondary
+   * cookie for environments with a shared session (that is, your app
+   * shares the domain with other apps).
    * @see WP_BaseFacebook::__construct in facebook.php
    */
   public function __construct($config) {
-    
+    if (!session_id()) {
+      session_start();
+    }
     parent::__construct($config);
+    if (!empty($config['sharedSession'])) {
+      $this->initSharedSession();
+    }
   }
 
   protected static $kSupportedKeys =
     array('state', 'code', 'access_token', 'user_id');
+
+  protected function initSharedSession() {
+    $cookie_name = $this->getSharedSessionCookieName();
+    if (isset($_COOKIE[$cookie_name])) {
+      $data = $this->parseSignedRequest($_COOKIE[$cookie_name]);
+      if ($data && !empty($data['domain']) &&
+          self::isAllowedDomain($this->getHttpHost(), $data['domain'])) {
+        // good case
+        $this->sharedSessionID = $data['id'];
+        return;
+      }
+      // ignoring potentially unreachable data
+    }
+    // evil/corrupt/missing case
+    $base_domain = $this->getBaseDomain();
+    $this->sharedSessionID = md5(uniqid(mt_rand(), true));
+    $cookie_value = $this->makeSignedRequest(
+      array(
+        'domain' => $base_domain,
+        'id' => $this->sharedSessionID,
+      )
+    );
+    $_COOKIE[$cookie_name] = $cookie_value;
+    if (!headers_sent()) {
+      $expire = time() + self::FBSS_COOKIE_EXPIRE;
+      setcookie($cookie_name, $cookie_value, $expire, '/', '.'.$base_domain);
+    } else {
+      // @codeCoverageIgnoreStart
+      self::errorLog(
+        'Shared session ID cookie could not be set! You must ensure you '.
+        'create the Facebook instance before headers have been sent. This '.
+        'will cause authentication issues after the first request.'
+      );
+      // @codeCoverageIgnoreEnd
+    }
+  }
 
   /**
    * Provides the implementations of the inherited abstract
@@ -83,12 +136,28 @@ class WP_Facebook extends WP_BaseFacebook
     foreach (self::$kSupportedKeys as $key) {
       $this->clearPersistentData($key);
     }
+    if ($this->sharedSessionID) {
+      $this->deleteSharedSessionCookie();
+    }
+  }
+
+  protected function deleteSharedSessionCookie() {
+    $cookie_name = $this->getSharedSessionCookieName();
+    unset($_COOKIE[$cookie_name]);
+    $base_domain = $this->getBaseDomain();
+    setcookie($cookie_name, '', 1, '/', '.'.$base_domain);
+  }
+
+  protected function getSharedSessionCookieName() {
+    return self::FBSS_COOKIE_NAME . '_' . $this->getAppId();
   }
 
   protected function constructSessionVariableName($key) {
-    return implode('_', array('fb',
-                              $this->getAppId(),
-                              $key));
+    $parts = array('fb', $this->getAppId(), $key);
+    if ($this->sharedSessionID) {
+      array_unshift($parts, $this->sharedSessionID);
+    }
+    return implode('_', $parts);
   }
 }
 endif;


### PR DESCRIPTION
update Facebook PHP SDK to version 3.2, matching current [facebook/facebook-php-sdk](https://github.com/facebook/facebook-php-sdk) repo master.

The WordPress version adds a "WP_" prefix to classes and some customizations to avoid cURL conflicts. I might not have caught them all.
