### PR TITLE
Simple fix for 2 minute hang references here: http://wordpress.org/support/topic/it-is-sooo-slow-and-php-fpms-slowlog-tell-who-is-to-blame

### DIFF
--- a/includes/facebook-php-sdk/class-facebook-wp.php
+++ b/includes/facebook-php-sdk/class-facebook-wp.php
@@ -119,6 +119,7 @@ class Facebook_WP_Extend extends WP_Facebook {
 			'redirection' => 0,
 			'httpversion' => '1.1',
 			'sslverify' => false, // warning: might be overridden by 'https_ssl_verify' filter
+			'headers' => array('Connection' => 'close'),
 			'user-agent' => apply_filters( 'http_headers_useragent', 'WordPress/' . $wp_version . '; ' . get_bloginfo( 'url' ) . '; facebook-php-' . self::VERSION . '-wp' )
 		);
 


### PR DESCRIPTION
...:graph_api() to avoid a two minute wait.
