### PR TITLE
integrate theme comment form properties

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -63,6 +63,8 @@ The development [source code for this plugin is available on Facebook's GitHub a
 * `facebook_settings_before_header_$hook_suffix` - add content to a settings page before the main page header section
 * `facebook_settings_after_header_$hook_suffix` - add content to a settings page after the main page header section
 * `facebook_settings_footer_$hook_suffix` - add content to a settings page below the wrapper div
+* `fb_comment_form_before` - comment form [pluggable action](http://codex.wordpress.org/Function_Reference/comment_form#Pluggable_actions "WordPress comment form pluggable action") replacing the WordPress `comment_form()` equivalent action `comment_form_before`
+* `fb_comment_form_after` - comment form [pluggable action](http://codex.wordpress.org/Function_Reference/comment_form#Pluggable_actions "WordPress comment form pluggable action") replacing the WordPress `comment_form()` equivalent action `comment_form_after`
 
 = Filters =
 

--- a/social-plugins/class-facebook-comments.php
+++ b/social-plugins/class-facebook-comments.php
@@ -382,7 +382,12 @@ class Facebook_Comments {
 
 		$comments_box = Facebook_Comments_Box::fromArray( $options );
 		if ( $comments_box ) {
-			$comments_jssdk_div = $comments_box->asHTML( array( 'class' => array( 'fb-social-plugin' ) ) );
+			$comments_box_attributes = array( 'class' => array( 'fb-social-plugin' ) );
+			$wp_comment_form_args = apply_filters( 'comment_form_defaults', array( 'source' => 'facebook', 'id_form' => 'commentform' ) );
+			if ( is_array( $wp_comment_form_args ) && isset( $wp_comment_form_args['id_form'] ) )
+				$comments_box_attributes['id'] = $wp_comment_form_args['id_form'];
+			unset( $wp_comment_form_args );
+			$comments_jssdk_div = $comments_box->asHTML( $comments_box_attributes );
 			if ( $comments_jssdk_div )
 				return "\n" . $comments_jssdk_div . "\n";
 		}

--- a/social-plugins/comments.php
+++ b/social-plugins/comments.php
@@ -33,8 +33,13 @@ if ( post_password_required() )
 endif; // have_comments()
 
 $_facebook_comments = Facebook_Comments::comments_box();
-if ( $_facebook_comments )
-	echo '<div id="respond" class="comments-area">' . $_facebook_comments . '</div>';
+if ( $_facebook_comments ) {
+	do_action( 'fb_comment_form_before' );
+	echo '<div id="respond">';
+	echo $_facebook_comments;
+	echo '</div>';
+	do_action( 'fb_comment_form_after' );
+}
 unset( $_facebook_comments );
 ?>
 </div>


### PR DESCRIPTION
try to match theme default id for comment form. add actions before and after comments box display similar to [comment_form()](http://codex.wordpress.org/Function_Reference/comment_form) behavior
