### PR TITLE
do not call session_start on WP_Facebook initialization

### DIFF
--- a/includes/facebook-php-sdk/facebook.php
+++ b/includes/facebook-php-sdk/facebook.php
@@ -47,9 +47,6 @@ class WP_Facebook extends WP_BaseFacebook
    * @see WP_BaseFacebook::__construct in facebook.php
    */
   public function __construct($config) {
-    if (!session_id()) {
-      session_start();
-    }
     parent::__construct($config);
     if (!empty($config['sharedSession'])) {
       $this->initSharedSession();


### PR DESCRIPTION
remove session_start() from WP_Facebook initialization. previously removed in 82c54a59367423d7b77067c86a2ad62f58b00ba5 then added back with Facebook PHP SDK update in f308c6bddd0cab48ad7a40ecc37c5901f85af015
