### PR TITLE
process existing app, comments options through 1.1.6 sanitizers

### DIFF
--- a/admin/migrate-options-115.php
+++ b/admin/migrate-options-115.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Store an app access token alongside app_id and app_secret
+ * Pass Comments Box settings through the sanitizer to verify proper saving of comments enabled option
+ *
+ * @since 1.1.6
+ */
+class Facebook_Migrate_Options_115 {
+
+	/**
+	 * Add an app access token and an app namespace to existing Facebook application data
+	 *
+	 * @since 1.1.6
+	 */
+	public static function app_settings() {
+		if ( ! class_exists( 'Facebook_Application_Settings' ) )
+			require_once( dirname(__FILE__) . '/settings-app.php' );
+		$app_options = get_option( Facebook_Application_Settings::OPTION_NAME );
+		if ( is_array( $app_options ) && isset( $app_options['app_id'] ) )
+			update_option( Facebook_Application_Settings::OPTION_NAME, Facebook_Application_Settings::sanitize_options( $app_options ) );
+	}
+
+	/**
+	 * Reprocess Comments Box settings to verify saved data
+	 *
+	 * @since 1.1.6
+	 */
+	public static function comments_settings() {
+		if ( ! class_exists( 'Facebook_Comments_Settings' ) )
+			require_once( dirname(__FILE__) . '/settings-comments.php' );
+		$comments_options = get_option( Facebook_Comments_Settings::OPTION_NAME );
+		if ( ! is_array( $comments_options ) )
+			$comments_options = array();
+		$comments_options['show_on'] = Facebook_Comments_Settings::get_display_conditionals_by_feature( 'comments', 'posts' );
+		update_option( Facebook_Comments_Settings::OPTION_NAME, Facebook_Comments_Settings::sanitize_options( $comments_options ) );
+	}
+
+	/**
+	 * Update options
+	 *
+	 * @since 1.1.6
+	 */
+	public static function migrate() {
+		self::app_settings();
+		self::comments_settings();
+	}
+}
+?>

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -361,14 +361,23 @@ class Facebook_Settings {
 	 * @since 1.1
 	 */
 	public static function migrate_options_10() {
-		if ( get_option( 'facebook_migration_10' ) )
+		if ( get_option( 'facebook_migration_10' ) ) {
+			// run 1.1.5 migration if 1.0 migration already run
+			if ( ! get_option( 'facebook_migration_115' ) && current_user_can( 'manage_options' ) ) {
+				if ( ! class_exists( 'Facebook_Migrate_Options_115' ) )
+					require_once( dirname(__FILE__) . '/migrate-options-115.php' );
+				Facebook_Migrate_Options_115::migrate();
+				update_option( 'facebook_migration_115', '1' );
+			}
 			return;
+		}
 
 		if ( current_user_can( 'manage_options' ) ) {
 			if ( ! class_exists( 'Facebook_Migrate_Options_10' ) )
 				require_once( dirname(__FILE__) . '/migrate-options-10.php' );
 			Facebook_Migrate_Options_10::migrate();
 			update_option( 'facebook_migration_10', '1' );
+			update_option( 'facebook_migration_115', '1' ); // 1.0 covers the changes from 1.1.5
 		}
 	}
 }


### PR DESCRIPTION
App options sanitizer saves app access token and namespace data retrieved from Facebook as of plugin version 1.1.6. Pass existing settings through the sanitizer to save new data based on old values.

Re-verify comments preferences by passing through comments sanitizer, setting the comments enabled option in the process.
