### PR TITLE
provide a comments closed equivalent for POSTs to wp-comments-post.php

### DIFF
--- a/social-plugins/class-facebook-comments.php
+++ b/social-plugins/class-facebook-comments.php
@@ -64,6 +64,23 @@ class Facebook_Comments {
 	}
 
 	/**
+	 * Kill attempts to comment on a post managed by Facebook Comments Box
+	 *
+	 * @since 1.3.1
+	 * @param int post_id post identifer
+	 */
+	public static function pre_comment_on_post( $post_id ) {
+		if ( ! $post_id )
+			return;
+		$_post = get_post( $post_id );
+		if ( $_post && self::comments_enabled_for_post_type( $_post ) ) {
+			// match comments closed message and behavior
+			do_action( 'comment_closed', $post_id );
+			wp_die( __('Sorry, comments are closed for this item.') );
+		}
+	}
+
+	/**
 	 * Overrides text displayed with comments number, inserting Facebook XFBML to be replaced by a number with the Facebook JavaScript SDK
 	 *
 	 * @param string $output number of comments text


### PR DESCRIPTION
The Facebook plugin for WordPress provides the opportunity to manage a post's comments through the [Comments Box social plugin](https://developers.facebook.com/docs/reference/plugins/comments/) stored and sorted on Facebook servers. The Comments Box removes the WordPress comment form from the page but does not currently reject new comments POSTed to [wp-comments-post.php](http://core.trac.wordpress.org/browser/trunk/wp-comments-post.php) for a post under its comments system.

Check if a new WordPress comment is submitted against a post with comments managed by the Facebook Comments Box social plugin. Reject these new comment attempts in the same way WordPress would reject the comment if the post was closed to new comments.
