### PR TITLE
only call add_settings_error if the function exists

### DIFF
--- a/admin/settings-app.php
+++ b/admin/settings-app.php
@@ -253,7 +253,7 @@ class Facebook_Application_Settings {
 						$clean_options['app_id'] = $app_id;
 				} else if ( preg_match( '/^[0-9]+$/', $app_id ) ) {
 					$clean_options['app_id'] = $app_id;
-				} else {
+				} else if ( function_exists( 'add_settings_error' ) ) {
 					add_settings_error( 'facebook-app-id', 'facebook-app-id-error', __( 'App ID must contain only digits.', 'facebook' ) );
 				}
 			} else {
@@ -268,7 +268,7 @@ class Facebook_Application_Settings {
 			if ( $app_secret ) {
 				if ( preg_match( '/^[0-9a-f]+$/', $app_secret ) ) // hex
 					$clean_options['app_secret'] = $app_secret;
-				else
+				else if ( function_exists( 'add_settings_error' ) )
 					add_settings_error( 'facebook-app-secret', 'facebook-app-secret-error', __( 'Invalid app secret.', 'facebook' ) );
 			}
 			unset( $app_secret );
@@ -295,7 +295,8 @@ class Facebook_Application_Settings {
 						}
 						unset( $app_info );
 					} else {
-						add_settings_error( 'facebook-app-auth', 'facebook-app-auth-error', __( 'Application ID and secret failed on authentication with Facebook.', 'facebook' ) );
+						if ( function_exists( 'add_settings_error' ) )
+							add_settings_error( 'facebook-app-auth', 'facebook-app-auth-error', __( 'Application ID and secret failed on authentication with Facebook.', 'facebook' ) );
 						unset( $clean_options['app_id'] );
 						unset( $clean_options['app_secret'] );
 					}

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -20,7 +20,7 @@ class Facebook_Settings {
 	 * @since 1.1
 	 */
 	public static function init() {
-		self::migrate_options_10();
+		self::migrate_options();
 		add_action( 'admin_menu', array( 'Facebook_Settings', 'settings_menu_items' ) );
 		add_filter( 'plugin_action_links', array( 'Facebook_Settings', 'plugin_action_links' ), 10, 2 );
 		add_action( 'admin_enqueue_scripts', array( 'Facebook_Settings', 'enqueue_scripts' ) );
@@ -360,7 +360,7 @@ class Facebook_Settings {
 	 *
 	 * @since 1.1
 	 */
-	public static function migrate_options_10() {
+	public static function migrate_options() {
 		if ( get_option( 'facebook_migration_10' ) ) {
 			// run 1.1.5 migration if 1.0 migration already run
 			if ( ! get_option( 'facebook_migration_115' ) && current_user_can( 'manage_options' ) ) {


### PR DESCRIPTION
do not queue up a settings error if page is incapable of displaying the error
