### PR TITLE
Post to feed by default. Offer OG action opt-in

### DIFF
--- a/admin/social-publisher/social-publisher.php
+++ b/admin/social-publisher/social-publisher.php
@@ -237,13 +237,12 @@ class Facebook_Social_Publisher {
 		if ( ! $old_status_object || ( isset( $old_status_object->public ) && $old_status_object->public ) )
 			return;
 
-		if ( isset( $post->post_author ) && self::user_can_publish_to_facebook( (int) $post->post_author ) ) {			
-			self::publish_to_facebook_profile( $post );
-		}
+		if ( isset( $post->post_author ) && self::user_can_publish_to_facebook( (int) $post->post_author ) )		
+			add_action( 'wp_insert_post', array( 'Facebook_Social_Publisher', 'publish_to_facebook_profile' ), 10, 2 );
 
-		$page_to_publish = self::get_publish_page();
-		if ( ! empty( $page_to_publish ) )
-			self::publish_to_facebook_page( $post, $page_to_publish );
+		$publish_page = self::get_publish_page();
+		if ( ! empty( $publish_page ) )
+			add_action( 'wp_insert_post', array( 'Facebook_Social_Publisher', 'publish_to_facebook_page' ), 10, 2 );
 	}
 
 	/**
@@ -251,17 +250,14 @@ class Facebook_Social_Publisher {
 	 *
 	 * @since 1.0
 	 * @link https://developers.facebook.com/docs/reference/api/page/#posts Facebook Graph API create page post
+	 * @param int $post_id post identifier
 	 * @param stdClass $post post object
-	 * @param array $facebook_page stored Facebook page data
 	 */
-	public static function publish_to_facebook_page( $post, $facebook_page = null ) {
+	public static function publish_to_facebook_page( $post_id, $post ) {
 		global $facebook_loader;
 
-		if ( ! ( $post && isset( $post->ID ) ) )
-			return;
-
-		$post_id = $post->ID;
-		if ( ! $post_id )
+		$post_id = absint( $post_id );
+		if ( ! ( $post && $post_id ) )
 			return;
 
 		// check if this post has previously been posted to the Facebook page
@@ -279,8 +275,6 @@ class Facebook_Social_Publisher {
 		if ( $meta_box_present && get_post_meta( $post_id, Facebook_Social_Publisher_Meta_Box_Page::POST_META_KEY_FEATURE_ENABLED, true ) === '0' )
 			return;
 
-		// thanks to Tareq Hasan on http://wordpress.org/support/topic/plugin-facebook-bug-problems-when-publishing-to-a-page
-		$post = get_post( $post );
 		setup_postdata( $post );
 
 		$post_type = get_post_type( $post );
@@ -291,6 +285,7 @@ class Facebook_Social_Publisher {
 		if ( ! empty( $post->post_password ) )
 			return;
 
+		$facebook_page = self::get_publish_page();
 		if ( ! $facebook_page )
 			$facebook_page = get_option( 'facebook_publish_page' );
 		if ( ! ( is_array( $facebook_page ) && ! empty( $facebook_page['access_token'] ) && ! empty( $facebook_page['id'] ) && isset( $facebook_page['name'] ) ) )
@@ -371,15 +366,15 @@ class Facebook_Social_Publisher {
 	 * Publish a post to a Facebook Timeline
 	 *
 	 * @since 1.0
+	 * @param int $post_id post identifier
 	 * @param stdClass $post post object
 	 */
-	public static function publish_to_facebook_profile( $post ) {
+	public static function publish_to_facebook_profile( $post_id, $post ) {
 		global $facebook_loader;
 
-		if ( ! ( isset( $facebook_loader ) && $facebook_loader->app_access_token_exists() && isset( $post ) && $post && isset( $post->ID ) ) )
+		$post_id = absint( $post_id );
+		if ( ! ( isset( $facebook_loader ) && $facebook_loader->app_access_token_exists() && $post && $post_id ) )
 			return;
-
-		$post_id = $post->ID;
 
 		// does the current post have an existing Facebook post id stored? no need to publish again
 		if ( get_post_meta( $post_id, 'fb_author_post_id', true ) )
@@ -394,7 +389,6 @@ class Facebook_Social_Publisher {
 		if ( $meta_box_present && get_post_meta( $post_id, Facebook_Social_Publisher_Meta_Box_Profile::POST_META_KEY_FEATURE_ENABLED, true ) === '0' )
 			return;
 
-		$post = get_post( $post );
 		setup_postdata( $post );
 
 		$post_type = get_post_type( $post );
@@ -421,8 +415,22 @@ class Facebook_Social_Publisher {
 		if ( ! $link )
 			return;
 
-		$story = array( 'article' => $link );
-		if ( $meta_box_present )
+		$og_action = false;
+		if ( ! class_exists( 'Facebook_Social_Publisher_Settings' ) )
+			require_once( dirname( dirname( __FILE__ ) ) . '/settings-social-publisher.php' );
+		if ( get_option( Facebook_Social_Publisher_Settings::OPTION_OG_ACTION ) )
+			$og_action = true;
+
+		$path = $author_facebook_id . '/';
+		if ( $og_action ) {
+			$story = array( 'article' => $link );
+			$path .= 'news.publishes';
+		} else {
+			$story = array( 'link' => $link );
+			$path .= 'feed';
+		}
+
+		if ( $og_action && $meta_box_present )
 			$story['fb:explicitly_shared'] = 'true';
 		$message = get_post_meta( $post_id, Facebook_Social_Publisher_Meta_Box_Profile::POST_META_KEY_MESSAGE, true );
 		if ( is_string( $message ) && $message )
@@ -433,7 +441,7 @@ class Facebook_Social_Publisher {
 
 		$status_messages = array();
 		try {
-			$publish_result = Facebook_WP_Extend::graph_api_with_app_access_token( $author_facebook_id . '/news.publishes', 'POST', $story );
+			$publish_result = Facebook_WP_Extend::graph_api_with_app_access_token( $path, 'POST', $story );
 
 			if ( isset( $publish_result['id'] ) ) {
 				update_post_meta( $post_id, 'fb_author_post_id', sanitize_text_field( $publish_result['id'] ) );


### PR DESCRIPTION
Setting up an Open Graph action - object pair with action permissions is a frustrating barrier to entry for webmasters. The approved action provides better news feed visibility and content highlighting than the generic feed endpoint yet it's beneficial for the plugin to have some basic functionality without much configuration. This pull request introduces an opt-in checkbox on the Social Publisher settings page to enable publishing to Facebook using the Open Graph news.publishes action and its additional properties.

Mentions tagging is not available without the Open Graph action and approved properties; the CSS and JavaScript in the post editor are removed if Open Graph action is not enabled.

This pull request moves the publish to Facebook functionality from the `transition_post_status` action to the `wp_insert_post` action at the end of the insert / update process, allowing our post meta save functionality in the `save_post` action to complete and other actors on the content about to become public.
