### PR TITLE
always show Comments Box order by property if set

### DIFF
--- a/social-plugins/class-facebook-comments-box.php
+++ b/social-plugins/class-facebook-comments-box.php
@@ -225,7 +225,7 @@ class Facebook_Comments_Box {
 		if ( isset( $this->num_posts ) && is_int( $this->num_posts ) && $this->num_posts > 0 && $this->num_posts !== 10 )
 			$data['num-posts'] = $this->num_posts;
 
-		if ( isset( $this->order_by ) && $this->order_by !== 'social' )
+		if ( isset( $this->order_by ) )
 			$data['order-by'] = $this->order_by;
 
 		if ( isset( $this->mobile ) && $this->mobile === true )


### PR DESCRIPTION
do not presume a default order-by. publisher may set his or her own default inside the comments tool at developers.facebook.com
