### PR TITLE
Use app access token on settings debugger page

### DIFF
--- a/admin/social-publisher/mentions/mentions-search.php
+++ b/admin/social-publisher/mentions/mentions-search.php
@@ -12,7 +12,7 @@ class Facebook_Mentions_Search {
 	 * @since 1.2
 	 * @var int
 	 */
-	const MAX_RESULTS = 10;
+	const MAX_RESULTS = 8;
 
 	/**
 	 * Respond to WordPress admin AJAX requests
@@ -61,7 +61,7 @@ class Facebook_Mentions_Search {
 			exit;
 		}
 
-		$results = self::search_friends( $search_term, 5 );
+		$results = self::search_friends( $search_term, self::MAX_RESULTS / 2 );
 		$results = array_merge( $results, self::search_pages( $search_term, self::MAX_RESULTS - count($results) ) );
 		if ( empty( $results ) ) {
 			status_header( 404 );
@@ -80,7 +80,7 @@ class Facebook_Mentions_Search {
 	 * @param int $limit maximum number of results
 	 * @return array friend results
 	 */
-	public static function search_friends( $search_term, $limit = 5 ) {
+	public static function search_friends( $search_term, $limit = 4 ) {
 		global $facebook;
 
 		$facebook_user_id = $facebook->getUser();
@@ -142,7 +142,7 @@ class Facebook_Mentions_Search {
 	 * @param int $limit maximum number of results
 	 * @return array pages results
 	 */
-	public static function search_pages( $search_term, $limit = 5 ) {
+	public static function search_pages( $search_term, $limit = 4 ) {
 		global $facebook, $facebook_loader;
 
 		$cache_key = 'facebook_12_pages_' . $search_term;

--- a/includes/facebook-php-sdk/class-facebook-wp.php
+++ b/includes/facebook-php-sdk/class-facebook-wp.php
@@ -120,6 +120,8 @@ class Facebook_WP_Extend extends WP_Facebook {
 		if ( ! is_array( $params ) )
 			$params = array();
 		$params['access_token'] = $facebook_loader->credentials['access_token'];
+		if ( ! isset( $params['ref'] ) )
+			$params['ref'] = 'fbwpp';
 		foreach ( $params as $key => $value ) {
 			if ( ! is_string( $value ) )
 				$params[$key] = json_encode( $value );
@@ -197,25 +199,15 @@ class Facebook_WP_Extend extends WP_Facebook {
 	/**
 	 * Retrieve Facebook permissions assigned to the application by a specific Facebook user id
 	 *
-	 * @since 1.1.6
+	 * @since 1.2
 	 * @param string $facebook_id Facebook user identifier
 	 * @return array Facebook permissions
 	 */
-	public function get_permissions_by_facebook_user_id( $facebook_id ) {
+	public static function get_permissions_by_facebook_user_id( $facebook_id ) {
 		if ( ! ( is_string( $facebook_id ) && $facebook_id ) )
 			return array();
 
-		try {
-			$response = $this->api( '/' . $facebook_id . '/permissions', 'GET', array( 'ref' => 'fbwpp' ) );
-		} catch ( WP_FacebookApiException $e ) {
-			$error_result = $e->getResult();
-			if ( $error_result && isset( $error_result['error_code'] ) ) {
-				// try to extend access token if request failed
-				if ( $error_result['error_code'] === 2500 )
-					$this->setExtendedAccessToken();
-			}
-			return array();
-		}
+		$response = self::graph_api_with_app_access_token( $facebook_id . '/permissions', 'GET' );
 
 		if ( is_array( $response ) && isset( $response['data'][0] ) ) {
 			$response = $response['data'][0];


### PR DESCRIPTION
Use app access token to retrieve Facebook application permissions information for each WordPress user.

Lower maximum number of search results from JSON endpoint used for mentions search to 8 by default. More closely matches a typical display area of jQuery UI autocomplete and edit post layout.
