### PR TITLE
update git properties

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,13 +1,12 @@
 # Set default behaviour, in case users don't have core.autocrlf set.
 * text=auto
 
-# Explicitly declare text files we want to always be normalized and converted 
+# Explicitly declare text files we want to always be normalized and converted
 # to native line endings on checkout.
-*.c text
-*.h text
-
-# Declare files that will always have CRLF line endings on checkout.
-*.sln text eol=crlf
+*.css text
+*.html text diff=html
+*.js text
+*.php text diff=php
 
 # Denote all files that are truly binary and should not be modified.
 *.png binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
 .DS_Store
-fb_for_wp.kpf
-social-plugins/pom/build/


### PR DESCRIPTION
Specify EOL for PHP, JS, HTML, and CSS files instead of Visual Studio and C files.

Limit gitignore to most common auto-generated filesystem files
