### PR TITLE
Remove generic CSS selector

### DIFF
--- a/style/style.css
+++ b/style/style.css
@@ -18,10 +18,6 @@
 		width: 100%;	
 	}
 
-	div#page {
-		width: 480px;
-	}
-
 	div.fb-comments span{
 		float:left;
  		width:100%;

--- a/style/style.min.css
+++ b/style/style.min.css
@@ -1,1 +1,1 @@
-.fb-social-plugin{width:100%;margin:2px 0 2px 0}.fb-mentions{width:100%;margin:10px 0 10px 0}.fb-mentions img{vertical-align:middle;margin-bottom:2px}@media only screen and (max-device-width:480px){.fb-like{float:left;width:100%}div#page{width:480px}div.fb-comments span{float:left;width:100%}}
+.fb-social-plugin{width:100%;margin:2px 0 2px 0}.fb-mentions{width:100%;margin:10px 0 10px 0}.fb-mentions img{vertical-align:middle;margin-bottom:2px}@media only screen and (max-device-width:480px){.fb-like{float:left;width:100%}div.fb-comments span{float:left;width:100%}}


### PR DESCRIPTION
Width of a element not created/explicitly used by the plugin should not be
modified. This can cause problems for existing/new sites that already
have themes that support mobile devices. div#page request to be removed.
