### PR TITLE
Add Facebook comments count to get_comments_number

### DIFF
--- a/facebook.php
+++ b/facebook.php
@@ -288,6 +288,8 @@ class Facebook_Loader {
 	 * @since 1.1
 	 */
 	public function public_init() {
+		global $facebook_loader;
+
 		// no feed filters yet
 		if ( is_feed() || is_404() )
 			return;
@@ -308,6 +310,11 @@ class Facebook_Loader {
 
 			// treat as if comments are open for post types with comments under management by Comments Box
 			add_filter( 'comments_open', array( 'Facebook_Comments', 'comments_open_filter' ), 10, 2 );
+
+			if ( isset( $facebook_loader ) && $facebook_loader->app_access_token_exists() ) {
+				// add Facebook comments count to WordPress comments count
+				add_filter( 'get_comments_number', array( 'Facebook_Comments', 'get_comments_number_filter' ), 10, 2 );
+			}
 
 			// display comments number XFBML for JS SDK interpretation if used in template
 			add_filter( 'comments_number', array( 'Facebook_Comments', 'comments_number_filter' ), 10, 2 );


### PR DESCRIPTION
Request a comment count for the post URL from Facebook servers, cache the result, and add the count to the existing WordPress comment count for the post.

Allows themes outputting the comments count int through [get_comments_number()](http://codex.wordpress.org/Template_Tags/get_comments_number) to receive a real comments count result at the time content is generated. Cache result for 15 minutes to match comment markup fallback cache time.

Continue to use XFBML value `<fb:comments-count>` for comment count display after interpretation by the Facebook JavaScript SDK by acting on the [comments_number()](http://codex.wordpress.org/Template_Tags/comments_number) function and its filter for a more accurate count outside the cached status of the parent webpage.
