### PR TITLE
move comments_open overrides to post type block

### DIFF
--- a/facebook.php
+++ b/facebook.php
@@ -227,9 +227,6 @@ class Facebook_Loader {
 
 		// include comment count filters on all pages
 		if ( get_option( 'facebook_comments_enabled' ) ) {
-			add_filter( 'comments_array', '__return_null' );
-			add_filter( 'comments_open', '__return_true' ); // comments are always open
-
 			// short-circuit special template behavior for comment count = 0
 			// prevents linking to #respond anchor which leads nowhere
 			add_filter( 'get_comments_number', create_function('', 'return -1;') );
@@ -284,6 +281,9 @@ class Facebook_Loader {
 			if ( isset( $enabled_features['comments'] ) && post_type_supports( $post_type, 'comments' ) ) {
 				if ( ! class_exists( 'Facebook_Comments' ) )
 					require_once( $this->plugin_directory . 'social-plugins/class-facebook-comments.php' );
+
+				add_filter( 'comments_array', '__return_null' );
+				add_filter( 'comments_open', '__return_true' ); // comments are always open
 
 				add_filter( 'the_content', array( 'Facebook_Comments', 'the_content_comments_box' ), $priority );
 				add_action( 'wp_enqueue_scripts', array( 'Facebook_Comments', 'css_hide_comments' ), 0 );


### PR DESCRIPTION
only apply comments open and comments array filter to specific enabled post types. allows different comment systems by post type
