### PR TITLE
do not compare strings of length less than needle length

### DIFF
--- a/admin/migrate-options-118.php
+++ b/admin/migrate-options-118.php
@@ -71,7 +71,7 @@ class Facebook_Migrate_Options_118 {
 
 		foreach ( $sidebars as $sidebar => $widgets ) {
 			foreach ( $widgets as $position => $widget_id ) {
-				if ( substr_compare( $widget_id, 'facebook-subscribe', 0, 18 ) === 0 ) {
+				if ( strlen( $widget_id ) > 18 && substr_compare( $widget_id, 'facebook-subscribe', 0, 18 ) === 0 ) {
 					$sidebars[$sidebar][$position] = 'facebook-follow' . substr( $widget_id, strrpos( $widget_id, '-' ) );
 					$found_widgets = true;
 				}

--- a/admin/settings-debug.php
+++ b/admin/settings-debug.php
@@ -431,7 +431,7 @@ class Facebook_Settings_Debugger {
 				if ( isset( $curl_version['ssl_version'] ) ) {
 					echo '; ';
 					$ssl_version = $curl_version['ssl_version'];
-					if ( substr_compare( $ssl_version, 'OpenSSL/', 0, 8 ) === 0 )
+					if ( strlen( $curl_version['ssl_version'] ) > 8 && substr_compare( $ssl_version, 'OpenSSL/', 0, 8 ) === 0 )
 						echo '<a href="http://openssl.org/">OpenSSL</a>/' . esc_html( substr( $ssl_version, 8 ) );
 					else
 						echo esc_html( $ssl_version );

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -297,6 +297,8 @@ class Facebook_Settings {
 		$widgets = array();
 		// iterate through each sidebar, then widgets within, looking for Facebook widgets
 		foreach ( $sidebar_widgets as $sidebar => $widget_list ) {
+			if ( ! is_array( $widget_list ) )
+				continue;
 			foreach ( $widget_list as $widget_id ) {
 				if ( strlen( $widget_id ) > 9 && substr_compare( $widget_id, 'facebook-', 0, 9 ) === 0 ) {
 					$feature = substr( $widget_id, 9, strrpos( $widget_id, '-' ) - 9 );

--- a/open-graph-protocol.php
+++ b/open-graph-protocol.php
@@ -163,17 +163,21 @@ class Facebook_Open_Graph_Protocol {
 
 		foreach ( $ogp as $property => $value ) {
 			$prefixed_property_set = false;
+			$property_length = strlen( $property );
 			foreach ( $curies as $reference => $properties ) {
-				if ( substr_compare( $property, $reference, 0, $properties['key_length'] ) === 0 ) {
+				if ( $property_length > $properties['key_length'] && substr_compare( $property, $reference, 0, $properties['key_length'] ) === 0 ) {
 					$ogp_prefixed[ $properties['prefix'] . ':' . substr( $property , $properties['key_length'] ) ] = $value;
 					$prefixed_property_set = true;
 					break;
 				}
 			}
+			unset( $property_length );
 
 			// pass through unmapped values
 			if ( ! $prefixed_property_set )
 				$ogp_prefixed[$property] = $value;
+
+			unset( $prefixed_property_set );
 		}
 
 		return $ogp_prefixed;


### PR DESCRIPTION
fix an issue where `substr_compare` emits a warning if needle length exceeds haystack length

quickly exit widget configurations without registered sidebars
