### PR TITLE
do not override comments_open if no existing comments stored by Facebook

### DIFF
--- a/social-plugins/class-facebook-comments.php
+++ b/social-plugins/class-facebook-comments.php
@@ -358,7 +358,12 @@ class Facebook_Comments {
 
 		// closed posts can have comments from their previous open state
 		// display noscript version of these comments
-		$content .= "\n" . self::comments_markup( 'noscript' ) . "\n";
+		$comments_markup = self::comments_markup( 'noscript' );
+		if ( $comments_markup )
+			$content .= "\n" . $comments_markup . "\n";
+		else
+			remove_filter( 'comments_open', '__return_true' ); // allow closed comments if no previous comments to display
+		unset( $comments_markup );
 
 		// no option via JS SDK to display comments yet not accept new comments
 		// only display JS SDK version of comments box display if we would like more comments
@@ -366,7 +371,7 @@ class Facebook_Comments {
 			$url = apply_filters( 'facebook_rel_canonical', get_permalink() );
 			if ( $url ) // false could happen. let JS SDK handle compatibility mode
 				$options['href'] = $url;
-			$content .= self::js_sdk_markup( $options );
+			$content .= "\n" . self::js_sdk_markup( $options ) . "\n";
 		}
 
 		return $content;


### PR DESCRIPTION
The [Facebook Comments Box](https://developers.facebook.com/docs/reference/plugins/comments/) displays comments for the given URL stored on Facebook servers sorted chronologically or by the social interests of the current viewers. The Comments Box always invites new comments; there is no way to freeze comments accepted for the given URL at a certain point in time (beyond never letting anything pass moderation) or specify a read-only mode.

The always-open nature of the Comments Box overrides the decisions of a WordPress site wanting to make a specific page or post open or closed to comments, or to close comments after a set period of time.

If a post permalink has no comments stored on Facebook, as determined by the Graph API call to output search engine friendly noscript markup on the page, then we should remove the filter we've attached declaring comments always open. If there are no previous comments to display through the Comments Box and the site would not like to invite further comments then there should be no Comments Box displayed on the webpage.
