### PR TITLE
change Subscribe button to Follow button

### DIFF
--- a/admin/migrate-options-10.php
+++ b/admin/migrate-options-10.php
@@ -76,8 +76,8 @@ class Facebook_Migrate_Options_10 {
 			self::migrate_send_button( $old_options['send'] );
 		if ( isset( $old_options['social_publisher'] ) )
 			self::migrate_social_publisher( $old_options['social_publisher'] );
-		if ( isset( $old_options['subscribe'] ) )
-			self::migrate_subscribe_button( $old_options['subscribe'] );
+		if ( isset( $old_options['follow'] ) )
+			self::migrate_follow_button( $old_options['follow'] );
 	}
 
 	/**
@@ -211,23 +211,23 @@ class Facebook_Migrate_Options_10 {
 	}
 
 	/**
-	 * Migrate subscribe button settings
+	 * Migrate follow button settings
 	 *
 	 * @since 1.1
 	 * @param array $options existing settings
 	 * @return result of update_option, if run
 	 */
-	public static function migrate_subscribe_button( $options ) {
+	public static function migrate_follow_button( $options ) {
 		if ( ! is_array( $options ) || empty( $options ) )
 			return;
 
 		$options = self::show_on( $options );
 
-		if ( ! class_exists( 'Facebook_Subscribe_Button_Settings' ) )
-			require_once( dirname(__FILE__) . '/settings-subscribe-button.php' );
-		$options = Facebook_Subscribe_Button_Settings::sanitize_options( $options );
+		if ( ! class_exists( 'Facebook_Follow_Button_Settings' ) )
+			require_once( dirname(__FILE__) . '/settings-follow-button.php' );
+		$options = Facebook_Follow_Button_Settings::sanitize_options( $options );
 		if ( ! empty( $options ) )
-			return update_option( Facebook_Subscribe_Button_Settings::OPTION_NAME, $options );
+			return update_option( Facebook_Follow_Button_Settings::OPTION_NAME, $options );
 	}
 }
 ?>

--- a/admin/migrate-options-115.php
+++ b/admin/migrate-options-115.php
@@ -31,7 +31,7 @@ class Facebook_Migrate_Options_115 {
 		$comments_options = get_option( Facebook_Comments_Settings::OPTION_NAME );
 		if ( ! is_array( $comments_options ) )
 			$comments_options = array();
-		$comments_options['show_on'] = Facebook_Comments_Settings::get_display_conditionals_by_feature( 'comments', 'posts' );
+		$comments_options['show_on'] = array_keys( Facebook_Comments_Settings::get_display_conditionals_by_feature( 'comments', 'posts' ) );
 		update_option( Facebook_Comments_Settings::OPTION_NAME, Facebook_Comments_Settings::sanitize_options( $comments_options ) );
 	}
 

--- a/admin/migrate-options-118.php
+++ b/admin/migrate-options-118.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Change Subscribe Button to Follow Button
+ *
+ * @since 1.1.9
+ */
+class Facebook_Migrate_Options_118 {
+
+	/**
+	 * Store subscribe button options as follow button options
+	 *
+	 * @since 1.1.9
+	 */
+	public static function update_option() {
+		$options = get_option( 'facebook_subscribe_button' );
+		if ( ! is_array( $options ) )
+			return false;
+
+		update_option( 'facebook_follow_button', $options );
+	}
+
+	/**
+	 * Iterate through possible view types for subscribe button
+	 * Change subscribe to follow if found
+	 *
+	 * @since 1.1.9
+	 */
+	public static function update_views() {
+		if ( ! class_exists( 'Facebook_Follow_Button_Settings' ) )
+			require_once( dirname(__FILE__) . '/settings-follow-button.php' );
+
+		// archives + post types
+		$all_possible_display_types = Facebook_Social_Plugin_Settings::get_show_on_choices( 'all' );
+		// archives + post types supporting authorship
+		$follow_display_types = Facebook_Follow_Button_Settings::get_show_on_choices();
+		// iterate through all display types, looking for our feature in each
+		foreach ( $all_possible_display_types as $display_type ) {
+			$option_name = "facebook_{$display_type}_features";
+			$display_preferences = get_option( $option_name );
+			if ( ! is_array( $display_preferences ) )
+				continue;
+
+			if ( isset( $display_preferences['subscribe'] ) ) {
+				unset( $display_preferences['subscribe'] );
+
+				// remove any post types not supporting authorship
+				if ( in_array( $display_type, $follow_display_types, true ) )
+					$display_preferences['follow'] = true;
+
+				// save new values
+				update_option( $option_name, $display_preferences );
+			}
+
+			unset( $option_name );
+			unset( $display_preferences );
+		}
+	}
+
+	/**
+	 * Update subscribe widget instances to follow widget instances
+	 *
+	 * @since 1.1.9
+	 */
+	public static function update_widgets() {
+		$sidebars = wp_get_sidebars_widgets();
+		if ( ! is_array( $sidebars ) )
+			return;
+
+		$found_widgets = false;
+
+		foreach ( $sidebars as $sidebar => $widgets ) {
+			foreach ( $widgets as $position => $widget_id ) {
+				if ( substr_compare( $widget_id, 'facebook-subscribe', 0, 18 ) === 0 ) {
+					$sidebars[$sidebar][$position] = 'facebook-follow' . substr( $widget_id, strrpos( $widget_id, '-' ) );
+					$found_widgets = true;
+				}
+			}
+		}
+
+		if ( $found_widgets ) {
+			$existing_instances = get_option( 'widget_facebook-subscribe' );
+			if ( is_array( $existing_instances ) )
+				update_option( 'widget_facebook-follow', $existing_instances );
+			if ( $existing_instances !== false )
+				delete_option( 'widget_facebook-subscribe' );
+			unset( $existing_instances );
+			wp_set_sidebars_widgets( $sidebars );
+		}
+	}
+
+	/**
+	 * Migrate subscribe to follow
+	 *
+	 * @since 1.1.9
+	 */
+	public static function migrate() {
+		self::update_option();
+		self::update_views();
+		self::update_widgets();
+	}
+}
+?>

--- a/admin/settings-debug.php
+++ b/admin/settings-debug.php
@@ -296,9 +296,9 @@ class Facebook_Settings_Debugger {
 				'name' => __( 'Send Button', 'facebook' ),
 				'url' => 'https://developers.facebook.com/docs/reference/plugins/send/'
 			),
-			'subscribe' => array(
-				'name' => __( 'Subscribe Button', 'facebook' ),
-				'url' => 'https://developers.facebook.com/docs/reference/plugins/subscribe/'
+			'follow' => array(
+				'name' => __( 'Follow Button', 'facebook' ),
+				'url' => 'https://developers.facebook.com/docs/reference/plugins/follow/'
 			),
 			'recommendations_bar' => array(
 				'name' => __( 'Recommendations Bar', 'facebook' ),
@@ -374,9 +374,9 @@ class Facebook_Settings_Debugger {
 				'name' => __( 'Send Button', 'facebook' ),
 				'url' => 'https://developers.facebook.com/docs/reference/plugins/send/'
 			),
-			'subscribe' => array(
-				'name' => __( 'Subscribe Button', 'facebook' ),
-				'url' => 'https://developers.facebook.com/docs/reference/plugins/subscribe/'
+			'follow' => array(
+				'name' => __( 'Follow Button', 'facebook' ),
+				'url' => 'https://developers.facebook.com/docs/reference/plugins/follow/'
 			)
 		);
 

--- a/admin/settings-follow-button.php
+++ b/admin/settings-follow-button.php
@@ -8,7 +8,7 @@ if ( ! class_exists( 'Facebook_Social_Plugin_Button_Settings' ) )
  *
  * @since 1.1
  */
-class Facebook_Subscribe_Button_Settings extends Facebook_Social_Plugin_Button_Settings {
+class Facebook_Follow_Button_Settings extends Facebook_Social_Plugin_Button_Settings {
 
 	/**
 	 * Setting page identifier
@@ -16,7 +16,7 @@ class Facebook_Subscribe_Button_Settings extends Facebook_Social_Plugin_Button_S
 	 * @since 1.1
 	 * @var string
 	 */
-	const PAGE_SLUG = 'facebook-subscribe-button';
+	const PAGE_SLUG = 'facebook-follow-button';
 
 	/**
 	 * Define our option array value
@@ -24,7 +24,7 @@ class Facebook_Subscribe_Button_Settings extends Facebook_Social_Plugin_Button_S
 	 * @since 1.1
 	 * @var string
 	 */
-	const OPTION_NAME = 'facebook_subscribe_button';
+	const OPTION_NAME = 'facebook_follow_button';
 
 	/**
 	 * Initialize with an options array
@@ -47,17 +47,17 @@ class Facebook_Subscribe_Button_Settings extends Facebook_Social_Plugin_Button_S
 	 * @return string social plugin name
 	 */
 	public static function social_plugin_name() {
-		return __( 'Subscribe Button', 'facebook' );
+		return __( 'Follow Button', 'facebook' );
 	}
 
 	/**
-	 * Evaluate the Facebook_Subscribe_Button class file if it is not already loaded
+	 * Evaluate the Facebook_Follow_Button class file if it is not already loaded
 	 *
 	 * @since 1.1
 	 */
-	public static function require_subscribe_button_builder() {
-		if ( ! class_exists( 'Facebook_Subscribe_Button' ) )
-			require_once( dirname( dirname(__FILE__) ) . '/social-plugins/class-facebook-subscribe-button.php' );
+	public static function require_follow_button_builder() {
+		if ( ! class_exists( 'Facebook_Follow_Button' ) )
+			require_once( dirname( dirname(__FILE__) ) . '/social-plugins/class-facebook-follow-button.php' );
 	}
 
 	/**
@@ -69,7 +69,7 @@ class Facebook_Subscribe_Button_Settings extends Facebook_Social_Plugin_Button_S
 	 * @return string submenu hook suffix
 	 */
 	public static function add_submenu_item( $parent_slug ) {
-		$subscribe_button_settings = new Facebook_Subscribe_Button_Settings();
+		$follow_button_settings = new Facebook_Follow_Button_Settings();
 
 		$hook_suffix = add_submenu_page(
 			$parent_slug,
@@ -77,13 +77,13 @@ class Facebook_Subscribe_Button_Settings extends Facebook_Social_Plugin_Button_S
 			self::social_plugin_name(),
 			'manage_options',
 			self::PAGE_SLUG,
-			array( &$subscribe_button_settings, 'settings_page' )
+			array( &$follow_button_settings, 'settings_page' )
 		);
 
 		if ( $hook_suffix ) {
-			$subscribe_button_settings->hook_suffix = $hook_suffix;
-			register_setting( $hook_suffix, self::OPTION_NAME, array( 'Facebook_Subscribe_Button_Settings', 'sanitize_options' ) );
-			add_action( 'load-' . $hook_suffix, array( &$subscribe_button_settings, 'onload' ) );
+			$follow_button_settings->hook_suffix = $hook_suffix;
+			register_setting( $hook_suffix, self::OPTION_NAME, array( 'Facebook_Follow_Button_Settings', 'sanitize_options' ) );
+			add_action( 'load-' . $hook_suffix, array( &$follow_button_settings, 'onload' ) );
 		}
 
 		return $hook_suffix;
@@ -127,7 +127,7 @@ class Facebook_Subscribe_Button_Settings extends Facebook_Social_Plugin_Button_S
 		if ( ! isset( $this->hook_suffix ) )
 			return;
 
-		$section = 'facebook-subscribe-button';
+		$section = 'facebook-follow-button';
 		add_settings_section(
 			$section,
 			'', // no title for main section
@@ -137,55 +137,55 @@ class Facebook_Subscribe_Button_Settings extends Facebook_Social_Plugin_Button_S
 
 		// when, where
 		add_settings_field(
-			'facebook-subscribe-show-on',
+			'facebook-follow-show-on',
 			__( 'Show on', 'facebook' ),
 			array( &$this, 'display_show_on' ),
 			$this->hook_suffix,
 			$section
 		);
 		add_settings_field(
-			'facebook-subscribe-position',
+			'facebook-follow-position',
 			__( 'Position', 'facebook' ),
 			array( &$this, 'display_position' ),
 			$this->hook_suffix,
 			$section,
-			array( 'label_for' => 'facebook-subscribe-position' )
+			array( 'label_for' => 'facebook-follow-position' )
 		);
 
-		// subscribe button options
+		// follow button options
 		add_settings_field(
-			'facebook-subscribe-layout',
+			'facebook-follow-layout',
 			__( 'Layout', 'facebook' ),
 			array( &$this, 'display_layout' ),
 			$this->hook_suffix,
 			$section
 		);
 		add_settings_field(
-			'facebook-subscribe-show-faces',
+			'facebook-follow-show-faces',
 			__( 'Show faces', 'facebook' ),
 			array( &$this, 'display_show_faces' ),
 			$this->hook_suffix,
 			$section,
-			array( 'label_for' => 'facebook-subscribe-show-faces' )
+			array( 'label_for' => 'facebook-follow-show-faces' )
 		);
 		add_settings_field(
-			'facebook-subscribe-width',
+			'facebook-follow-width',
 			__( 'Width', 'facebook' ),
 			array( &$this, 'display_width' ),
 			$this->hook_suffix,
 			$section,
-			array( 'label_for' => 'facebook-subscribe-width' )
+			array( 'label_for' => 'facebook-follow-width' )
 		);
 		add_settings_field(
-			'facebook-subscribe-font',
+			'facebook-follow-font',
 			__( 'Font', 'facebook' ),
 			array( &$this, 'display_font' ),
 			$this->hook_suffix,
 			$section,
-			array( 'label_for' => 'facebook-subscribe-font' )
+			array( 'label_for' => 'facebook-follow-font' )
 		);
 		add_settings_field(
-			'facebook-subscribe-colorscheme',
+			'facebook-follow-colorscheme',
 			__( 'Color scheme', 'facebook' ),
 			array( &$this, 'display_colorscheme' ),
 			$this->hook_suffix,
@@ -194,12 +194,44 @@ class Facebook_Subscribe_Button_Settings extends Facebook_Social_Plugin_Button_S
 	}
 
 	/**
-	 * Introduce publishers to the Subscribe Button social plugin
+	 * Introduce publishers to the Follow Button social plugin
 	 *
 	 * @since 1.1
 	 */
 	public function section_header() {
-		echo '<p>' . esc_html( sprintf( __( "Encourage visitors to subscribe to public updates from an author's %s account.", 'facebook' ), 'Facebook' ) ) . ' <a href="https://developers.facebook.com/docs/reference/plugins/subscribe/" title="' . esc_attr( sprintf( __( '%s social plugin documentation', 'facebook' ), 'Facebook ' . self::social_plugin_name() ) ) . '">' . esc_html( __( 'Read more...', 'facebook' ) ) . '</a></p>';
+		echo '<p>' . esc_html( __( "Encourage visitors to follow to public updates from an author's Facebook account.", 'facebook' ) ) . ' <a href="https://developers.facebook.com/docs/reference/plugins/follow/" title="' . esc_attr( sprintf( __( '%s social plugin documentation', 'facebook' ), 'Facebook ' . self::social_plugin_name() ) ) . '">' . esc_html( __( 'Read more...', 'facebook' ) ) . '</a></p>';
+	}
+
+	/**
+	 * Archive choices and post type choices
+	 *
+	 * @since 1.1.9
+	 * @return array list of archive names and public post type names
+	 */
+	public static function get_show_on_choices() {
+		return array_merge( array( 'home', 'archive' ), self::post_types_supporting_authorship() );
+	}
+
+	/**
+	 * Not all post types support the concept of an author
+	 * Limit selectable post types to just public post types supporting authors
+	 *
+	 * @since 1.1.9
+	 * @return array list of public post types supporting author feature
+	 */
+	public static function post_types_supporting_authorship() {
+		// get a list of all public post types
+		$public_post_types = get_post_types( array( 'public' => true ) );
+
+		// reduce the list of public post types to just the post types supporting comments
+		$post_types_supporting_authorship = array();
+		foreach( $public_post_types as $post_type ) {
+			if ( post_type_supports( $post_type, 'author' ) ) {
+				$post_types_supporting_authorship[] = $post_type;
+			}
+		}
+
+		return $post_types_supporting_authorship;
 	}
 
 	/**
@@ -214,16 +246,31 @@ class Facebook_Subscribe_Button_Settings extends Facebook_Social_Plugin_Button_S
 		extract( self::parse_form_field_attributes(
 			$extra_attributes,
 			array(
-				'id' => 'facebook-subscribe-show-on',
+				'id' => 'facebook-follow-show-on',
 				'class' => '',
 				'name' => self::OPTION_NAME . '[' . $key . ']'
 			)
 		) );
 
+		$existing_value = self::get_display_conditionals_by_feature( 'follow', 'all' );
+
 		echo '<fieldset id="' . $id . '"';
 		if ( isset( $class ) && $class )
 			echo ' class="' . $class . '"';
-		echo '>' . self::show_on_choices( $name, self::get_display_conditionals_by_feature( 'subscribe', 'all' ), 'all' ) . '</fieldset>';
+		echo '>';
+
+		$choices = self::get_show_on_choices();
+		$fields = array();
+		foreach( $choices as $type ) {
+			$field = '<label><input type="checkbox" name="' . $name . '[]" value="' . esc_attr( $type ) . '"';
+			$field .= checked( isset( $existing_value[$type] ), true, false );
+			$field .= ' /> ' . esc_html( $type ) . '</label>';
+
+			$fields[] = $field;
+			unset( $field );
+		}
+		echo implode( ' ', $fields );
+		echo '</fieldset>';
 		echo '<p class="description">' . esc_html( self::show_on_description( self::social_plugin_name() ) ) . '</p>';
 	}
 
@@ -234,16 +281,16 @@ class Facebook_Subscribe_Button_Settings extends Facebook_Social_Plugin_Button_S
 	 * @return array layout descriptions keyed by layout choice
 	 */
 	public static function layout_descriptions() {
-		$subscribe_plural = __( 'subscribers', 'facebook' );
+		$follow_plural = __( 'followers', 'facebook' );
 		return array(
 			'standard' => __( 'Display social text next to the button.', 'facebook' ),
-			'button_count' => sprintf( __( 'Display total number of %s next to the button.', 'facebook' ), $subscribe_plural ),
-			'box_count' => sprintf( __( 'Display total number of %s above the button.', 'facebook' ), $subscribe_plural )
+			'button_count' => sprintf( __( 'Display total number of %s next to the button.', 'facebook' ), $follow_plural ),
+			'box_count' => sprintf( __( 'Display total number of %s above the button.', 'facebook' ), $follow_plural )
 		);
 	}
 
 	/**
-	 * Choose a Subscribe Button layout option
+	 * Choose a Follow Button layout option
 	 *
 	 * @since 1.1
 	 * @param array $extra_attributes custom form attributes
@@ -254,16 +301,16 @@ class Facebook_Subscribe_Button_Settings extends Facebook_Social_Plugin_Button_S
 		extract( self::parse_form_field_attributes(
 			$extra_attributes,
 			array(
-				'id' => 'facebook-subscribe-' . $key,
+				'id' => 'facebook-follow-' . $key,
 				'class' => '',
 				'name' => self::OPTION_NAME . '[' . $key . ']'
 			)
 		) );
 		$name = esc_attr( $name );
 
-		self::require_subscribe_button_builder();
+		self::require_follow_button_builder();
 
-		if ( isset( $this->existing_options[$key] ) && in_array( $this->existing_options[$key], Facebook_Subscribe_Button::$layout_choices ) )
+		if ( isset( $this->existing_options[$key] ) && in_array( $this->existing_options[$key], Facebook_Follow_Button::$layout_choices ) )
 			$existing_value = $this->existing_options[$key];
 		else
 			$existing_value = 'standard';
@@ -271,7 +318,7 @@ class Facebook_Subscribe_Button_Settings extends Facebook_Social_Plugin_Button_S
 		$descriptions = self::layout_descriptions();
 
 		$choices = array();
-		foreach( Facebook_Subscribe_Button::$layout_choices as $layout ) {
+		foreach( Facebook_Follow_Button::$layout_choices as $layout ) {
 			$choice = '<label><input type="radio" name="' . $name . '" value="' . $layout . '"';
 			$choice .= checked( $layout, $existing_value, false );
 			$choice .= ' /> ';
@@ -296,7 +343,7 @@ class Facebook_Subscribe_Button_Settings extends Facebook_Social_Plugin_Button_S
 	}
 
 	/**
-	 * Option to display faces of friends below the Subscribe Button
+	 * Option to display faces of friends below the Follow Button
 	 *
 	 * @since 1.1
 	 * @param array $extra_attributes custom form attributes
@@ -307,7 +354,7 @@ class Facebook_Subscribe_Button_Settings extends Facebook_Social_Plugin_Button_S
 		extract( self::parse_form_field_attributes(
 			$extra_attributes,
 			array(
-				'id' => 'facebook-subscribe-show-faces',
+				'id' => 'facebook-follow-show-faces',
 				'class' => '',
 				'name' => self::OPTION_NAME . '[' . $key . ']'
 			)
@@ -317,11 +364,11 @@ class Facebook_Subscribe_Button_Settings extends Facebook_Social_Plugin_Button_S
 		if ( isset( $class ) && $class )
 			echo ' class="' . $class . '"';
 		checked( isset( $this->existing_options[$key] ) );
-		echo ' /> ' . esc_html( __( "Show profile photos of the viewer's friends who have already subscribed.", 'facebook' ) ) . '</label>';
+		echo ' /> ' . esc_html( __( "Show profile photos of the viewer's friends who already follow this person.", 'facebook' ) ) . '</label>';
 	}
 
 	/**
-	 * Allow the publisher to customize the width of the Subscribe Button
+	 * Allow the publisher to customize the width of the Follow Button
 	 *
 	 * @since 1.1
 	 * @param array $extra_attributes custom form attributes
@@ -333,7 +380,7 @@ class Facebook_Subscribe_Button_Settings extends Facebook_Social_Plugin_Button_S
 		extract( self::parse_form_field_attributes(
 			$extra_attributes,
 			array(
-				'id' => 'facebook-subscribe-' . $key,
+				'id' => 'facebook-follow-' . $key,
 				'class' => '',
 				'name' => self::OPTION_NAME . '[' . $key . ']'
 			)
@@ -369,7 +416,7 @@ class Facebook_Subscribe_Button_Settings extends Facebook_Social_Plugin_Button_S
 		extract( self::parse_form_field_attributes(
 			$extra_attributes,
 			array(
-				'id' => 'facebook-subscribe-' . $key,
+				'id' => 'facebook-follow-' . $key,
 				'class' => '',
 				'name' => self::OPTION_NAME . '[' . $key . ']'
 			)
@@ -393,7 +440,7 @@ class Facebook_Subscribe_Button_Settings extends Facebook_Social_Plugin_Button_S
 		extract( self::parse_form_field_attributes(
 			$extra_attributes,
 			array(
-				'id' => 'facebook-subscribe-' . $key,
+				'id' => 'facebook-follow-' . $key,
 				'class' => '',
 				'name' => self::OPTION_NAME . '[' . $key . ']'
 			)
@@ -417,7 +464,7 @@ class Facebook_Subscribe_Button_Settings extends Facebook_Social_Plugin_Button_S
 		extract( self::parse_form_field_attributes(
 			$extra_attributes,
 			array(
-				'id' => 'facebook-subscribe-' . $key,
+				'id' => 'facebook-follow-' . $key,
 				'class' => '',
 				'name' => self::OPTION_NAME . '[' . $key . ']'
 			)
@@ -455,11 +502,11 @@ class Facebook_Subscribe_Button_Settings extends Facebook_Social_Plugin_Button_S
 	}
 
 	/**
-	 * Sanitize Subscribe Button settings before they are saved to the database
+	 * Sanitize Follow Button settings before they are saved to the database
 	 *
 	 * @since 1.1
-	 * @param array $options Subscribe Button options
-	 * @return array clean option sets. note: we remove Subscribe Button social plugin default options, storing only custom settings (e.g. dark color scheme stored, light is default and therefore not stored)
+	 * @param array $options Follow Button options
+	 * @return array clean option sets. note: we remove Follow Button social plugin default options, storing only custom settings (e.g. dark color scheme stored, light is default and therefore not stored)
 	 */
 	public static function sanitize_options( $options ) {
 		if ( ! is_array( $options ) || empty( $options ) )
@@ -467,30 +514,30 @@ class Facebook_Subscribe_Button_Settings extends Facebook_Social_Plugin_Button_S
 
 		$clean_options = array();
 
-		self::require_subscribe_button_builder();
+		self::require_follow_button_builder();
 
 		// Handle display preferences first
 		$clean_options = parent::sanitize_options( $options );
 		if ( isset( $clean_options['show_on'] ) ) {
-			self::update_display_conditionals( 'subscribe', $clean_options['show_on'], self::get_show_on_choices( 'all' ) );
+			self::update_display_conditionals( 'follow', $clean_options['show_on'], self::get_show_on_choices() );
 			unset( $clean_options['show_on'] );
 		}
 		unset( $options['show_on'] );
 
-		// href required for subscribe button
+		// href required for follow button
 		// set href contextual to the post author, not at settings
 		// fake it here to pass sanitization, then remove before save
 		$options['href'] = 'https://www.facebook.com/zuck';
 
-		$subscribe_button = Facebook_Subscribe_Button::fromArray( $options );
-		if ( $subscribe_button ) {
-			$subscribe_button_options = self::html_data_to_options( $subscribe_button->toHTMLDataArray() );
+		$follow_button = Facebook_Follow_Button::fromArray( $options );
+		if ( $follow_button ) {
+			$follow_button_options = self::html_data_to_options( $follow_button->toHTMLDataArray() );
 
 			// remove the dummy value set above
 			// remove here instead of html_data_to_options to separate widget usage with its real href
-			unset( $subscribe_button_options['href'] );
+			unset( $follow_button_options['href'] );
 
-			return array_merge( $clean_options, $subscribe_button_options );
+			return array_merge( $clean_options, $follow_button_options );
 		}
 
 		return $clean_options;

--- a/admin/settings-social-plugin.php
+++ b/admin/settings-social-plugin.php
@@ -190,13 +190,12 @@ class Facebook_Social_Plugin_Settings {
 
 		// iterate through all display types, looking for our feature in each
 		foreach ( $all_possible_display_types as $display_type ) {
-			$option_name = "facebook_{$display_type}_features";
-
-			$display_preferences = get_option( $option_name );
+			$display_preferences = get_option( "facebook_{$display_type}_features" );
 			if ( ! is_array( $display_preferences ) )
 				continue;
 			if ( isset( $display_preferences[$feature_slug] ) )
 				$show_on[$display_type] = true;
+			unset( $display_preferences );
 		}
 
 		return $show_on;

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -12,7 +12,7 @@ class Facebook_Settings {
 	 * @since 1.1
 	 * @var array
 	 */
-	public static $features = array( 'like' => true, 'send' => true, 'subscribe' => true, 'recommendations_bar' => true, 'comments' => true, 'social_publisher' => true );
+	public static $features = array( 'like' => true, 'send' => true, 'follow' => true, 'recommendations_bar' => true, 'comments' => true, 'social_publisher' => true );
 
 	/**
 	 * Add hooks
@@ -44,7 +44,7 @@ class Facebook_Settings {
 	 * @since 1.1.6
 	 */
 	public static function enqueue_scripts() {
-		wp_enqueue_style( 'facebook-admin-icons', plugins_url( 'static/css/admin/icons' . ( ( defined('SCRIPT_DEBUG') && SCRIPT_DEBUG ) ? '' : '.min' ) . '.css', dirname( __FILE__ ) ), array(), '1.1' );
+		wp_enqueue_style( 'facebook-admin-icons', plugins_url( 'static/css/admin/icons' . ( ( defined('SCRIPT_DEBUG') && SCRIPT_DEBUG ) ? '' : '.min' ) . '.css', dirname( __FILE__ ) ), array(), '1.1.9' );
 	}
 
 	/**
@@ -101,11 +101,11 @@ class Facebook_Settings {
 			Facebook_Send_Button_Settings::add_submenu_item( $menu_slug );
 		}
 
-		if ( isset( $available_features['subscribe'] ) ) {
-			if ( ! class_exists( 'Facebook_Subscribe_Button_Settings' ) )
-				require_once( dirname(__FILE__) . '/settings-subscribe-button.php' );
+		if ( isset( $available_features['follow'] ) ) {
+			if ( ! class_exists( 'Facebook_Follow_Button_Settings' ) )
+				require_once( dirname(__FILE__) . '/settings-follow-button.php' );
 
-			Facebook_Subscribe_Button_Settings::add_submenu_item( $menu_slug );
+			Facebook_Follow_Button_Settings::add_submenu_item( $menu_slug );
 		}
 
 		// some features require stored Facbook application credentials. don't be a tease.
@@ -284,26 +284,26 @@ class Facebook_Settings {
 	 * Get a list of Facebook widgets in one or more sidebars
 	 *
 	 * @since 1.1.6
-	 * @return array widget slugs
+	 * @return array Facebook widget feature slugs
 	 */
 	public static function get_active_widgets() {
 		$sidebar_widgets = wp_get_sidebars_widgets();
-		unset( $sidebar_widgets['wp_inactive_widgets'] ); // no need to track inactives
-		$sidebar_widgets = array_unique( array_merge( array_values( $sidebar_widgets ) ) ); // track widgets, not sidebar names
-		if ( ! ( is_array( $sidebar_widgets ) && isset( $sidebar_widgets[0] ) ) )
+		if ( ! is_array( $sidebar_widgets ) )
 			return array();
 
-		$sidebar_widgets = $sidebar_widgets[0];
-		$widgets = array();
+		// actives only
+		unset( $sidebar_widgets['wp_inactive_widgets'] ); // no need to track inactives
 
-		// iterate through each sidebar configuration
-		// note any facebook widgets we find along the way
-		foreach( $sidebar_widgets as $widget_id ) {
-			if ( strlen( $widget_id ) > 9 && substr_compare( $widget_id, 'facebook-', 0, 9 ) === 0 ) {
-				$feature = substr( $widget_id, 9, strrpos( $widget_id, '-' ) - 9 );
-				if ( ! isset( $widgets[$feature] ) )
-					$widgets[$feature] = true;
-				unset( $feature );
+		$widgets = array();
+		// iterate through each sidebar, then widgets within, looking for Facebook widgets
+		foreach ( $sidebar_widgets as $sidebar => $widget_list ) {
+			foreach ( $widget_list as $widget_id ) {
+				if ( strlen( $widget_id ) > 9 && substr_compare( $widget_id, 'facebook-', 0, 9 ) === 0 ) {
+					$feature = substr( $widget_id, 9, strrpos( $widget_id, '-' ) - 9 );
+					if ( ! isset( $widgets[$feature] ) )
+						$widgets[$feature] = true;
+					unset( $feature );
+				}
 			}
 		}
 
@@ -344,14 +344,14 @@ class Facebook_Settings {
 				continue;
 
 			if ( isset( $og_conflicting_plugins[ $plugin_data['PluginURI'] ] ) )
-				$conflicting_plugins[] = $plugin_data['Name'];
+				$conflicting_plugins[] = esc_html( $plugin_data['Name'] );
 
 			unset( $plugin_data );
 		}
 
 		//if there are more than 1 plugins relying on Open Graph, warn the user on this plugins page
 		if ( ! empty( $conflicting_plugins ) ) {
-			fb_admin_dialog( sprintf( __( 'You have plugins installed that could potentially conflict with the Facebook plugin. Please consider disabling the following plugins on the %s:', 'facebook' ) . '<br />' . implode( ', ', $conflicting_plugins ), '<a href="' . admin_url( 'plugins.php' ) .'">' . esc_html( __( 'Plugins Settings page', 'facebook' ) ) . '</a>' ), true);
+			echo '<div id="facebook-warning" class="error fade"><p>' . sprintf( esc_html( __( 'You have plugins installed that could potentially conflict with the Facebook plugin. Please consider disabling the following plugins on the %s:', 'facebook' ) . '<br />' . implode( ', ', $conflicting_plugins ) ), '<a href="' . admin_url( 'plugins.php' ) .'">' . esc_html( __( 'Plugins Settings page', 'facebook' ) ) . '</a>' ) . '</p></div>';
 		}
 	}
 
@@ -361,23 +361,33 @@ class Facebook_Settings {
 	 * @since 1.1
 	 */
 	public static function migrate_options() {
+		if ( get_option( 'facebook_migration_118' ) )
+			return;
+
+		// wait for an appropirate user
+		if ( ! current_user_can( 'manage_options' ) )
+			return;
+
+		// the options migration from 1.1 sets migrations from 1.1.5 and 1.1.8
 		if ( get_option( 'facebook_migration_10' ) ) {
 			// run 1.1.5 migration if 1.0 migration already run
-			if ( ! get_option( 'facebook_migration_115' ) && current_user_can( 'manage_options' ) ) {
+			if ( ! get_option( 'facebook_migration_115' ) ) {
 				if ( ! class_exists( 'Facebook_Migrate_Options_115' ) )
 					require_once( dirname(__FILE__) . '/migrate-options-115.php' );
 				Facebook_Migrate_Options_115::migrate();
 				update_option( 'facebook_migration_115', '1' );
 			}
-			return;
-		}
-
-		if ( current_user_can( 'manage_options' ) ) {
+			if ( ! class_exists( 'Facebook_Migrate_Options_118' ) )
+				require_once( dirname(__FILE__) . '/migrate-options-118.php' );
+			Facebook_Migrate_Options_118::migrate();
+			update_option( 'facebook_migration_118', '1' );
+		} else {
 			if ( ! class_exists( 'Facebook_Migrate_Options_10' ) )
 				require_once( dirname(__FILE__) . '/migrate-options-10.php' );
 			Facebook_Migrate_Options_10::migrate();
 			update_option( 'facebook_migration_10', '1' );
 			update_option( 'facebook_migration_115', '1' ); // 1.0 covers the changes from 1.1.5
+			update_option( 'facebook_migration_118', '1' ); // 1.0 covers the changes from 1.1.8
 		}
 	}
 }

--- a/facebook.php
+++ b/facebook.php
@@ -288,8 +288,8 @@ class Facebook_Loader {
 			add_filter( 'the_content', 'facebook_the_content_like_button', $priority );
 		if ( isset( $enabled_features['send'] ) )
 			add_filter( 'the_content', 'facebook_the_content_send_button', $priority );
-		if ( isset( $enabled_features['subscribe'] ) )
-			add_filter( 'the_content', 'facebook_the_content_subscribe_button', $priority );
+		if ( isset( $enabled_features['follow'] ) )
+			add_filter( 'the_content', 'facebook_the_content_follow_button', $priority );
 		if ( isset( $enabled_features['mentions'] ) ) {
 			if ( ! function_exists( 'facebook_social_publisher_mentioning_output' ) )
 				require_once( dirname(__FILE__) . '/social-publisher/mentions.php' );
@@ -355,7 +355,7 @@ class Facebook_Loader {
 		foreach ( array(
 			'like-button' => 'Facebook_Like_Button_Widget',
 			'send-button' => 'Facebook_Send_Button_Widget',
-			'subscribe-button' => 'Facebook_Subscribe_Button_Widget',
+			'follow-button' => 'Facebook_Follow_Button_Widget',
 			'recommendations-box' => 'Facebook_Recommendations_Widget',
 			'activity-feed' => 'Facebook_Activity_Feed_Widget'
 		) as $filename => $classname ) {

--- a/social-plugins/class-facebook-follow-button.php
+++ b/social-plugins/class-facebook-follow-button.php
@@ -4,12 +4,12 @@ if ( ! class_exists( 'Facebook_Social_Plugin' ) )
 	require_once( dirname(__FILE__) . '/class-facebook-social-plugin.php' );
 
 /**
- * Encourage visitors to subscribe to your public updates on Facebook with a Subscribe Button
+ * Encourage visitors to follow your public updates on Facebook with a Follow Button
  *
  * @since 1.1
- * @link https://developers.facebook.com/docs/reference/plugins/subscribe/ Facebook Subscribe Button
+ * @link https://developers.facebook.com/docs/reference/plugins/follow/ Facebook Follow Button
  */
-class Facebook_Subscribe_Button extends Facebook_Social_Plugin {
+class Facebook_Follow_Button extends Facebook_Social_Plugin {
 
 	/**
 	 * Element and class name used in markup builders
@@ -17,20 +17,20 @@ class Facebook_Subscribe_Button extends Facebook_Social_Plugin {
 	 * @since 1.1
 	 * @var string
 	 */
-	const ID = 'subscribe';
+	const ID = 'follow';
 
 	/**
-	 * The Facebook URL representing a user profile or page open to new subscribers
-	 * Your account must allow subscribers. Subscribe only available for accounts belonging to a user over 18 years of age
+	 * The Facebook URL representing a user profile or page open to new followers
+	 * Your account must allow followers. Follow ability only available for accounts belonging to a user over 18 years of age
 	 *
-	 * @link https://www.facebook.com/about/subscribe About Facebook Subscribe
+	 * @link https://www.facebook.com/about/follow About Facebook Follow
 	 * @since 1.1
 	 * @var string
 	 */
 	protected $href;
 
 	/**
-	 * Which style subscribe button you would like displayed
+	 * Which style follow button you would like displayed
 	 *
 	 * @since 1.1
 	 * @var string
@@ -38,7 +38,7 @@ class Facebook_Subscribe_Button extends Facebook_Social_Plugin {
 	protected $layout;
 
 	/**
-	 * Choose your subscribe button
+	 * Choose your follow button
 	 *
 	 * @since 1.1
 	 * @var array
@@ -46,7 +46,7 @@ class Facebook_Subscribe_Button extends Facebook_Social_Plugin {
 	public static $layout_choices = array( 'standard', 'button_count', 'box_count' );
 
 	/**
-	 * Show faces of the viewer's friends already subscribed?
+	 * Show faces of the viewer's friends already following?
 	 * Only applies to standard layout. Needs the extra width.
 	 *
 	 * @since 1.1
@@ -77,13 +77,13 @@ class Facebook_Subscribe_Button extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * I am a subscribe button
+	 * I am a follow button
 	 *
 	 * @since 1.1
 	 * @return string
 	 */
 	public function __toString() {
-		return 'Facebook Subscribe Button';
+		return 'Facebook Follow Button';
 	}
 
 	/**
@@ -91,12 +91,12 @@ class Facebook_Subscribe_Button extends Facebook_Social_Plugin {
 	 *
 	 * @since 1.1
 	 * @param string $url absolute URL
-	 * @return Facebook_Subscribe_Button support chaining
+	 * @return Facebook_Follow_Button support chaining
 	 */
 	public function setURL( $url ) {
 		$url = esc_url_raw( $url, array( 'http', 'https' ) );
 		if ( $url ) {
-			// you can only subscribe to a Facebook URL
+			// you can only follow a Facebook URL
 			if ( parse_url( $url, PHP_URL_HOST ) === 'www.facebook.com' )
 				$this->href = $url;
 		}
@@ -109,7 +109,7 @@ class Facebook_Subscribe_Button extends Facebook_Social_Plugin {
 	 * @since 1.1
 	 * @see self::$layout_choices
 	 * @param string $layout a supported layout option
-	 * @return Facebook_Subscribe_Button support chaining
+	 * @return Facebook_Follow_Button support chaining
 	 */
 	public function setLayout( $layout ) {
 		if ( is_string( $layout ) && in_array( $layout, self::$layout_choices, true ) )
@@ -121,7 +121,7 @@ class Facebook_Subscribe_Button extends Facebook_Social_Plugin {
 	 * Show the faces of a logged-on Facebook user's friends
 	 *
 	 * @since 1.1
-	 * @return Facebook_Subscribe_Button support chaining
+	 * @return Facebook_Follow_Button support chaining
 	 */
 	public function showFaces() {
 		$this->show_faces = true;
@@ -129,22 +129,22 @@ class Facebook_Subscribe_Button extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Width of the subscribe button
+	 * Width of the follow button
 	 * Should be greater than the minimum width of layout option
 	 *
 	 * @since 1.1
 	 * @param int $width width in whole pixels
-	 * @return Facebook_Subscribe_Button support chaining
+	 * @return Facebook_Follow_Button support chaining
 	 */
 	public function setWidth( $width ) {
-		// narrowest subscribe button is box_count at 55
+		// narrowest follow button is box_count at 55
 		if ( is_int( $width ) && $width > 55 )
 			$this->width = $width;
 		return $this;
 	}
 
 	/**
-	 * Compute a minimum width of a subscribe button based on configured options
+	 * Compute a minimum width of a follow button based on configured options
 	 *
 	 * @since 1.1
 	 * @return int minimum width of the current configuration in whole pixels
@@ -192,33 +192,33 @@ class Facebook_Subscribe_Button extends Facebook_Social_Plugin {
 	 *
 	 * @since 1.1
 	 * @param array $values associative array
-	 * @return Facebook_Subscribe_Button subscribe object
+	 * @return Facebook_Follow_Button follow object
 	 */
 	public static function fromArray( $values ) {
 		if ( ! is_array( $values ) || empty( $values ) )
 			return;
 
-		$subscribe_button = new Facebook_Subscribe_Button();
+		$follow_button = new Facebook_Follow_Button();
 
 		if ( isset( $values['href'] ) )
-			$subscribe_button->setURL( $values['href'] );
+			$follow_button->setURL( $values['href'] );
 
 		if ( isset( $values['layout'] ) )
-			$subscribe_button->setLayout( $values['layout'] );
+			$follow_button->setLayout( $values['layout'] );
 
 		if ( isset( $values['show_faces'] ) && ( $values['show_faces'] === true || $values['show_faces'] === 'true' || $values['show_faces'] == 1 ) )
-			$subscribe_button->showFaces();
+			$follow_button->showFaces();
 
 		if ( isset( $values['width'] ) )
-			$subscribe_button->setWidth( absint( $values['width'] ) );
+			$follow_button->setWidth( absint( $values['width'] ) );
 
 		if ( isset( $values['font'] ) )
-			$subscribe_button->setFont( $values['font'] );
+			$follow_button->setFont( $values['font'] );
 
 		if ( isset( $values['colorscheme'] ) )
-			$subscribe_button->setColorScheme( $values['colorscheme'] );
+			$follow_button->setColorScheme( $values['colorscheme'] );
 
-		return $subscribe_button;
+		return $follow_button;
 	}
 
 	/**
@@ -250,7 +250,7 @@ class Facebook_Subscribe_Button extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Output Subscribe button with data-* attributes
+	 * Output Follow button with data-* attributes
 	 *
 	 * @since 1.1
 	 * @param array $div_attributes associative array. customize the returned div with id, class, or style attributes
@@ -269,7 +269,7 @@ class Facebook_Subscribe_Button extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Output Subscribe button as XFBML
+	 * Output Follow button as XFBML
 	 *
 	 * @since 1.1
 	 * @return string XFBML markup

--- a/social-plugins/social-plugins.php
+++ b/social-plugins/social-plugins.php
@@ -172,25 +172,25 @@ function facebook_the_content_send_button( $content ) {
 }
 
 /**
- * Generate HTML for a subscribe button based on passed options
+ * Generate HTML for a follow button based on passed options
  *
  * @since 1.1
  * @param array $options customizations
- * @return string subscribe button HTML for use with the JavaScript SDK
+ * @return string follow button HTML for use with the JavaScript SDK
  */
-function facebook_get_subscribe_button( $options = array() ) {
+function facebook_get_follow_button( $options = array() ) {
 	// need a subscription target
 	if ( ! is_array( $options ) || empty( $options['href'] ) )
 		return '';
 
-	if ( ! class_exists( 'Facebook_Subscribe_Button' ) )
-		require_once( dirname(__FILE__) . '/class-facebook-subscribe-button.php' );
+	if ( ! class_exists( 'Facebook_Follow_Button' ) )
+		require_once( dirname(__FILE__) . '/class-facebook-follow-button.php' );
 
-	$subscribe_button = Facebook_Subscribe_Button::fromArray( $options );
-	if ( ! $subscribe_button )
+	$follow_button = Facebook_Follow_Button::fromArray( $options );
+	if ( ! $follow_button )
 		return '';
 
-	$html = $subscribe_button->asHTML( array( 'class' => array( 'fb-social-plugin' ) ) );
+	$html = $follow_button->asHTML( array( 'class' => array( 'fb-social-plugin' ) ) );
 	if ( is_string($html) && $html )
 		return "\n" . $html . "\n";
 
@@ -198,21 +198,21 @@ function facebook_get_subscribe_button( $options = array() ) {
 }
 
 /**
- * Add Subscribe Button(s) to post content
- * Adds a subscribe button above the post, below the post, or both above and below the post depending on stored preferences.
+ * Add Follow Button(s) to post content
+ * Adds a follow button above the post, below the post, or both above and below the post depending on stored preferences.
  *
  * @since 1.1
  * @param string $content existing content
- * @return string passed content with Subscribe Button markup prepended, appended, or both.
+ * @return string passed content with Follow Button markup prepended, appended, or both.
  */
-function facebook_the_content_subscribe_button( $content ) {
+function facebook_the_content_follow_button( $content ) {
 	global $post;
 
 	// Send Button should not be the only content
 	if ( ! $content )
 		return $content;
 
-	$options = get_option( 'facebook_subscribe_button' );
+	$options = get_option( 'facebook_follow_button' );
 	if ( ! is_array( $options ) )
 		$options = array();
 
@@ -230,15 +230,15 @@ function facebook_the_content_subscribe_button( $content ) {
 
 	if ( $options['position'] === 'top' ) {
 		$options['ref'] = 'above-post';
-		return facebook_get_subscribe_button( $options ) . $content;
+		return facebook_get_follow_button( $options ) . $content;
 	} else if ( $options['position'] === 'bottom' ) {
 		$options['ref'] = 'below-post';
-		return $content . facebook_get_subscribe_button( $options );
+		return $content . facebook_get_follow_button( $options );
 	} else if ( $options['position'] === 'both' ) {
 		$options['ref'] = 'above-post';
-		$above = facebook_get_subscribe_button( $options );
+		$above = facebook_get_follow_button( $options );
 		$options['ref'] = 'below-post';
-		return $above . $content . facebook_get_subscribe_button( $options );
+		return $above . $content . facebook_get_follow_button( $options );
 	}
 
 	// don't break the filter

--- a/social-plugins/widgets/follow-button.php
+++ b/social-plugins/widgets/follow-button.php
@@ -1,19 +1,19 @@
 <?php
 /**
- * Adds the Subscribe Button Social Plugin as a WordPress Widget
+ * Adds the Follow Button Social Plugin as a WordPress Widget
  *
  * @since 1.0
  */
-class Facebook_Subscribe_Button_Widget extends WP_Widget {
+class Facebook_Follow_Button_Widget extends WP_Widget {
 
 	/**
 	 * Register widget with WordPress
 	 */
 	public function __construct() {
 		parent::__construct(
-	 		'facebook-subscribe', // Base ID
-			__( 'Facebook Subscribe Button', 'facebook' ), // Name
-			array( 'description' => __( 'Lets a user subscribe to your public updates on Facebook.', 'facebook' ) ) // Args
+	 		'facebook-follow', // Base ID
+			__( 'Facebook Follow Button', 'facebook' ), // Name
+			array( 'description' => __( 'Lets a user follow your public updates on Facebook.', 'facebook' ) ) // Args
 		);
 	}
 
@@ -26,7 +26,7 @@ class Facebook_Subscribe_Button_Widget extends WP_Widget {
 	 * @param array $instance Saved values from database.
 	 */
 	public function widget( $args, $instance ) {
-		// no subscribe target. fail early
+		// no follow target. fail early
 		if ( empty( $instance['href'] ) )
 			return;
 
@@ -35,11 +35,11 @@ class Facebook_Subscribe_Button_Widget extends WP_Widget {
 		if ( ! isset( $instance['ref'] ) )
 			$instance['ref'] = 'widget';
 
-		if ( ! function_exists( 'facebook_get_subscribe_button' ) )
+		if ( ! function_exists( 'facebook_get_follow_button' ) )
 			require_once( dirname( dirname(__FILE__) ) . '/social-plugins.php' );
 
-		$subscribe_button_html = facebook_get_subscribe_button( $instance );
-		if ( ! ( is_string( $subscribe_button_html ) && $subscribe_button_html ) )
+		$follow_button_html = facebook_get_follow_button( $instance );
+		if ( ! ( is_string( $follow_button_html ) && $follow_button_html ) )
 			return;
 
 		echo $before_widget;
@@ -49,7 +49,7 @@ class Facebook_Subscribe_Button_Widget extends WP_Widget {
 		if ( $title )
 			echo $before_title . esc_html( $title ) . $after_title;
 
-		echo $subscribe_button_html;
+		echo $follow_button_html;
 
 		echo $after_widget;
 	}
@@ -70,15 +70,15 @@ class Facebook_Subscribe_Button_Widget extends WP_Widget {
 		if ( ! empty( $new_instance['title'] ) )
 			$instance['title'] = strip_tags( $new_instance['title'] );
 
-		if ( ! class_exists( 'Facebook_Subscribe_Button' ) )
-			require_once( dirname( dirname(__FILE__) ) . '/class-facebook-subscribe-button.php' );
+		if ( ! class_exists( 'Facebook_Follow_Button' ) )
+			require_once( dirname( dirname(__FILE__) ) . '/class-facebook-follow-button.php' );
 
-		$subscribe_button = Facebook_Subscribe_Button::fromArray( $new_instance );
-		if ( $subscribe_button ) {
-			if ( ! class_exists( 'Facebook_Subscribe_Button_Settings' ) )
-				require_once( dirname( dirname( dirname(__FILE__) ) ) . '/admin/settings-subscribe-button.php' );
+		$follow_button = Facebook_Follow_Button::fromArray( $new_instance );
+		if ( $follow_button ) {
+			if ( ! class_exists( 'Facebook_Follow_Button_Settings' ) )
+				require_once( dirname( dirname( dirname(__FILE__) ) ) . '/admin/settings-follow-button.php' );
 
-			return array_merge( $instance, Facebook_Subscribe_Button_Settings::html_data_to_options( $subscribe_button->toHTMLDataArray() ) );
+			return array_merge( $instance, Facebook_Follow_Button_Settings::html_data_to_options( $follow_button->toHTMLDataArray() ) );
 		}
 
 		return $instance;
@@ -95,41 +95,41 @@ class Facebook_Subscribe_Button_Widget extends WP_Widget {
 		$this->display_title( isset( $instance['title'] ) ? $instance['title'] : '' );
 		$this->display_href( isset( $instance['href'] ) ? $instance['href'] : '' );
 
-		if ( ! class_exists( 'Facebook_Subscribe_Button_Settings' ) )
-			require_once( dirname( dirname( dirname(__FILE__) ) ) . '/admin/settings-subscribe-button.php' );
+		if ( ! class_exists( 'Facebook_Follow_Button_Settings' ) )
+			require_once( dirname( dirname( dirname(__FILE__) ) ) . '/admin/settings-follow-button.php' );
 
-		$subscribe_button_settings = new Facebook_Subscribe_Button_Settings( $instance );
+		$follow_button_settings = new Facebook_Follow_Button_Settings( $instance );
 
 		echo '<div>' . esc_html( __( 'Layout', 'facebook' ) ) . ': ';
-		$subscribe_button_settings->display_layout( array(
+		$follow_button_settings->display_layout( array(
 			'id' => $this->get_field_id( 'layout' ),
 			'name' => $this->get_field_name( 'layout' )
 		) );
 		echo '</div><p></p>';
 
 		echo '<div>';
-		$subscribe_button_settings->display_show_faces( array(
+		$follow_button_settings->display_show_faces( array(
 			'id' => $this->get_field_id( 'show_faces' ),
 			'name' => $this->get_field_name( 'show_faces' )
 		) );
 		echo '</div><p></p>';
 
 		echo '<div><label for="' . $this->get_field_id( 'width' ) . '">' . esc_html( __( 'Width', 'facebook' ) ) . '</label>: ';
-		$subscribe_button_settings->display_width( array(
+		$follow_button_settings->display_width( array(
 			'id' => $this->get_field_id( 'width' ),
 			'name' => $this->get_field_name( 'width' )
 		) );
 		echo '</div><p></p>';
 
 		echo '<div><label for="' . $this->get_field_id( 'font' ) . '">' . esc_html( __( 'Font', 'facebook' ) ) . '</label>: ';
-		$subscribe_button_settings->display_font( array(
+		$follow_button_settings->display_font( array(
 			'id' => $this->get_field_id( 'font' ),
 			'name' => $this->get_field_name( 'font' )
 		) );
 		echo '</div><p></p>';
 
 		echo '<div style="line-height:2em">' . esc_html( __( 'Color scheme', 'facebook' ) ) . ': ';
-		$subscribe_button_settings->display_colorscheme( array(
+		$follow_button_settings->display_colorscheme( array(
 			'id' => $this->get_field_id( 'colorscheme' ),
 			'name' => $this->get_field_name( 'colorscheme' )
 		) );

--- a/uninstall.php
+++ b/uninstall.php
@@ -27,7 +27,7 @@ $__options = array(
 	'facebook_send_button',
 	'facebook_mentions',
 	'facebook_publish_page',
-	'facebook_subscribe_button',
+	'facebook_follow_button',
 	'facebook_home_features',
 	'facebook_archive_features'
 );


### PR DESCRIPTION
Facebook rebranded Subscribe button as Follow button. Change plugin text, variables, and options from subscribe to follow.
