### PR TITLE
prefer true to !0 in JS SDK loader

### DIFF
--- a/facebook.php
+++ b/facebook.php
@@ -181,7 +181,7 @@ class Facebook_Loader {
 			return $src;
 
 		// @link https://developers.facebook.com/docs/reference/javascript/#loading
-		$html = '<div id="fb-root"></div><script type="text/javascript">(function(d){var id="facebook-jssdk";if(!d.getElementById(id)){var js=d.createElement("script"),ref=d.getElementsByTagName("script")[0];js.id=id,js.async=!0,js.src=' . json_encode( $src ) . ',ref.parentNode.insertBefore(js,ref)}})(document)</script>' . "\n";
+		$html = '<div id="fb-root"></div><script type="text/javascript">(function(d){var id="facebook-jssdk";if(!d.getElementById(id)){var js=d.createElement("script"),ref=d.getElementsByTagName("script")[0];js.id=id,js.async=true,js.src=' . json_encode( $src ) . ',ref.parentNode.insertBefore(js,ref)}})(document)</script>' . "\n";
 		if ( isset( $wp_scripts ) && $wp_scripts->do_concat )
 			$wp_scripts->print_html .= $html;
 		else


### PR DESCRIPTION
prefer `true` over `!0` for readability
