### PR TITLE
add fb:admins OGP property

### DIFF
--- a/admin/login.php
+++ b/admin/login.php
@@ -31,7 +31,7 @@ class Facebook_Admin_Login {
 			return;
 
 		if ( ! class_exists( 'Facebook_User' ) )
-			require_once( dirname(__FILE__) . '/facebook-user.php' );
+			require_once( dirname( dirname(__FILE__) ) . '/facebook-user.php' );
 
 		$facebook_user_data_exists = false;
 		$facebook_user_data = Facebook_User::get_user_meta( $current_user->ID, 'fb_data', true );


### PR DESCRIPTION
set OGP property of fb:admins to author Facebook profile ID for single posts with Comments Box enabled if author has a stored associated Facebook account and the moderate_comments capability
