### PR TITLE
delete comments enabled when settings comments form show_on value present but empty

### DIFF
--- a/admin/settings-comments.php
+++ b/admin/settings-comments.php
@@ -317,8 +317,11 @@ class Facebook_Comments_Settings extends Facebook_Social_Plugin_Settings {
 		// Handle display preferences first
 		$clean_options = parent::sanitize_options( $options );
 		if ( isset( $clean_options['show_on'] ) ) {
-			update_option( 'facebook_comments_enabled', '1' );
 			self::update_display_conditionals( 'comments', $clean_options['show_on'], self::post_types_supporting_comments() );
+			if ( empty( $clean_options['show_on'] ) )
+				delete_option( 'facebook_comments_enabled' );
+			else
+				update_option( 'facebook_comments_enabled', '1' );
 			unset( $clean_options['show_on'] );
 		} else {
 			delete_option( 'facebook_comments_enabled' );

--- a/facebook.php
+++ b/facebook.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package Facebook
- * @version 1.1.4
+ * @version 1.1.5
  */
 /*
 Plugin Name: Facebook
@@ -9,7 +9,7 @@ Plugin URI: http://wordpress.org/extend/plugins/facebook/
 Description: Facebook for WordPress. Make your site deeply social in just a couple of clicks.
 Author: Facebook
 Author URI: https://developers.facebook.com/wordpress/
-Version: 1.1.4
+Version: 1.1.5
 License: GPL2
 License URI: license.txt
 Domain Path: /languages/
@@ -28,7 +28,7 @@ class Facebook_Loader {
 	 * @since 1.1
 	 * @var string
 	 */
-	const VERSION = '1.1.4';
+	const VERSION = '1.1.5';
 
 	/**
 	 * Locale of the site expressed as a Facebook locale

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires at least: 3.3
 Tested up to: 3.5
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
-Stable tag: 1.1.4
+Stable tag: 1.1.5
 
 Make your WordPress site social in a couple of clicks, powered by Facebook.
 
@@ -105,6 +105,9 @@ The [Comments Box social plugin](https://developers.facebook.com/docs/reference/
 
 == Upgrade Notice ==
 
+= 1.1.5 =
+Fix comments enabled option improperly set on comments settings save when no post types selected.
+
 = 1.1.4 =
 Comments number filter available on all contexts when comments box enabled for one or more post types.
 
@@ -124,6 +127,9 @@ Improve site performance when cURL not installed or SSL not available. Removed p
 Security fixes. Improved customization and debugging of settings. l10n and i18n fixes.
 
 == Changelog ==
+
+= 1.1.5 =
+* Delete comments enabled option on plugin's settings comments page save when no comments selected.
 
 = 1.1.4 =
 


### PR DESCRIPTION
properly delete the comments enabled option when our cleaned options results in an empty show_on array

bumps version to 1.1.5
