### PR TITLE
Use app access token for Facebook requests without an active user session

### DIFF
--- a/admin/login.php
+++ b/admin/login.php
@@ -13,7 +13,7 @@ class Facebook_Admin_Login {
 	 * @since 1.1
 	 */
 	public static function connect_facebook_account( $verify_permissions = null ) {
-		global $facebook;
+		global $facebook, $facebook_loader;
 
 		$profile_prompt = false;
 
@@ -42,8 +42,11 @@ class Facebook_Admin_Login {
 		}
 
 		// Facebook information not found
-		$facebook_user = Facebook_User::get_current_user( array( 'id','username' ) );
+		$facebook_user = Facebook_User::get_current_user( array( 'id','username','third_party_id' ) );
 		if ( $facebook_user ) {
+			if ( ! isset( $facebook ) && ! ( isset( $facebook_loader ) && $facebook_loader->load_php_sdk() ) )
+				return;
+
 			$permissions = $facebook->get_current_user_permissions( $facebook_user );
 
 			$all_permissions_exist = true;
@@ -62,6 +65,8 @@ class Facebook_Admin_Login {
 					);
 					if ( ! empty( $facebook_user['username'] ) )
 						$facebook_user_data['username'] = $facebook_user['username'];
+					if ( ! empty( $facebook_user['third_party_id'] ) )
+						$facebook_user_data['third_party_id'] = $facebook_user['third_party_id'];
 
 					Facebook_User::update_user_meta( $current_user->ID, 'fb_data', $facebook_user_data );
 				}

--- a/admin/settings-app.php
+++ b/admin/settings-app.php
@@ -173,15 +173,10 @@ class Facebook_Application_Settings {
 	 * @since 1.1
 	 */
 	public function section_header() {
-		global $facebook;
-
-		if ( isset( $facebook ) && $facebook ) {
-			if ( isset( $this->existing_options['app_id'] ) && $this->existing_options['app_id'] ) {
-				echo '<p><a href="' . esc_url( 'https://developers.facebook.com/apps/' . $this->existing_options['app_id'] ) . '">' . esc_html( __( 'Edit your application settings on Facebook', 'facebook' ) ) . '</a></p>';
-			}
-		} else {
+		if ( ! empty( $this->existing_options['app_id'] ) )
+			echo '<p><a href="' . esc_url( 'https://developers.facebook.com/apps/' . $this->existing_options['app_id'] ) . '">' . esc_html( __( 'Edit your application settings on Facebook', 'facebook' ) ) . '</a></p>';
+		else
 			echo '<p><a href="https://developers.facebook.com/apps/">' . esc_html( sprintf( __( 'Create a new Facebook application or associate %s with an existing Facebook application.', 'facebook' ), get_bloginfo( 'name' ) ) ) . '</a></p>';
-		}
 	}
 
 	/**
@@ -237,7 +232,7 @@ class Facebook_Application_Settings {
 	 * @param array $options form options values
 	 */
 	public static function sanitize_options( $options ) {
-		global $facebook;
+		global $facebook_loader;
 
 		// start fresh
 		$clean_options = array();
@@ -277,17 +272,17 @@ class Facebook_Application_Settings {
 		// store an application access token and verify additional data
 		if ( isset( $clean_options['app_id'] ) && isset( $clean_options['app_secret'] ) ) {
 			if ( ! class_exists( 'Facebook_WP_Extend' ) )
-				require_once( dirname( dirname( __FILE__ ) ) . '/includes/facebook-php-sdk/class-facebook-wp.php' );
+				require_once( $facebook_loader->plugin_directory . 'includes/facebook-php-sdk/class-facebook-wp.php' );
 
-			$facebook = new Facebook_WP_Extend( array(
+			$facebook_php_sdk = new Facebook_WP_Extend( array(
 				'appId' => $clean_options['app_id'],
 				'secret' => $clean_options['app_secret']
 			) );
-			if ( $facebook ) {
+			if ( $facebook_php_sdk ) {
 				if ( wp_http_supports( array( 'ssl' => true ) ) ) {
-					$access_token = $facebook->getAppAccessToken();
+					$access_token = $facebook_php_sdk->getAppAccessToken();
 					if ( $access_token ) {
-						$app_info = $facebook->get_app_details_by_access_token( $access_token );
+						$app_info = $facebook_php_sdk->get_app_details_by_access_token( $access_token );
 						if ( ! empty( $app_info ) ) {
 							if ( isset( $app_info['namespace'] ) )
 								$clean_options['app_namespace'] = $app_info['namespace'];
@@ -302,7 +297,7 @@ class Facebook_Application_Settings {
 					}
 					unset( $access_token );
 				} else {
-					$app_info = $facebook->get_app_details();
+					$app_info = $facebook_php_sdk->get_app_details();
 					if ( ! empty( $app_info ) ) {
 						if ( isset( $app_info['namespace'] ) )
 							$clean_options['app_namespace'] = $app_info['namespace'];

--- a/admin/settings-social-publisher.php
+++ b/admin/settings-social-publisher.php
@@ -74,7 +74,7 @@ class Facebook_Social_Publisher_Settings {
 	 * @since 1.1
 	 */
 	public function onload() {
-		global $facebook;
+		global $facebook, $facebook_loader;
 
 		// prompt to log in or update account info
 		if ( ! class_exists( 'Facebook_Admin_Login' ) )
@@ -90,7 +90,8 @@ class Facebook_Social_Publisher_Settings {
 		$facebook_user_data = Facebook_User::get_user_meta( $this->current_user->ID, 'fb_data', true );
 		if ( is_array( $facebook_user_data ) && isset( $facebook_user_data['fb_uid'] ) ) {
 			$this->user_associated_with_facebook_account = true;
-			$this->user_permissions = $facebook->get_current_user_permissions( $this->current_user );
+			if ( isset( $facebook ) || ( isset( $facebook_loader ) && $facebook_loader->load_php_sdk() ) )
+				$this->user_permissions = $facebook->get_current_user_permissions( $this->current_user );
 			if ( ! is_array( $this->user_permissions ) )
 				$this->user_permissions = array();
 		} else {
@@ -215,9 +216,9 @@ class Facebook_Social_Publisher_Settings {
 	 * @return array associative array of id, name, and access token for pages with create content permissions
 	 */
 	public static function get_publishable_pages_for_current_user() {
-		global $facebook;
+		global $facebook, $facebook_loader;
 
-		if ( ! isset( $facebook ) )
+		if ( ! isset( $facebook ) && ! ( isset( $facebook_loader ) && $facebook_loader->load_php_sdk() ) )
 			return array();
 
 		try {
@@ -385,8 +386,6 @@ class Facebook_Social_Publisher_Settings {
 	 * @return array clean option sets.
 	 */
 	public static function sanitize_publish_options( $options ) {
-		global $facebook;
-
 		if ( ! is_array( $options ) || empty( $options ) )
 			return array();
 

--- a/admin/social-publisher/mentions/mentions-search.php
+++ b/admin/social-publisher/mentions/mentions-search.php
@@ -31,7 +31,7 @@ class Facebook_Mentions_Search {
 	 * @since 1.2
 	 */
 	public static function search_endpoint() {
-		global $facebook;
+		global $facebook, $facebook_loader;
 
 		header( 'Content-Type: application/json; charset=utf-8', true );
 
@@ -49,7 +49,7 @@ class Facebook_Mentions_Search {
 			exit;
 		}
 
-		if ( ! isset( $facebook ) ) {
+		if ( ! isset( $facebook ) && ! ( isset( $facebook_loader ) && $facebook_loader->load_php_sdk() ) ) {
 			status_header( 403 );
 			echo json_encode( array( 'error' => __( 'Facebook credentials not properly configured on the server', 'facebook' ) ) );
 			exit;

--- a/facebook-user.php
+++ b/facebook-user.php
@@ -13,9 +13,9 @@ class Facebook_User {
 	 * @since 1.0
 	 */
 	public static function extend_access_token() {
-		global $facebook;
+		global $facebook, $facebook_loader;
 
-		if ( isset( $facebook ) )
+		if ( isset( $facebook ) || ( isset( $facebook_loader ) && $facebook_loader->load_php_sdk() ) )
 			$facebook->setExtendedAccessToken();
 	}
 
@@ -25,9 +25,9 @@ class Facebook_User {
 	 * @since 1.0
 	 */
 	public static function get_current_user( $fields = array() ) {
-		global $facebook;
+		global $facebook, $facebook_loader;
 
-		if ( ! isset( $facebook ) )
+		if ( ! isset( $facebook ) && ! ( isset( $facebook_loader ) && $facebook_loader->load_php_sdk() ) )
 			return;
 
 		$params = array( 'ref' => 'fbwpp' );
@@ -109,9 +109,9 @@ class Facebook_User {
 	 * @return array permissions array returned by Facebook Graph API
 	 */
 	public static function get_permissions() {
-		global $facebook;
+		global $facebook, $facebook_loader;
 
-		if ( ! isset( $facebook ) )
+		if ( ! isset( $facebook ) && ! ( isset( $facebook_loader ) && $facebook_loader->load_php_sdk() ) )
 			return array();
 
 		$current_user = wp_get_current_user();
@@ -135,9 +135,9 @@ class Facebook_User {
 	 * @return bool true if Facebook information present for current user and publish permissions exist
 	 */
 	public static function can_publish_to_facebook() {
-		global $facebook;
+		global $facebook, $facebook_loader;
 
-		if ( ! isset( $facebook ) )
+		if ( ! isset( $facebook ) && ! ( isset( $facebook_loader ) && $facebook_loader->load_php_sdk() ) )
 			return false;
 
 		$current_user = wp_get_current_user();
@@ -196,6 +196,24 @@ class Facebook_User {
 		}
 
 		return $authors;
+	}
+
+	/**
+	 * Get the Facebook user identifier associated with the given WordPress user identifier, if one exists
+	 *
+	 * @since 1.2
+	 * @param int $wordpress_user_id WordPress user identifier
+	 * @return string Facebook user identifier
+	 */
+	public static function get_facebook_profile_id( $wordpress_user_id ) {
+		if ( ! ( is_int( $wordpress_user_id ) && $wordpress_user_id ) )
+			return '';
+
+		$facebook_user_data = self::get_user_meta( $wordpress_user_id, 'fb_data', true );
+		if ( is_array( $facebook_user_data ) && isset( $facebook_user_data['fb_uid'] ) )
+			return $facebook_user_data['fb_uid'];
+
+		return '';
 	}
 }
 

--- a/includes/facebook-php-sdk/class-facebook-wp.php
+++ b/includes/facebook-php-sdk/class-facebook-wp.php
@@ -95,6 +95,65 @@ class Facebook_WP_Extend extends WP_Facebook {
 	}
 
 	/**
+	 * Invoke the Graph API for server-to-server communication using an application access token (no user session)
+	 *
+	 * @since 1.2
+	 * @param string $path The Graph API URI endpoint path component
+	 * @param string $method The HTTP method (default 'GET')
+	 * @param array $params The query/post data
+	 *
+	 * @return mixed The decoded response object
+	 * @throws WP_FacebookApiException
+	 */
+	public static function graph_api_with_app_access_token( $path, $method = 'GET', $params = array() ) {
+		global $facebook_loader, $wp_version;
+
+		if ( ! ( isset( $facebook_loader ) && $facebook_loader->app_access_token_exists() && is_string( $path ) ) )
+			return;
+
+		$path = ltrim( $path, '/' ); // normalize the leading slash
+		if ( ! $path )
+			return;
+
+		if ( ! in_array( $method, array( 'GET', 'POST', 'DELETE' ), true ) )
+			$method = 'GET';
+		if ( ! is_array( $params ) )
+			$params = array();
+		$params['access_token'] = $facebook_loader->credentials['access_token'];
+		foreach ( $params as $key => $value ) {
+			if ( ! is_string( $value ) )
+				$params[$key] = json_encode( $value );
+		}
+
+		$url = self::$DOMAIN_MAP['graph'] . $path;
+		$http_args = array(
+			'redirection' => 0,
+			'httpversion' => '1.1',
+			'sslverify' => false, // warning: might be overridden by 'https_ssl_verify' filter
+			'user-agent' => apply_filters( 'http_headers_useragent', 'WordPress/' . $wp_version . '; ' . get_bloginfo( 'url' ) . '; facebook-php-' . self::VERSION . '-wp' )
+		);
+
+		if ( $method === 'GET' ) {
+			if ( ! empty( $params ) )
+				$url .= '?' . http_build_query( $params, '', '&' );
+			$http_args['timeout'] = 5;
+			$response = self::handle_response( wp_remote_get( $url, $http_args ) );
+		} else {
+			// WP_HTTP does not support DELETE verb. store as method param for interpretation by Facebook Graph API server
+			if ( $method === 'DELETE' )
+				$params['method'] = 'DELETE';
+			$http_args['timeout'] = 60;
+			$http_args['body'] = http_build_query( $params, '', '&' );
+			$http_args['headers'] = array( 'Connection' => 'close' , 'Content-type' => 'application/x-www-form-urlencoded' );
+
+			$response = self::handle_response( wp_remote_post( $url, $http_args ) );
+		}
+
+		if ( isset( $response ) && $response )
+			return json_decode( $response, true );
+	}
+
+	/**
 	 * Request current application permissions for an authenticated Facebook user
 	 *
 	 * @since 1.1

--- a/open-graph-protocol.php
+++ b/open-graph-protocol.php
@@ -333,6 +333,11 @@ class Facebook_Open_Graph_Protocol {
 			if ( $description )
 				$meta_tags[ self::OGP_NS . 'description'] = $description;
 
+			$facebook_user_data = Facebook_User::get_user_meta( $author_id, 'fb_data', true );
+			if ( is_array( $facebook_user_data ) && isset( $facebook_user_data['third_party_id'] ) )
+					$meta_tags[ self::FB_NS . 'profile_id' ] = $facebook_user_data['third_party_id'];
+			unset( $facebook_user_data );
+
 			// no need to show username if there is only one
 			if ( is_multi_author() )
 				$meta_tags[ self::PROFILE_NS . 'username' ] = get_the_author_meta( 'login', $author_id );

--- a/readme.txt
+++ b/readme.txt
@@ -100,7 +100,7 @@ The [Comments Box social plugin](https://developers.facebook.com/docs/reference/
 == Upgrade Notice ==
 
 = 1.2 =
-Mention tagging support. Explicit sharing to Facebook Timeline and/or Facebook Page.
+App access token support. Mention tagging support. Explicit sharing to Facebook Timeline and/or Facebook Page.
 
 = 1.1.11 =
 Like Box widget. Improved locale selector. Bugfix publishing to a Facebook Page.
@@ -144,6 +144,8 @@ Security fixes. Improved customization and debugging of settings. l10n and i18n 
 == Changelog ==
 
 = 1.2 =
+* Post to Timeline now uses an [app access token](https://developers.facebook.com/docs/concepts/login/access-tokens-and-types/#appaccess) to communicate with Facebook servers without needing an active Facebook user session. Improves XML-RPC compatibility and wp-admin performance.
+* The Facebook PHP SDK is now loaded as needed, not with every admin request.
 * [Mention tagging](https://developers.facebook.com/docs/technical-guides/opengraph/mention-tagging/) Facebook friends and Facebook pages replaces previous mention meta boxes for friends and pages.
 * Removed mention display alongside a post. Mentions are constructed in a custom Facebook message.
 

--- a/social-plugins/class-facebook-comments.php
+++ b/social-plugins/class-facebook-comments.php
@@ -166,13 +166,15 @@ class Facebook_Comments {
 	 * @return array list of comments
 	 */
 	public static function get_comments_by_url( $url ) {
-		global $facebook;
+		global $facebook_loader;
 
-		if ( ! ( isset( $facebook ) && is_string( $url ) && $url ) )
+		if ( ! ( isset( $facebook_loader ) && $facebook_loader->app_access_token_exists() && is_string( $url ) && $url ) )
 			return array();
 
+		if ( ! class_exists( 'Facebook_WP_Extend' ) )
+			require_once( $facebook_loader->plugin_directory . 'includes/facebook-php-sdk/class-facebook-wp.php' );
 		try {
-			$comments = $facebook->api( '/comments', array( 'id' => $url ) );
+			$comments = Facebook_WP_Extend::graph_api_with_app_access_token( 'comments', 'GET', array( 'id' => $url ) );
 		} catch ( WP_FacebookApiException $e ) {
 			return array();
 		}


### PR DESCRIPTION
[Facebook application access token](https://developers.facebook.com/docs/concepts/login/access-tokens-and-types/#appaccess) supports server-to-server communication without an active user session, acting on previously granted permissions for each associated user. Switch to app access tokens for requests not requiring a logged-in Facebook user with an active session tied to the site's app id.

Post to Timeline posts to the Timeline of the post author, not the person who took the post public (only if the post author has authenticated and authorized the Facebook app to post on his or her behalf). Mobile users taking advantage of XML-RPC posting should be able to send their posts to Facebook.

Comments output in a noscript element for SEO purposes no longer load through Facebook PHP methods.

The Facebook PHP SDK is loaded on an as-needed basis and saved to the same `$facebook` global previously referenced for reuse later in the request.

Publish to stream permissions for the current user and Facebook application is no longer verified with each load of a post edit/create screen. The Facebook token for the user is no longer extended with each admin page load.
