### PR TITLE
update comments noscript fallback to support July 2013 Facebook Graph API change

### DIFF
--- a/social-plugins/class-facebook-comments.php
+++ b/social-plugins/class-facebook-comments.php
@@ -179,7 +179,7 @@ class Facebook_Comments {
 		if ( ! class_exists( 'Facebook_WP_Extend' ) )
 			require_once( $facebook_loader->plugin_directory . 'includes/facebook-php-sdk/class-facebook-wp.php' );
 		try {
-			$comments = Facebook_WP_Extend::graph_api_with_app_access_token( 'comments', 'GET', array( 'id' => $url ) );
+			$comments = Facebook_WP_Extend::graph_api_with_app_access_token( 'comments', 'GET', array( 'id' => $url, 'filter' => 'toplevel', 'fields' => 'id,from,created_time,message,comments.fields(id,from,created_time,message)' ) );
 		} catch ( WP_FacebookApiException $e ) {
 			return array();
 		}


### PR DESCRIPTION
Support [updated Facebook comment API](https://developers.facebook.com/blog/post/2013/04/03/new-apis-for-comment-replies/) retrieval required by July 10, 2013.

Reduce the total number of fields returned for each request, and therefore the size of the payload and parse, by explicitly specifying field parameters for toplevel comments and children.
