### PR TITLE
Default image support added

### DIFF
--- a/fb-admin-menu.php
+++ b/fb-admin-menu.php
@@ -320,6 +320,12 @@ function fb_get_main_settings_fields() {
 			'name' => 'app_namespace',
 			'type' => 'text',
 			'help_text' => __( 'Your App Namespace.', 'facebook' )
+		),
+		array(
+			'name' => 'app_default_image',
+			'label' => __( 'Default image for posts', 'facebook' ),
+			'type' => 'text',
+			'help_text' => __( 'Default image to be used by Facebook when there is no post thumbnail available.', 'facebook' )
 		)
 	);
 
@@ -371,6 +377,8 @@ function fb_options_validate($input) {
 		case 'app_namespace':
 			$label = __( 'App namespace', 'facebook' );
 			$value = fb_options_validate_namespace($value, $label);
+			break;
+		case 'app_default_image':
 			break;
 		case 'social_publisher':
 			$label_prefix = __( 'The Social Publisher\'s', 'facebook' );

--- a/fb-open-graph.php
+++ b/fb-open-graph.php
@@ -155,6 +155,11 @@ function fb_add_og_protocol() {
 
 	$options = get_option( 'fb_options' );
 
+	if ( empty( $meta_tags['http://ogp.me/ns#image'] ) && ! empty( $options['app_default_image'] ) ) {
+		$image = array( 'url' => $options['app_default_image'] );
+		$meta_tags['http://ogp.me/ns#image'] = array( $image );
+	}
+
 	if ( ! empty( $options['app_id'] ) )
 		$meta_tags['http://ogp.me/ns/fb#app_id'] = $options['app_id'];
 


### PR DESCRIPTION
Blog administrator is now allowed to set a default image to be used when
posting articles without a designated thumbnail to Facebook

This will bypass the automatic search for images on the page being shared/liked made by Facebook.
