### PR TITLE
remove div#page width rule

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -18,10 +18,6 @@
 		width: 100%;	
 	}
 
-	div#page {
-		width: 480px;
-	}
-
 	div.fb-comments span{
 		float:left;
  		width:100%;

--- a/static/css/style.min.css
+++ b/static/css/style.min.css
@@ -1,1 +1,1 @@
-.fb-social-plugin{width:100%;margin:2px 0 2px 0}.fb-mentions{width:100%;margin:10px 0 10px 0}.fb-mentions img{vertical-align:middle;margin-bottom:2px}@media only screen and (max-device-width:480px){.fb-like{float:left;width:100%}div#page{width:480px}div.fb-comments span{float:left;width:100%}}
+.fb-social-plugin{width:100%;margin:2px 0 2px 0}.fb-mentions{width:100%;margin:10px 0 10px 0}.fb-mentions img{vertical-align:middle;margin-bottom:2px}@media only screen and (max-device-width:480px){.fb-like{float:left;width:100%}div.fb-comments span{float:left;width:100%}}


### PR DESCRIPTION
Commit 40e24355ababb42f8b7e00f77230f52984e2b1c0 added mobile-focused CSS rules applied at a width of 480 or lower. One of those rules set width on `div#page` - an element not defined in the plugin.

Remove the rule as it may interfere with theme rules. If the problem this rule is trying to solve can be better documented then the problem should be addressed within the scope of plugin-generated markup.

fixes #282
