### PR TITLE
remove mention of the facebook_mentions_classes filter in readme

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -79,7 +79,6 @@ The development [source code for this plugin is available on Facebook's GitHub a
 * `fb_rel_canonical` - customize the canonical URL used by Facebook for a post. Affects Open Graph protocol URL definitions, URL references sent in Open Graph actions, and more. default: result of `get_permalink()`
 * `facebook_comment_schema_org` - override output of search engine friendly comments content using [Schema.org microdata markup](http://googlewebmastercentral.blogspot.com/2011/06/introducing-schemaorg-search-engines.html)
 * `facebook_comments_number_more` - override the default "% Comments" text used to generate a client-side comments number. similar to WordPress' [comments_number](http://codex.wordpress.org/Function_Reference/comments_number) more parameter
-* `facebook_mentions_classes` - add or remove HTML classes from the parent HTML div element of mentions links
 * `fb_meta_tags` - Customize Open Graph protocol markup before it is output to the page
 * `facebook_ogp_prefixed` - true to always use prefixed properties (og:title) or false to use full IRI properties (http://ogp.me/ns#title)
 * `facebook_rdfa_mappings` - array of RDFa references with desired prefix. Used to remap Open Graph protocol properties from a full IRI to a prefix


### PR DESCRIPTION
The functionality referenced by this filter was removed with the old public site-facing mention tagging in February
