### PR TITLE
pass comments number text through a Facebook-specific filter

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -82,6 +82,7 @@ Note: all contributors must agree to and sign the [Facebook Contributor License 
 * `facebook_excerpt_more` - string appearing at the end of a truncated excerpt string. default: "&hellip;"
 * `fb_rel_canonical` - customize the canonical URL used by Facebook for a post. Affects Open Graph protocol URL definitions, URL references sent in Open Graph actions, and more. default: result of `get_permalink()`
 * `facebook_comment_schema_org` - override output of search engine friendly comments content using [Schema.org microdata markup](http://googlewebmastercentral.blogspot.com/2011/06/introducing-schemaorg-search-engines.html)
+* `facebook_comments_number_more` - override the default "% Comments" text used to generate a client-side comments number. similar to WordPress' [comments_number](http://codex.wordpress.org/Function_Reference/comments_number) more parameter.
 * `facebook_anchor_target` - customize the [browsing context name](http://www.whatwg.org/specs/web-apps/current-work/multipage/browsers.html#browsing-context-names) used for links to Facebook output alongside your post such as mentions. default: `_blank`
 * `facebook_mentions_classes` - add or remove HTML classes from the parent HTML div element of mentions links
 * `fb_meta_tags` - Customize Open Graph protocol markup before it is output to the page

--- a/social-plugins/class-facebook-comments.php
+++ b/social-plugins/class-facebook-comments.php
@@ -104,7 +104,7 @@ class Facebook_Comments {
 
 		if ( $url ) {
 			// match comments_number() text builder, adding XFBML element instead of a number
-			return str_replace( '%', '<fb:comments-count xmlns="http://ogp.me/ns/fb#" href="' . $url .  '"></fb:comments-count>', __('% Comments') );
+			return str_replace( '%', '<fb:comments-count xmlns="http://ogp.me/ns/fb#" href="' . $url .  '"></fb:comments-count>', apply_filters( 'facebook_comments_number_more', __( '% Comments' ) ) );
 		}
 
 		return '';


### PR DESCRIPTION
allow a text override similar to comments_number() parameter override for more than one comment
