### PR TITLE
Update fb-open-graph.php

### DIFF
--- a/fb-open-graph.php
+++ b/fb-open-graph.php
@@ -136,7 +136,8 @@ function fb_add_og_protocol() {
 				if ( ! empty($post_thumbnail_height) )
 					$image['height'] = absint( $post_thumbnail_height );
 
-				$meta_tags['http://ogp.me/ns#image'] = array( $image );
+				//$meta_tags['http://ogp.me/ns#image'] = array( $image );
+				$meta_tags['og:image'] = array( $image );
 			}
 		}
 	}


### PR DESCRIPTION
Fix for plugin not showing the correct post image. (Reverted to meta og:image instead of http://ogp.me/ns#image )
