### PR TITLE
always specify href for Like Button

### DIFF
--- a/social-plugins/social-plugins.php
+++ b/social-plugins/social-plugins.php
@@ -43,8 +43,7 @@ function facebook_the_content_like_button( $content ) {
 	if ( ! isset( $options['position'] ) )
 		return $content;
 
-	if ( ! is_singular( get_post_type( $post ) ) )
-		$options['href'] = apply_filters( 'facebook_rel_canonical', get_permalink( $post->ID ) );
+	$options['href'] = apply_filters( 'facebook_rel_canonical', get_permalink( $post->ID ) );
 
 	if ( $options['position'] === 'top' ) {
 		$options['ref'] = 'above-post';


### PR DESCRIPTION
improve compliance with [July 2013 Facebook changes](https://developers.facebook.com/roadmap/#q3_2013)
