### PR TITLE
attempt to migrate settings during admin_init

### DIFF
--- a/admin/settings-app.php
+++ b/admin/settings-app.php
@@ -232,8 +232,6 @@ class Facebook_Application_Settings {
 	 * @param array $options form options values
 	 */
 	public static function sanitize_options( $options ) {
-		global $facebook_loader;
-
 		// start fresh
 		$clean_options = array();
 
@@ -272,7 +270,7 @@ class Facebook_Application_Settings {
 		// store an application access token and verify additional data
 		if ( isset( $clean_options['app_id'] ) && isset( $clean_options['app_secret'] ) ) {
 			if ( ! class_exists( 'Facebook_WP_Extend' ) )
-				require_once( $facebook_loader->plugin_directory . 'includes/facebook-php-sdk/class-facebook-wp.php' );
+				require_once( dirname( dirname(__FILE__) ) . '/includes/facebook-php-sdk/class-facebook-wp.php' );
 
 			$facebook_php_sdk = new Facebook_WP_Extend( array(
 				'appId' => $clean_options['app_id'],

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -20,7 +20,7 @@ class Facebook_Settings {
 	 * @since 1.1
 	 */
 	public static function init() {
-		self::migrate_options();
+		add_action( 'admin_init', array( 'Facebook_Settings', 'migrate_options' ), 0, 0 );
 		add_action( 'admin_menu', array( 'Facebook_Settings', 'settings_menu_items' ) );
 		add_filter( 'plugin_action_links', array( 'Facebook_Settings', 'plugin_action_links' ), 10, 2 );
 		add_action( 'admin_init', array( 'Facebook_Settings', 'load_social_settings' ), 1 );

--- a/facebook-user.php
+++ b/facebook-user.php
@@ -147,7 +147,7 @@ class Facebook_User {
 		if ( ! ( is_array( $facebook_user_data ) && isset( $facebook_user_data['fb_uid'] ) ) )
 			return false;
 
-		if ( Facebook_User::get_user_meta( $current_user->ID, 'facebook_timeline_disabled', true ) )
+		if ( self::get_user_meta( $current_user->ID, 'facebook_timeline_disabled', true ) )
 			return false;
 
 		$permissions = $facebook->get_current_user_permissions( $current_user );

--- a/facebook.php
+++ b/facebook.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package Facebook
- * @version 1.2.1
+ * @version 1.2.2
  */
 /*
 Plugin Name: Facebook
@@ -9,7 +9,7 @@ Plugin URI: http://wordpress.org/extend/plugins/facebook/
 Description: Facebook for WordPress. Make your site deeply social in just a couple of clicks.
 Author: Facebook
 Author URI: https://developers.facebook.com/wordpress/
-Version: 1.2.1
+Version: 1.2.2
 License: GPL2
 License URI: license.txt
 Domain Path: /languages/
@@ -28,7 +28,7 @@ class Facebook_Loader {
 	 * @since 1.1
 	 * @var string
 	 */
-	const VERSION = '1.2.1';
+	const VERSION = '1.2.2';
 
 	/**
 	 * Default Facebook locale

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires at least: 3.3
 Tested up to: 3.5.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
-Stable tag: 1.2.1
+Stable tag: 1.2.2
 
 Make your WordPress site social in a couple of clicks, powered by Facebook.
 
@@ -99,6 +99,9 @@ The [Comments Box social plugin](https://developers.facebook.com/docs/reference/
 
 == Upgrade Notice ==
 
+= 1.2.2 =
+Improve performance of settings migration from old versions of the plugin.
+
 = 1.2.1 =
 Fixes an issue with author pages and Open Graph protocol.
 
@@ -146,15 +149,18 @@ Security fixes. Improved customization and debugging of settings. l10n and i18n 
 
 == Changelog ==
 
+= 1.2.2 =
+* Improve performance of settings migration from old versions of the plugin
+
 = 1.2.1 =
-* Fix: Properly display Open Graph protocol data on author page.
+* Fix: Properly display Open Graph protocol data on author page
 
 = 1.2 =
-* Post to Timeline now uses an [app access token](https://developers.facebook.com/docs/concepts/login/access-tokens-and-types/#appaccess) to communicate with Facebook servers without needing an active Facebook user session. Improves XML-RPC compatibility and wp-admin performance.
-* The Facebook PHP SDK is now loaded as needed, not with every admin request.
-* [Mention tagging](https://developers.facebook.com/docs/technical-guides/opengraph/mention-tagging/) Facebook friends and Facebook pages replaces previous mention meta boxes for friends and pages.
-* Removed mention display alongside a post. Mentions are constructed in a custom Facebook message.
-* Associate a WordPress account with a Facebook account from the edit profile page.
+* Post to Timeline now uses an [app access token](https://developers.facebook.com/docs/concepts/login/access-tokens-and-types/#appaccess) to communicate with Facebook servers without needing an active Facebook user session. Improves XML-RPC compatibility and wp-admin performance
+* The Facebook PHP SDK is now loaded as needed, not with every admin request
+* [Mention tagging](https://developers.facebook.com/docs/technical-guides/opengraph/mention-tagging/) Facebook friends and Facebook pages replaces previous mention meta boxes for friends and pages
+* Removed mention display alongside a post. Mentions are constructed in a custom Facebook message
+* Associate a WordPress account with a Facebook account from the edit profile page
 
 = 1.1.11 =
 * Added [Like Box](https://developers.facebook.com/docs/reference/plugins/like-box/) widget for Facebook Page promotion


### PR DESCRIPTION
move migrate options function to `admin_init`. run after `$facebook_loader` is present and initial functionality loaded
