### PR TITLE
Move Facebook Comments Box code into a comments template

### DIFF
--- a/admin/settings-comments.php
+++ b/admin/settings-comments.php
@@ -142,6 +142,13 @@ class Facebook_Comments_Settings extends Facebook_Social_Plugin_Settings {
 			array( 'label_for' => 'facebook-comments-num-posts' )
 		);
 		add_settings_field(
+			'facebook-comments-order-by',
+			__( 'Order by', 'facebook' ),
+			array( &$this, 'display_order_by' ),
+			$this->hook_suffix,
+			$section
+		);
+		add_settings_field(
 			'facebook-comments-width',
 			__( 'Width', 'facebook' ),
 			array( &$this, 'display_width' ),
@@ -280,6 +287,42 @@ class Facebook_Comments_Settings extends Facebook_Social_Plugin_Settings {
 	}
 
 	/**
+	 * Ordering choices
+	 *
+	 * @since 1.3
+	 * @return array associative array of social plugin field value and translated label
+	 */
+	public static function order_by_choices() {
+		return array(
+			'social' => __( 'social', 'facebook' ),
+			'time' => _x( 'oldest first', 'display comments ordered from oldest to newest', 'facebook' ),
+			'reverse_time' => _x( 'newest first', 'display comments ordered from newest to oldest', 'facebook' )
+		);
+	}
+
+	/**
+	 * Customize comment order
+	 *
+	 * @since 1.3
+	 */
+	public function display_order_by() {
+		$key = 'order_by';
+		$choices = self::order_by_choices();
+		if ( isset( $this->existing_options[$key] ) )
+			$existing_value = $this->existing_options[$key];
+		else
+			$existing_value = 'social';
+
+		echo '<fieldset id="facebook-comments-' . $key . '">';
+		foreach( $choices as $choice => $label ) {
+			echo '<label><input type="radio" name="' . self::OPTION_NAME . '[' . $key  . ']" value="' . $choice . '"';
+			checked( $choice, $existing_value );
+			echo ' /> ' . esc_html( $label ) . '</label> ';
+		}
+		echo '</fieldset>';
+	}
+
+	/**
 	 * Translate HTML data response returned from Facebook social plugin builder into underscored keys and PHP values before saving
 	 *
 	 * @since 1.1
@@ -293,6 +336,10 @@ class Facebook_Comments_Settings extends Facebook_Social_Plugin_Settings {
 		if ( isset( $options['num-posts'] ) ) {
 			$options['num_posts'] = absint( $options['num-posts'] );
 			unset( $options['num-posts'] );
+		}
+		if ( isset( $options['order-by'] ) ) {
+			$options['order_by'] = $options['order-by'];
+			unset( $options['order-by'] );
 		}
 		if ( isset( $options['width'] ) )
 			$options['width'] = absint( $options['width'] );

--- a/facebook.php
+++ b/facebook.php
@@ -287,11 +287,8 @@ class Facebook_Loader {
 			if ( ! class_exists( 'Facebook_Comments' ) )
 				require_once( $this->plugin_directory . 'social-plugins/class-facebook-comments.php' );
 
-			add_filter( 'comments_array', array( 'Facebook_Comments', 'comments_array_filter' ), 10, 2 );
 			add_filter( 'comments_open', array( 'Facebook_Comments', 'comments_open_filter' ), 10, 2 );
 
-			// override comment count to a garbage number
-			add_filter( 'get_comments_number', array( 'Facebook_Comments', 'get_comments_number_filter' ), 10, 2 );
 			// display comments number if used in template
 			add_filter( 'comments_number', array( 'Facebook_Comments', 'comments_number_filter' ), 10, 2 );
 		}
@@ -335,8 +332,7 @@ class Facebook_Loader {
 				if ( ! class_exists( 'Facebook_Comments' ) )
 					require_once( $this->plugin_directory . 'social-plugins/class-facebook-comments.php' );
 
-				add_filter( 'the_content', array( 'Facebook_Comments', 'the_content_comments_box' ), $priority );
-				add_action( 'wp_enqueue_scripts', array( 'Facebook_Comments', 'css_hide_comments' ), 0 );
+				add_filter( 'comments_template', array( 'Facebook_Comments', 'comments_template' ) );
 			}
 		}
 
@@ -497,6 +493,16 @@ class Facebook_Loader {
 				require_once( dirname(__FILE__) . '/extras/google-analytics.php' );
 			add_filter( 'yoast-ga-push-after-pageview', array( 'Facebook_Google_Analytics', 'gaq_filter' ) );
 		}
+	}
+
+	/**
+	 * Useful for blanking a string filter
+	 *
+	 * @since 1.3
+	 * @return string empty string
+	 */
+	public static function __return_empty_string() {
+		return '';
 	}
 }
 

--- a/social-plugins/class-facebook-comments-box.php
+++ b/social-plugins/class-facebook-comments-box.php
@@ -27,6 +27,7 @@ class Facebook_Comments_Box {
 
 	/**
 	 * Define a custom width in whole pixels
+	 * Minimum recommended width: 400 pixels
 	 *
 	 * @since 1.1
 	 * @var int
@@ -47,7 +48,7 @@ class Facebook_Comments_Box {
 	 * @since 1.1.11
 	 * @var array
 	 */
-	public static $colorscheme_choices = array( 'light', 'dark' );
+	public static $colorscheme_choices = array( 'light' => true, 'dark' => true );
 
 	/**
 	 * The number of comments to show by default
@@ -56,6 +57,22 @@ class Facebook_Comments_Box {
 	 * @var int
 	 */
 	protected $num_posts;
+
+	/**
+	 * The order to use when displaying comments
+	 *
+	 * @since 1.3
+	 * @var string
+	 */
+	protected $order_by;
+
+	/**
+	 * Choices for the order_by property
+	 *
+	 * @since 1.3
+	 * @var string
+	 */
+	public static $order_by_choices = array( 'social' => true, 'time' => true, 'reverse_time' => true );
 
 	/**
 	 * Should we force the mobile-optimized version?
@@ -110,7 +127,7 @@ class Facebook_Comments_Box {
 	 * @return Facebook_Comments_Box support chaining
 	 */
 	public function setColorScheme( $color_scheme ) {
-		if ( is_string( $color_scheme ) && in_array( $color_scheme, self::$colorscheme_choices, true ) )
+		if ( is_string( $color_scheme ) && $color_scheme && isset( self::$colorscheme_choices[$color_scheme] ) )
 			$this->colorscheme = $color_scheme;
 		return $this;
 	}
@@ -125,6 +142,20 @@ class Facebook_Comments_Box {
 	public function setNumPosts( $num ) {
 		if ( is_int( $num ) && $num > 0 )
 			$this->num_posts = $num;
+		return $this;
+	}
+
+	/**
+	 * Choose a social, chronological, or reverse chronological comment ordering
+	 *
+	 * @since 1.3
+	 * @see self::order_by_choices
+	 * @param string $order_by social|time|
+	 * @return Facebook_Comments_Box support chaining
+	 */
+	public function setOrderBy( $order_by ) {
+		if ( is_string( $order_by ) && $order_by && isset( self::$order_by_choices[$order_by] ) )
+			$this->order_by = $order_by;
 		return $this;
 	}
 
@@ -163,6 +194,9 @@ class Facebook_Comments_Box {
 		if ( isset( $values['colorscheme'] ) )
 			$comments_box->setColorScheme( $values['colorscheme'] );
 
+		if ( isset( $values['order_by'] ) )
+			$comments_box->setOrderBy( $values['order_by'] );
+
 		if ( isset( $values['mobile'] ) && ( $values['mobile'] === true || $values['mobile'] === 'true' || $values['mobile'] == 1 )  )
 			$comments_box->forceMobile();
 
@@ -190,6 +224,9 @@ class Facebook_Comments_Box {
 
 		if ( isset( $this->num_posts ) && is_int( $this->num_posts ) && $this->num_posts > 0 && $this->num_posts !== 10 )
 			$data['num-posts'] = $this->num_posts;
+
+		if ( isset( $this->order_by ) && $this->order_by !== 'social' )
+			$data['order-by'] = $this->order_by;
 
 		if ( isset( $this->mobile ) && $this->mobile === true )
 			$data['mobile'] = 'true';

--- a/social-plugins/comments.php
+++ b/social-plugins/comments.php
@@ -8,7 +8,10 @@ if ( post_password_required() )
 ?>
 
 <div id="comments" class="comments-area">
-<?php if ( have_comments() ) : ?>
+<?php if ( have_comments() ) :
+	add_filter( 'comment_reply_link', array( 'Facebook_Loader', '__return_empty_string' ) );
+	add_filter( 'post_comments_link', array( 'Facebook_Loader', '__return_empty_string' ) );
+?>
 	<h2 class="comments-title"><?php echo esc_html( apply_filters( 'facebook_wp_comments_title', __( 'Comments' ) ) ); ?></h2>
 	<ol class="comment-list"><?php
 		/**

--- a/social-plugins/comments.php
+++ b/social-plugins/comments.php
@@ -12,14 +12,21 @@ if ( post_password_required() )
 	add_filter( 'comment_reply_link', array( 'Facebook_Loader', '__return_empty_string' ) );
 	add_filter( 'post_comments_link', array( 'Facebook_Loader', '__return_empty_string' ) );
 ?>
-	<h2 class="comments-title"><?php echo esc_html( apply_filters( 'facebook_wp_comments_title', __( 'Comments' ) ) ); ?></h2>
-	<ol class="comment-list"><?php
+	<h2 class="comments-title"><?php echo esc_html( apply_filters( 'facebook_wp_comments_title', __( 'Comments' ) ) ); ?></h2><?php
+	$_comment_options = apply_filters( 'facebook_wp_list_comments', array( 'style' => 'ol' ) );
+	// correct filter if broken
+	if ( ! is_array( $_comment_options ) )
+		$_comment_options = array( 'style' => 'ol' );
+	else if ( ! ( isset( $_comment_options['style'] ) ) && in_array( $_comment_options['style'], array( 'ol', 'ul', 'div' ), true ) )
+		$_comment_options['style'] = 'ol';
+	?>
+	<<?php echo $_comment_options['style']; ?> class="comment-list"><?php
 		/**
 		 * List comments using the default WordPress comments output
 		 * Allow parameter overrides through facebook_wp_list_comments filter
 		 */
-		wp_list_comments( apply_filters( 'facebook_wp_list_comments', array( 'style' => 'ol' ) ) ); ?></ol><?php
-
+		wp_list_comments( $_comment_options ); ?></<?php echo $_comment_options['style']; ?>><?php
+	unset( $_comment_options );
 endif; // have_comments()
 
 $_facebook_comments = Facebook_Comments::comments_box();

--- a/social-plugins/comments.php
+++ b/social-plugins/comments.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * If the current post is protected by a password and the visitor has not yet
+ * entered the password we will return early without loading the comments.
+ */
+if ( post_password_required() )
+	return;
+?>
+
+<div id="comments" class="comments-area">
+<?php if ( have_comments() ) : ?>
+	<h2 class="comments-title"><?php echo esc_html( apply_filters( 'facebook_wp_comments_title', __( 'Comments' ) ) ); ?></h2>
+	<ol class="comment-list"><?php
+		/**
+		 * List comments using the default WordPress comments output
+		 * Allow parameter overrides through facebook_wp_list_comments filter
+		 */
+		wp_list_comments( apply_filters( 'facebook_wp_list_comments', array( 'style' => 'ol' ) ) ); ?></ol><?php
+
+endif; // have_comments()
+
+$_facebook_comments = Facebook_Comments::comments_box();
+if ( $_facebook_comments )
+	echo '<div id="respond">' . $_facebook_comments . '</div>';
+unset( $_facebook_comments );
+?>
+</div>

--- a/static/css/hide-wp-comments.css
+++ b/static/css/hide-wp-comments.css
@@ -1,3 +1,0 @@
-#respond, #commentform, #addcomment, #comment-form-wrap .entry-comments {
-	display: none;
-}

--- a/static/css/hide-wp-comments.min.css
+++ b/static/css/hide-wp-comments.min.css
@@ -1,1 +1,0 @@
-#respond,#commentform,#addcomment,#comment-form-wrap .entry-comments{display:none}


### PR DESCRIPTION
Load Facebook Comments box inside a custom comments template, overriding theme-specific comments template when Facebook comments are active for the post type.

Display previous WordPress comments without a reply link or WordPress comment form. Publishers may override the call to `wp_list_comments` by acting on the array passed to the `facebook_wp_list_comments` filter.

Include a new option to sort Facebook comments in chronological or reverse chronological order, overriding default sort of social.
