### PR TITLE
allow prefixed OGP properties

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -86,6 +86,8 @@ Note: all contributors must agree to and sign the [Facebook Contributor License 
 * `facebook_anchor_target` - customize the [browsing context name](http://www.whatwg.org/specs/web-apps/current-work/multipage/browsers.html#browsing-context-names) used for links to Facebook output alongside your post such as mentions. default: `_blank`
 * `facebook_mentions_classes` - add or remove HTML classes from the parent HTML div element of mentions links
 * `fb_meta_tags` - Customize Open Graph protocol markup before it is output to the page
+* `facebook_ogp_prefixed` - true to always use prefixed properties (og:title) or false to use full IRI properties (http://ogp.me/ns#title)
+* `facebook_rdfa_mappings` - array of RDFa references with desired prefix. Used to remap Open Graph protocol properties from a full IRI to a prefix
 * `fb_get_user_meta` - fetch a user meta value by attaching to this filter, bypassing the WordPress user meta API
 * `fb_update_user_meta` - update a user meta value by attaching to this filter, bypassing the WordPress user meta API
 * `fb_delete_user_meta` - delete a user meta value by attaching to this filter, bypassing the WordPress user meta API


### PR DESCRIPTION
Add a function to convert full IRI Open Graph protocol properties to a prefixed equivalent based on Open Graph protocol global prefixes and namespaces as well as the app-specific namespace if defined.

Trigger the conversion by evaluating a bool passed through a filter; this configuration allows publishers to override full IRI defaults if they have defined prefix mappings in a parent element or just prefer not to use the full IRI definition.

Mention the new filters in the readme.

Existing third-party functions acting on full IRI Open Graph protocol data are maintained. If another plugin or theme adds or replaces Facebook plugin values for Open Graph protocol properties the full IRI mapping is maintained through the separate conversion before output. It's a trade-off between consistency in values passed to the filter and a speed decrease to compare and convert all the property strings we just set.
