### PR TITLE
remove array_unique second parameter

### DIFF
--- a/admin/settings-social-plugin.php
+++ b/admin/settings-social-plugin.php
@@ -168,7 +168,7 @@ class Facebook_Social_Plugin_Settings {
 
 		if ( isset( $options['show_on'] ) ) {
 			if ( is_array( $options['show_on'] ) )
-				$clean_options['show_on'] = array_unique( $options['show_on'], SORT_STRING ); // SORT_STRING default after PHP 5.2.10. WordPress min requirement is 5.2.4
+				$clean_options['show_on'] = array_unique( $options['show_on'] ); // SORT_STRING default after PHP 5.2.10. WordPress min requirement is 5.2.4
 			else if ( is_string( $options['show_on'] ) )
 				$clean_options['show_on'] = array( $options['show_on'] );
 		}


### PR DESCRIPTION
compatibility with PHP 5.2.4 - ...5.2.8. one release where SORT_STRING was not default (5.2.9) should not affect this cleaner
