### PR TITLE
a more cautious approach to widget loading

### DIFF
--- a/facebook.php
+++ b/facebook.php
@@ -359,8 +359,17 @@ class Facebook_Loader {
 			'recommendations-box' => 'Facebook_Recommendations_Widget',
 			'activity-feed' => 'Facebook_Activity_Feed_Widget'
 		) as $filename => $classname ) {
-			include_once( $widget_directory . $filename . '.php' );
-			register_widget( $classname );
+			if ( class_exists( $classname ) ) {
+				register_widget( $classname );
+			} else {
+				$file = $widget_directory . $filename . '.php';
+				if ( file_exists( $file ) ) {
+					include_once( $file );
+					if ( class_exists( $classname ) )
+						register_widget( $classname );
+				}
+				unset( $file );
+			}
 		}
 	}
 


### PR DESCRIPTION
Widget loading might fail for various reasons. Try to fail more silently.

Some sites might run into PHP cache issues after upgrading. A class might already be defined. An assumption about a file location relative to our plugin base might be incorrect. Run additional checks when loading widgets.
