### PR TITLE
replace comments admin menu item with Facebook comments menu item

### DIFF
--- a/admin/settings-app.php
+++ b/admin/settings-app.php
@@ -296,6 +296,9 @@ class Facebook_Application_Settings {
 				} else {
 					add_settings_error( 'facebook-app-id', 'facebook-app-id-error', __( 'App ID must contain only digits.', 'facebook' ) );
 				}
+			} else {
+				// removing app id disables other features such as comments
+				delete_option( 'facebook_comments_enabled' );
 			}
 			unset( $app_id );
 		}

--- a/admin/settings-comments.php
+++ b/admin/settings-comments.php
@@ -313,8 +313,11 @@ class Facebook_Comments_Settings extends Facebook_Social_Plugin_Settings {
 		// Handle display preferences first
 		$clean_options = parent::sanitize_options( $options );
 		if ( isset( $clean_options['show_on'] ) ) {
+			update_option( 'facebook_comments_enabled', '1' );
 			self::update_display_conditionals( 'comments', $clean_options['show_on'], self::post_types_supporting_comments() );
 			unset( $clean_options['show_on'] );
+		} else {
+			delete_option( 'facebook_comments_enabled' );
 		}
 		unset( $options['show_on'] );
 

--- a/facebook.php
+++ b/facebook.php
@@ -75,12 +75,34 @@ class Facebook_Loader {
 
 		add_action( 'widgets_init', array( &$this, 'widgets_init' ) );
 
+		if ( is_user_logged_in() ) {
+			// admin bar may show on public-facing site as well as administrative section
+			add_action( 'add_admin_bar_menus', array( &$this, 'admin_bar' ) );
+		}
+		
+
 		if ( is_admin() ) {
 			add_action( 'admin_enqueue_scripts', array( &$this, 'register_js_sdk' ), 1 );
 			$this->admin_init();
 		} else {
 			add_action( 'wp_enqueue_scripts', array( &$this, 'register_js_sdk' ), 1 );
 			add_action( 'wp', array( &$this, 'public_init' ) );
+		}
+	}
+
+	/**
+	 * Add Facebook functionality to the WordPress admin bar
+	 *
+	 * @since 1.1
+	 * @param WP_Admin_Bar $wp_admin_bar existing WordPress admin bar object
+	 */
+	public function admin_bar() {
+		if ( isset( $this->credentials ) && isset( $this->credentials['app_id'] ) ) {
+			if ( get_option( 'facebook_comments_enabled' ) ) {
+				if ( ! class_exists( 'Facebook_Comments' ) )
+					require_once( $this->plugin_directory . 'social-plugins/class-facebook-comments.php' );
+				Facebook_Comments::admin_bar_menu();
+			}
 		}
 	}
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -19,6 +19,7 @@ $__options = array(
 	'fb_options', // did not delete the old options on migration in case we needed to rerun
 	'facebook_application',
 	'facebook_comments',
+	'facebook_comments_enabled',
 	'facebook_like_button',
 	'facebook_recommendations_bar',
 	'facebook_send_button',


### PR DESCRIPTION
WordPress may display a comments menu item in the admin menu linking to the WordPress comments moderation screen. If the Comments Box social plugin is enabled it makes sense to send WordPress users with sufficient permissions to the comments moderation page on Facebook.com instead.

Add a new comments enabled option to quickly and efficiently determine if comments are enabled for one or more post types. If the WordPress comments menu item is present then swap it out for the Facebook comments menu item while keeping the same styling and placement.
