### PR TITLE
make static class methods passed to call_user_func_array more compatible with PHP 5.2 installations

### DIFF
--- a/admin/login.php
+++ b/admin/login.php
@@ -70,12 +70,12 @@ class Facebook_Admin_Login {
 		}
 
 		// priority before js sdk registration needed to add JS inside FbAsyncInit
-		add_action( 'admin_enqueue_scripts', 'Facebook_Admin_Login::add_async_load_javascript_filter', -1, 0 );
+		add_action( 'admin_enqueue_scripts', array( 'Facebook_Admin_Login', 'add_async_load_javascript_filter' ), -1, 0 );
 		// add all others at P11 after scripts registered
-		add_action( 'admin_enqueue_scripts', 'Facebook_Admin_Login::enqueue_scripts', 11 );
+		add_action( 'admin_enqueue_scripts', array( 'Facebook_Admin_Login', 'enqueue_scripts' ), 11 );
 
 		if ( $profile_prompt )
-			add_action( 'admin_notices', 'Facebook_Admin_Login::admin_notice', 1, 0 ); // up top
+			add_action( 'admin_notices', array( 'Facebook_Admin_Login', 'admin_notice' ), 1, 0 ); // up top
 	}
 
 	/**
@@ -92,7 +92,7 @@ class Facebook_Admin_Login {
 
 	public static function add_async_load_javascript_filter() {
 		// async load our script after we async load Facebook JavaScript SDK
-		add_filter( 'facebook_jssdk_init_extras', 'Facebook_Admin_Login::async_load_javascript', 10, 2 );
+		add_filter( 'facebook_jssdk_init_extras', array( 'Facebook_Admin_Login', 'async_load_javascript' ), 10, 2 );
 	}
 
 	/**

--- a/admin/settings-app.php
+++ b/admin/settings-app.php
@@ -53,7 +53,7 @@ class Facebook_Application_Settings {
 		// conditional load CSS, scripts
 		if ( $hook_suffix ) {
 			$app_settings->hook_suffix = $hook_suffix;
-			register_setting( $hook_suffix, self::OPTION_NAME, 'Facebook_Application_Settings::sanitize_options' );
+			register_setting( $hook_suffix, self::OPTION_NAME, array( 'Facebook_Application_Settings', 'sanitize_options' ) );
 			add_action( 'load-' . $hook_suffix, array( &$app_settings, 'onload' ) );
 		}
 
@@ -73,7 +73,7 @@ class Facebook_Application_Settings {
 
 		$this->settings_api_init();
 
-		add_action( 'admin_enqueue_scripts', 'Facebook_Application_Settings::enqueue_scripts' );
+		add_action( 'admin_enqueue_scripts', array( 'Facebook_Application_Settings', 'enqueue_scripts' ) );
 	}
 
 	/**
@@ -87,10 +87,10 @@ class Facebook_Application_Settings {
 
 		// notify of conflicts on the main settings page
 		// tie to an action to allow easy removal on sites/networks that rather not run checks
-		add_action( 'facebook_notify_plugin_conflicts', 'Facebook_Settings::plugin_conflicts' );
+		add_action( 'facebook_notify_plugin_conflicts', array( 'Facebook_Settings', 'plugin_conflicts' ) );
 
-		add_action( 'facebook_settings_before_header_' . $this->hook_suffix, 'Facebook_Application_Settings::before_header' );
-		add_action( 'facebook_settings_after_header_' . $this->hook_suffix, 'Facebook_Application_Settings::after_header' );
+		add_action( 'facebook_settings_before_header_' . $this->hook_suffix, array( 'Facebook_Application_Settings', 'before_header' ) );
+		add_action( 'facebook_settings_after_header_' . $this->hook_suffix, array( 'Facebook_Application_Settings', 'after_header' ) );
 
 		Facebook_Settings::settings_page_template( $this->hook_suffix, __( 'Facebook for WordPress', 'facebook' ) );
 	}

--- a/admin/settings-comments.php
+++ b/admin/settings-comments.php
@@ -72,7 +72,7 @@ class Facebook_Comments_Settings extends Facebook_Social_Plugin_Settings {
 
 		if ( $hook_suffix ) {
 			$comments_settings->hook_suffix = $hook_suffix;
-			register_setting( $hook_suffix, self::OPTION_NAME, 'Facebook_Comments_Settings::sanitize_options' );
+			register_setting( $hook_suffix, self::OPTION_NAME, array( 'Facebook_Comments_Settings', 'sanitize_options' ) );
 			add_action( 'load-' . $hook_suffix, array( &$comments_settings, 'onload' ) );
 		}
 

--- a/admin/settings-like-button.php
+++ b/admin/settings-like-button.php
@@ -81,7 +81,7 @@ class Facebook_Like_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 
 		if ( $hook_suffix ) {
 			$like_button_settings->hook_suffix = $hook_suffix;
-			register_setting( $hook_suffix, self::OPTION_NAME, 'Facebook_Like_Button_Settings::sanitize_options' );
+			register_setting( $hook_suffix, self::OPTION_NAME, array( 'Facebook_Like_Button_Settings', 'sanitize_options' ) );
 			add_action( 'load-' . $hook_suffix, array( &$like_button_settings, 'onload' ) );
 		}
 

--- a/admin/settings-recommendations-bar.php
+++ b/admin/settings-recommendations-bar.php
@@ -76,7 +76,7 @@ class Facebook_Recommendations_Bar_Settings extends Facebook_Social_Plugin_Setti
 
 		if ( $hook_suffix ) {
 			$recommendations_bar_settings->hook_suffix = $hook_suffix;
-			register_setting( $hook_suffix, self::OPTION_NAME, 'Facebook_Recommendations_Bar_Settings::sanitize_options' );
+			register_setting( $hook_suffix, self::OPTION_NAME, array( 'Facebook_Recommendations_Bar_Settings', 'sanitize_options' ) );
 			add_action( 'load-' . $hook_suffix, array( &$recommendations_bar_settings, 'onload' ) );
 		}
 

--- a/admin/settings-send-button.php
+++ b/admin/settings-send-button.php
@@ -71,7 +71,7 @@ class Facebook_Send_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 
 		if ( $hook_suffix ) {
 			$send_button_settings->hook_suffix = $hook_suffix;
-			register_setting( $hook_suffix, self::OPTION_NAME, 'Facebook_Send_Button_Settings::sanitize_options' );
+			register_setting( $hook_suffix, self::OPTION_NAME, array( 'Facebook_Send_Button_Settings', 'sanitize_options' ) );
 			add_action( 'load-' . $hook_suffix, array( &$send_button_settings, 'onload' ) );
 		}
 

--- a/admin/settings-social-publisher.php
+++ b/admin/settings-social-publisher.php
@@ -69,8 +69,8 @@ class Facebook_Social_Publisher_Settings {
 
 		if ( $hook_suffix ) {
 			$social_publisher_settings->hook_suffix = $hook_suffix;
-			register_setting( $hook_suffix, self::PUBLISH_OPTION_NAME, 'Facebook_Social_Publisher_Settings::sanitize_publish_options' );
-			register_setting( $hook_suffix, self::MENTIONS_OPTION_NAME, 'Facebook_Social_Publisher_Settings::sanitize_mentions_options' );
+			register_setting( $hook_suffix, self::PUBLISH_OPTION_NAME, array( 'Facebook_Social_Publisher_Settings', 'sanitize_publish_options' ) );
+			register_setting( $hook_suffix, self::MENTIONS_OPTION_NAME, array( 'Facebook_Social_Publisher_Settings', 'sanitize_mentions_options' ) );
 			add_action( 'load-' . $hook_suffix, array( &$social_publisher_settings, 'onload' ) );
 		}
 

--- a/admin/settings-subscribe-button.php
+++ b/admin/settings-subscribe-button.php
@@ -82,7 +82,7 @@ class Facebook_Subscribe_Button_Settings extends Facebook_Social_Plugin_Button_S
 
 		if ( $hook_suffix ) {
 			$subscribe_button_settings->hook_suffix = $hook_suffix;
-			register_setting( $hook_suffix, self::OPTION_NAME, 'Facebook_Subscribe_Button_Settings::sanitize_options' );
+			register_setting( $hook_suffix, self::OPTION_NAME, array( 'Facebook_Subscribe_Button_Settings', 'sanitize_options' ) );
 			add_action( 'load-' . $hook_suffix, array( &$subscribe_button_settings, 'onload' ) );
 		}
 

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -272,7 +272,7 @@ class Facebook_Settings {
 			// note any facebook widgets we find along the way
 			foreach( $sidebar_widgets as $widget_id ) {
 				if ( strlen( $widget_id ) > 9 && substr_compare( $widget_id, 'facebook-', 0, 9 ) === 0 ) {
-					$feature = substr( $key, 9, strrpos( $key, '-' ) - 9 );
+					$feature = substr( $widget_id, 9, strrpos( $widget_id, '-' ) - 9 );
 					if ( ! isset( $widgets[$feature] ) )
 						$widgets[$feature] = true;
 					unset( $feature );

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -21,8 +21,8 @@ class Facebook_Settings {
 	 */
 	public static function init() {
 		self::migrate_options_10();
-		add_action( 'admin_menu', 'Facebook_Settings::settings_menu_items' );
-		add_filter( 'plugin_action_links', 'Facebook_Settings::plugin_action_links', 10, 2 );
+		add_action( 'admin_menu', array( 'Facebook_Settings', 'settings_menu_items' ) );
+		add_filter( 'plugin_action_links', array( 'Facebook_Settings', 'plugin_action_links' ), 10, 2 );
 
 		if ( self::app_credentials_exist() ) {
 			$available_features = apply_filters( 'facebook_features', self::$features );
@@ -31,7 +31,7 @@ class Facebook_Settings {
 					// check user capability to publish to Facebook
 					$current_user = wp_get_current_user();
 					if ( user_can( $current_user, 'edit_posts' ) )
-						add_action( 'admin_init', 'Facebook_Settings::prompt_user_login' );
+						add_action( 'admin_init', array( 'Facebook_Settings', 'prompt_user_login' ) );
 				}
 			}
 		}
@@ -149,7 +149,7 @@ class Facebook_Settings {
 
 		// show admin dialog on post creation, post edit, or user profile screen
 		foreach( array( 'post-new.php','post.php','profile.php' ) as $pagenow ) {
-			add_action( 'load-' . $pagenow, 'Facebook_Admin_Login::connect_facebook_account' );
+			add_action( 'load-' . $pagenow, array( 'Facebook_Admin_Login', 'connect_facebook_account' ) );
 		} 
 	}
 

--- a/admin/social-publisher/mentions/mentions-box-friends.php
+++ b/admin/social-publisher/mentions/mentions-box-friends.php
@@ -56,7 +56,7 @@ class Facebook_Mentions_Box_Friends {
 		add_meta_box(
 			'facebook-friend-mention-box-id',
 			__( 'Mention Facebook Friends', 'facebook' ),
-			'Facebook_Mentions_Box_Friends::content',
+			array( 'Facebook_Mentions_Box_Friends', 'content' ),
 			$post_type,
 			'side'
 		);

--- a/admin/social-publisher/mentions/mentions-box-pages.php
+++ b/admin/social-publisher/mentions/mentions-box-pages.php
@@ -56,7 +56,7 @@ class Facebook_Mentions_Box_Pages {
 		add_meta_box(
 			'facebook-page-mention-box-id',
 			__( 'Mention Facebook Pages', 'facebook' ),
-			'Facebook_Mentions_Box_Pages::content',
+			array( 'Facebook_Mentions_Box_Pages', 'content' ),
 			$post_type,
 			'side'
 		);

--- a/admin/social-publisher/mentions/mentions-box.php
+++ b/admin/social-publisher/mentions/mentions-box.php
@@ -22,7 +22,7 @@ class Facebook_Mentions_Box {
 		if ( ! is_array( $enabled_post_types ) || empty( $enabled_post_types ) || ! isset( $enabled_post_types[$post_type] ) )
 			return;
 
-		add_action( 'admin_enqueue_scripts', 'Facebook_Mentions_Box::enqueue_scripts' );
+		add_action( 'admin_enqueue_scripts', array( 'Facebook_Mentions_Box', 'enqueue_scripts' ) );
 
 		if ( ! class_exists( 'Facebook_Mentions_Box_Friends' ) )
 			require_once( dirname(__FILE__) . '/mentions-box-friends.php' );
@@ -41,11 +41,11 @@ class Facebook_Mentions_Box {
 	public static function add_save_post_hooks() {
 		if ( ! class_exists( 'Facebook_Mentions_Box_Friends' ) )
 			require_once( dirname(__FILE__) . '/mentions-box-friends.php' );
-		add_action( 'save_post', 'Facebook_Mentions_Box_Friends::save' );
+		add_action( 'save_post', array( 'Facebook_Mentions_Box_Friends', 'save' ) );
 
 		if ( ! class_exists( 'Facebook_Mentions_Box_Pages' ) )
 			require_once( dirname(__FILE__) . '/mentions-box-pages.php' );
-		add_action( 'save_post', 'Facebook_Mentions_Box_Pages::save' );
+		add_action( 'save_post', array( 'Facebook_Mentions_Box_Pages', 'save' ) );
 	}
 
 	/**

--- a/admin/social-publisher/mentions/mentions-search.php
+++ b/admin/social-publisher/mentions/mentions-search.php
@@ -14,8 +14,8 @@ class Facebook_Mentions_Search {
 	 * @since 1.1
 	 */
 	public static function wp_ajax_handlers() {
-		add_action( 'wp_ajax_facebook_mentions_friends_autocomplete', 'Facebook_Mentions_Search::search_endpoint_friends' );
-		add_action( 'wp_ajax_facebook_mentions_pages_autocomplete', 'Facebook_Mentions_Search::search_endpoint_pages' );
+		add_action( 'wp_ajax_facebook_mentions_friends_autocomplete', array( 'Facebook_Mentions_Search', 'search_endpoint_friends' ) );
+		add_action( 'wp_ajax_facebook_mentions_pages_autocomplete', array( 'Facebook_Mentions_Search', 'search_endpoint_pages' ) );
 	}
 
 	/**

--- a/admin/social-publisher/publish-box-page.php
+++ b/admin/social-publisher/publish-box-page.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * Add a custom message to your article posted to a Facebook page
+ *
+ * @since 1.1
+ */
 class Facebook_Social_Publisher_Meta_Box_Page {
 	/**
 	 * Check page origin before saving
@@ -36,7 +41,7 @@ class Facebook_Social_Publisher_Meta_Box_Page {
 		add_meta_box(
 			'facebook-fan-page-message-box-id',
 			sprintf( __( 'Facebook Status on %s Timeline', 'facebook' ), $page['name'] ),
-			'Facebook_Social_Publisher_Meta_Box_Page::content',
+			array( 'Facebook_Social_Publisher_Meta_Box_Page', 'content' ),
 			$post_type
 		);
 	}

--- a/admin/social-publisher/publish-box-profile.php
+++ b/admin/social-publisher/publish-box-profile.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * Add a custom message to your article posted to a Facebook profile
+ *
+ * @since 1.1
+ */
 class Facebook_Social_Publisher_Meta_Box_Profile {
 
 	/**
@@ -37,7 +42,7 @@ class Facebook_Social_Publisher_Meta_Box_Profile {
 		add_meta_box(
 			'facebook-author-message-box-id',
 			__( 'Facebook Status on Your Timeline', 'facebook' ),
-			'Facebook_Social_Publisher_Meta_Box_Profile::content',
+			array( 'Facebook_Social_Publisher_Meta_Box_Profile', 'content' ),
 			$post_type
 		);
 	}

--- a/admin/social-publisher/social-publisher.php
+++ b/admin/social-publisher/social-publisher.php
@@ -37,8 +37,8 @@ class Facebook_Social_Publisher {
 
 		// always load publish and delete hooks
 		// post can be published or deleted many different ways
-		add_action( 'transition_post_status', 'Facebook_Social_Publisher::publish', 10, 3 );
-		add_action( 'before_delete_post', 'Facebook_Social_Publisher::delete_facebook_post' );
+		add_action( 'transition_post_status', array( 'Facebook_Social_Publisher', 'publish' ), 10, 3 );
+		add_action( 'before_delete_post', array( 'Facebook_Social_Publisher', 'delete_facebook_post' ) );
 		self::add_save_post_hooks();
 
 		// load meta box hooks on post creation screens
@@ -60,11 +60,11 @@ class Facebook_Social_Publisher {
 
 		if ( ! class_exists( 'Facebook_Social_Publisher_Meta_Box_Profile' ) )
 			require_once( dirname(__FILE__) . '/publish-box-profile.php' );
-		add_action( 'save_post', 'Facebook_Social_Publisher_Meta_Box_Profile::save' );
+		add_action( 'save_post', array( 'Facebook_Social_Publisher_Meta_Box_Profile', 'save' ) );
 
 		if ( ! class_exists( 'Facebook_Social_Publisher_Meta_Box_Page' ) )
 			require_once(  dirname(__FILE__) . '/publish-box-page.php' );
-		add_action( 'save_post', 'Facebook_Social_Publisher_Meta_Box_Page::save' );
+		add_action( 'save_post', array( 'Facebook_Social_Publisher_Meta_Box_Page', 'save' ) );
 
 		if ( ! class_exists( 'Facebook_Mentions_Box' ) )
 			require_once( dirname(__FILE__) . '/mentions/mentions-box.php' );
@@ -85,7 +85,7 @@ class Facebook_Social_Publisher {
 			return;
 
 		// on post pages
-		add_action( 'admin_notices', 'Facebook_Social_Publisher::output_post_admin_notices' );
+		add_action( 'admin_notices', array( 'Facebook_Social_Publisher', 'output_post_admin_notices' ) );
 
 		// wait until after post data loaded, then evaluate post
 		add_action( 'add_meta_boxes', array( &$this, 'load_post_features' ) );
@@ -375,7 +375,7 @@ class Facebook_Social_Publisher {
 				$status_messages = array_merge( $existing_status_messages, $status_messages );
 
 			update_post_meta( $post_id, 'facebook_status_messages', $status_messages );
-			add_filter( 'redirect_post_location', 'Facebook_Social_Publisher::add_new_post_location' );
+			add_filter( 'redirect_post_location', array( 'Facebook_Social_Publisher', 'add_new_post_location' ) );
 		}
 	}
 
@@ -438,7 +438,7 @@ class Facebook_Social_Publisher {
 				$status_messages = array_merge($existing_status_messages, $status_messages);
 
 			update_post_meta( $post_id, 'facebook_status_messages', $status_messages );
-			add_filter( 'redirect_post_location', 'Facebook_Social_Publisher::add_new_post_location' );
+			add_filter( 'redirect_post_location', array( 'Facebook_Social_Publisher', 'add_new_post_location' ) );
 		}
 	}
 

--- a/facebook.php
+++ b/facebook.php
@@ -210,9 +210,9 @@ class Facebook_Loader {
 		// always include Open Graph protocol markup
 		if ( ! class_exists( 'Facebook_Open_Graph_Protocol' ) )
 			require_once( $this->plugin_directory . 'open-graph-protocol.php' );
-		add_action( 'wp_head', 'Facebook_Open_Graph_Protocol::add_og_protocol' );
+		add_action( 'wp_head', array( 'Facebook_Open_Graph_Protocol', 'add_og_protocol' ) );
 
-		add_action( 'wp_enqueue_scripts', 'Facebook_Loader::enqueue_jssdk' );
+		add_action( 'wp_enqueue_scripts', array( 'Facebook_Loader', 'enqueue_jssdk' ) );
 
 		$enabled_features = array();
 		$option_name = 'facebook_%s_features';
@@ -242,9 +242,9 @@ class Facebook_Loader {
 		if ( isset( $enabled_features['subscribe'] ) )
 			add_filter( 'the_content', 'facebook_the_content_subscribe_button', $priority );
 		if ( isset( $enabled_features['mentions'] ) ) {
-			if ( ! function_exists( 'fb_social_publisher_mentioning_output' ) )
+			if ( ! function_exists( 'facebook_social_publisher_mentioning_output' ) )
 				require_once( dirname(__FILE__) . '/social-publisher/mentions.php' );
-			add_filter( 'the_content', 'fb_social_publisher_mentioning_output', $priority );
+			add_filter( 'the_content', 'facebook_social_publisher_mentioning_output', $priority );
 		}
 
 		// individual posts, pages, and custom post types features
@@ -257,13 +257,13 @@ class Facebook_Loader {
 				if ( ! class_exists( 'Facebook_Comments' ) )
 					require_once( $this->plugin_directory . 'social-plugins/class-facebook-comments.php' );
 
-				add_filter( 'the_content', 'Facebook_Comments::the_content_comments_box', $priority );
-				add_action( 'wp_enqueue_scripts', 'Facebook_Comments::css_hide_comments', 0 );
+				add_filter( 'the_content', array( 'Facebook_Comments', 'the_content_comments_box' ), $priority );
+				add_action( 'wp_enqueue_scripts', array( 'Facebook_Comments', 'css_hide_comments' ), 0 );
 				add_filter( 'comments_array', '__return_null' );
 				add_filter( 'comments_open', '__return_true' ); // comments are always open
 
 				// display comments number if used in template
-				add_filter( 'comments_number', 'Facebook_Comments::comments_count_xfbml' );
+				add_filter( 'comments_number', array( 'Facebook_Comments', 'comments_count_xfbml' ) );
 
 				// short-circuit special template behavior for comment count = 0
 				// prevents linking to #respond anchor which leads nowhere
@@ -271,7 +271,7 @@ class Facebook_Loader {
 			}
 		}
 
-		add_action( 'wp_enqueue_scripts', 'Facebook_Loader::enqueue_styles' );
+		add_action( 'wp_enqueue_scripts', array( 'Facebook_Loader', 'enqueue_styles' ) );
 	}
 
 	/**

--- a/social-plugins/class-facebook-activity-feed.php
+++ b/social-plugins/class-facebook-activity-feed.php
@@ -17,7 +17,7 @@ class Facebook_Activity_Feed extends Facebook_Recommendations_Box {
 	 * @since 1.1
 	 * @var string
 	 */
-	const id = 'activity';
+	const ID = 'activity';
 
 	/**
 	 * Include recommendations?
@@ -168,7 +168,7 @@ class Facebook_Activity_Feed extends Facebook_Recommendations_Box {
 	 * @return HTML div or empty string
 	 */
 	public function asHTML( $div_attributes=array() ) {
-		$div_attributes = self::add_required_class( 'fb-' . self::id, $div_attributes );
+		$div_attributes = self::add_required_class( 'fb-' . self::ID, $div_attributes );
 		$div_attributes['data'] = $this->toHTMLDataArray();
 
 		return self::div_builder( $div_attributes );
@@ -181,7 +181,7 @@ class Facebook_Activity_Feed extends Facebook_Recommendations_Box {
 	 * @return string XFBML markup
 	 */
 	public function asXFBML() {
-		return self::xfbml_builder( self::id, $this->toHTMLDataArray() );
+		return self::xfbml_builder( self::ID, $this->toHTMLDataArray() );
 	}
 }
 

--- a/social-plugins/class-facebook-comments-box.php
+++ b/social-plugins/class-facebook-comments-box.php
@@ -14,7 +14,7 @@ class Facebook_Comments_Box {
 	 * @since 1.1
 	 * @var string
 	 */
-	const id = 'comments';
+	const ID = 'comments';
 
 	/**
 	 * Override the URL related to this comment.
@@ -207,7 +207,7 @@ class Facebook_Comments_Box {
 		if ( ! class_exists( 'Facebook_Social_Plugin' ) )
 			require_once( dirname(__FILE__) . '/class-facebook-social-plugin.php' );
 
-		$div_attributes = Facebook_Social_Plugin::add_required_class( 'fb-' . self::id, $div_attributes );
+		$div_attributes = Facebook_Social_Plugin::add_required_class( 'fb-' . self::ID, $div_attributes );
 		$div_attributes['data'] = $this->toHTMLDataArray();
 
 		return Facebook_Social_Plugin::div_builder( $div_attributes );
@@ -223,7 +223,7 @@ class Facebook_Comments_Box {
 		if ( ! class_exists( 'Facebook_Social_Plugin' ) )
 			require_once( dirname(__FILE__) . '/class-facebook-social-plugin.php' );
 
-		return Facebook_Social_Plugin::xfbml_builder( self::id, $this->toHTMLDataArray() );
+		return Facebook_Social_Plugin::xfbml_builder( self::ID, $this->toHTMLDataArray() );
 	}
 }
 

--- a/social-plugins/class-facebook-comments.php
+++ b/social-plugins/class-facebook-comments.php
@@ -46,7 +46,7 @@ class Facebook_Comments {
 
 		// swap only. don't add a menu item if none existed
 		if ( remove_action( 'admin_bar_menu', 'wp_admin_bar_comments_menu', 60 ) ) {
-			add_action( 'admin_bar_menu', 'Facebook_Comments::admin_bar_add_comments_menu', 60 );
+			add_action( 'admin_bar_menu', array( 'Facebook_Comments', 'admin_bar_add_comments_menu' ), 60 );
 		}
 	}
 

--- a/social-plugins/class-facebook-like-button.php
+++ b/social-plugins/class-facebook-like-button.php
@@ -17,7 +17,7 @@ class Facebook_Like_Button extends Facebook_Social_Plugin {
 	 * @since 1.1
 	 * @var string
 	 */
-	const id = 'like';
+	const ID = 'like';
 
 	/**
 	 * Override the URL used for the like action.
@@ -319,7 +319,7 @@ class Facebook_Like_Button extends Facebook_Social_Plugin {
 	 * @return HTML div or empty string
 	 */
 	public function asHTML( $div_attributes=array() ) {
-		$div_attributes = self::add_required_class( 'fb-' . self::id, $div_attributes );
+		$div_attributes = self::add_required_class( 'fb-' . self::ID, $div_attributes );
 		$div_attributes['data'] = $this->toHTMLDataArray();
 
 		return self::div_builder( $div_attributes );
@@ -332,7 +332,7 @@ class Facebook_Like_Button extends Facebook_Social_Plugin {
 	 * @return string XFBML markup
 	 */
 	public function asXFBML() {
-		return self::xfbml_builder( self::id, $this->toHTMLDataArray() );
+		return self::xfbml_builder( self::ID, $this->toHTMLDataArray() );
 	}
 }
 ?>

--- a/social-plugins/class-facebook-recommendations-bar.php
+++ b/social-plugins/class-facebook-recommendations-bar.php
@@ -17,7 +17,7 @@ class Facebook_Recommendations_Bar extends Facebook_Social_Plugin {
 	 * @since 1.1
 	 * @var string
 	 */
-	const id = 'recommendations-bar';
+	const ID = 'recommendations-bar';
 
 	/**
 	 * Override the URL used for the like action.
@@ -368,7 +368,7 @@ class Facebook_Recommendations_Bar extends Facebook_Social_Plugin {
 		if ( ! class_exists( 'Facebook_Social_Plugin' ) )
 			require_once( dirname(__FILE__) . '/class-facebook-social-plugin.php' );
 
-		$div_attributes = Facebook_Social_Plugin::add_required_class( 'fb-' . self::id, $div_attributes );
+		$div_attributes = Facebook_Social_Plugin::add_required_class( 'fb-' . self::ID, $div_attributes );
 		$div_attributes['data'] = $this->toHTMLDataArray();
 
 		return Facebook_Social_Plugin::div_builder( $div_attributes );
@@ -384,7 +384,7 @@ class Facebook_Recommendations_Bar extends Facebook_Social_Plugin {
 		if ( ! class_exists( 'Facebook_Social_Plugin' ) )
 			require_once( dirname(__FILE__) . '/class-facebook-social-plugin.php' );
 
-		return Facebook_Social_Plugin::xfbml_builder( self::id, $this->toHTMLDataArray() );
+		return Facebook_Social_Plugin::xfbml_builder( self::ID, $this->toHTMLDataArray() );
 	}
 }
 

--- a/social-plugins/class-facebook-recommendations-box.php
+++ b/social-plugins/class-facebook-recommendations-box.php
@@ -17,7 +17,7 @@ class Facebook_Recommendations_Box extends Facebook_Social_Plugin {
 	 * @since 1.1
 	 * @var string
 	 */
-	const id = 'recommendations';
+	const ID = 'recommendations';
 
 	/**
 	 * The activity domain. Defaults to the current domain
@@ -353,7 +353,7 @@ class Facebook_Recommendations_Box extends Facebook_Social_Plugin {
 	 * @return HTML div or empty string
 	 */
 	public function asHTML( $div_attributes=array() ) {
-		$div_attributes = self::add_required_class( 'fb-' . self::id, $div_attributes );
+		$div_attributes = self::add_required_class( 'fb-' . self::ID, $div_attributes );
 		$div_attributes['data'] = $this->toHTMLDataArray();
 
 		return self::div_builder( $div_attributes );
@@ -366,7 +366,7 @@ class Facebook_Recommendations_Box extends Facebook_Social_Plugin {
 	 * @return string XFBML markup
 	 */
 	public function asXFBML() {
-		return self::xfbml_builder( self::id, $this->toHTMLDataArray() );
+		return self::xfbml_builder( self::ID, $this->toHTMLDataArray() );
 	}
 }
 

--- a/social-plugins/class-facebook-send-button.php
+++ b/social-plugins/class-facebook-send-button.php
@@ -17,7 +17,7 @@ class Facebook_Send_Button extends Facebook_Social_Plugin {
 	 * @since 1.1
 	 * @var string
 	 */
-	const id = 'send';
+	const ID = 'send';
 
 	/**
 	 * Override the URL used for the Send action.
@@ -103,7 +103,7 @@ class Facebook_Send_Button extends Facebook_Social_Plugin {
 	 * @return HTML div or empty string
 	 */
 	public function asHTML( $div_attributes=array() ) {
-		$div_attributes = self::add_required_class( 'fb-' . self::id, $div_attributes );
+		$div_attributes = self::add_required_class( 'fb-' . self::ID, $div_attributes );
 		$div_attributes['data'] = $this->toHTMLDataArray();
 
 		return self::div_builder( $div_attributes );
@@ -116,7 +116,7 @@ class Facebook_Send_Button extends Facebook_Social_Plugin {
 	 * @return string XFBML markup
 	 */
 	public function asXFBML() {
-		return self::xfbml_builder( self::id, $this->toHTMLDataArray() );
+		return self::xfbml_builder( self::ID, $this->toHTMLDataArray() );
 	}
 }
 

--- a/social-plugins/class-facebook-subscribe-button.php
+++ b/social-plugins/class-facebook-subscribe-button.php
@@ -17,7 +17,7 @@ class Facebook_Subscribe_Button extends Facebook_Social_Plugin {
 	 * @since 1.1
 	 * @var string
 	 */
-	const id = 'subscribe';
+	const ID = 'subscribe';
 
 	/**
 	 * The Facebook URL representing a user profile or page open to new subscribers
@@ -262,7 +262,7 @@ class Facebook_Subscribe_Button extends Facebook_Social_Plugin {
 		if ( empty( $data ) )
 			return '';
 
-		$div_attributes = self::add_required_class( 'fb-' . self::id, $div_attributes );
+		$div_attributes = self::add_required_class( 'fb-' . self::ID, $div_attributes );
 		$div_attributes['data'] = $data;
 
 		return self::div_builder( $div_attributes );
@@ -279,7 +279,7 @@ class Facebook_Subscribe_Button extends Facebook_Social_Plugin {
 		if ( empty( $data ) )
 			return '';
 
-		return self::xfbml_builder( self::id, $data );
+		return self::xfbml_builder( self::ID, $data );
 	}
 }
 ?>

--- a/social-plugins/widgets/like-button.php
+++ b/social-plugins/widgets/like-button.php
@@ -2,6 +2,8 @@
 
 /**
  * Adds the Like Button Social Plugin as a WordPress Widget
+ *
+ * @since 1.0
  */
 class Facebook_Like_Button_Widget extends WP_Widget {
 

--- a/social-publisher/mentions.php
+++ b/social-publisher/mentions.php
@@ -4,7 +4,7 @@
  *
  * @since 1.0
  */
-function fb_social_publisher_mentioning_output( $content ) {
+function facebook_social_publisher_mentioning_output( $content ) {
 	global $post;
 
 	if ( ! isset( $post ) )


### PR DESCRIPTION
change 'classname::method_name' to array( 'classname', 'method_name' ) for callbacks to improve compatibility with PHP 5.2 installs.
