### PR TITLE
support Facebook embedded posts as shortcode and embed URL

### DIFF
--- a/social-plugins/class-facebook-embedded-post.php
+++ b/social-plugins/class-facebook-embedded-post.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * Facebook Embedded post
+ *
+ * @since 1.5
+ * @link https://developers.facebook.com/docs/plugins/embedded-posts/ Facebook Embedded Posts
+ */
+class Facebook_Embedded_Post {
+	/**
+	 * Element and class name used in markup builders
+	 *
+	 * @since 1.1
+	 * @var string
+	 */
+	const ID = 'post';
+
+	/**
+	 * The Facebook URL representing public post by a person or page
+	 *
+	 * @since 1.5
+	 * @var string
+	 */
+	protected $href;
+
+	/**
+	 * I am an embedded post
+	 *
+	 * @since 1.5
+	 * @return string
+	 */
+	public function __toString() {
+		return 'Facebook Embedded Post';
+	}
+
+	/**
+	 * Setter for href attribute
+	 *
+	 * @since 1.5
+	 * @param string $url absolute URL
+	 * @return Facebook_Follow_Button support chaining
+	 */
+	public function setURL( $url ) {
+		$url = esc_url_raw( $url, array( 'http', 'https' ) );
+		if ( $url )
+			$this->href = $url;
+		return $this;
+	}
+
+	/**
+	 * convert an options array into an object
+	 *
+	 * @since 1.5
+	 * @param array $values associative array
+	 * @return Facebook_Embedded_Post embedded post object
+	 */
+	public static function fromArray( $values ) {
+		if ( ! ( is_array( $values ) && isset( $values['href'] ) ) )
+			return;
+
+		$embed = new Facebook_Embedded_Post();
+
+		if ( isset( $values['href'] ) && $values['href'] )
+			$embed->setURL( $values['href'] );
+
+		return $embed;
+	}
+
+	/**
+	 * Output Embedded Post with data-* attributes
+	 *
+	 * @since 1.5
+	 * @param array $div_attributes associative array. customize the returned div with id, class, or style attributes
+	 * @return HTML div or empty string
+	 */
+	public function asHTML( $div_attributes = array() ) {
+		if ( ! ( isset( $this->href ) && $this->href ) )
+			return '';
+
+		if ( ! class_exists( 'Facebook_Social_Plugin' ) )
+			require_once( dirname(__FILE__) . '/class-facebook-social-plugin.php' );
+
+		$div_attributes = Facebook_Social_Plugin::add_required_class( 'fb-' . self::ID, $div_attributes );
+		$div_attributes['data'] = array( 'href' => $this->href );
+
+		return Facebook_Social_Plugin::div_builder( $div_attributes );
+	}
+
+	/**
+	 * Output Embedded Post as XFBML
+	 *
+	 * @since 1.5
+	 * @return string XFBML markup
+	 */
+	public function asXFBML() {
+		if ( ! ( isset( $this->href ) && $this->href ) )
+			return '';
+
+		if ( ! class_exists( 'Facebook_Social_Plugin' ) )
+			require_once( dirname(__FILE__) . '/class-facebook-social-plugin.php' );
+
+		return Facebook_Social_Plugin::xfbml_builder( self::ID, array( 'href' => $this->href ) );
+	}
+}
+
+?>

--- a/social-plugins/class-facebook-embedded-post.php
+++ b/social-plugins/class-facebook-embedded-post.php
@@ -24,6 +24,16 @@ class Facebook_Embedded_Post {
 	protected $href;
 
 	/**
+	 * Show a border around the plugin
+	 * Default: true
+	 * Set to false to style the resulting iframe with your custom CSS
+	 *
+	 * @since 1.5
+	 * @var bool
+	 */
+	protected $show_border = true;
+
+	/**
 	 * I am an embedded post
 	 *
 	 * @since 1.5
@@ -38,12 +48,34 @@ class Facebook_Embedded_Post {
 	 *
 	 * @since 1.5
 	 * @param string $url absolute URL
-	 * @return Facebook_Follow_Button support chaining
+	 * @return Facebook_Embedded_Post support chaining
 	 */
 	public function setURL( $url ) {
 		$url = esc_url_raw( $url, array( 'http', 'https' ) );
 		if ( $url )
 			$this->href = $url;
+		return $this;
+	}
+
+	/**
+	 * Add a border to the box
+	 *
+	 * @since 1.5
+	 * @return Facebook_Embedded_Post support chaining
+	 */
+	public function showBorder() {
+		$this->show_border = true;
+		return $this;
+	}
+
+	/**
+	 * Hide the box border
+	 *
+	 * @since 1.5
+	 * @return Facebook_Embedded_Post support chaining
+	 */
+	public function hideBorder() {
+		$this->show_border = false;
 		return $this;
 	}
 
@@ -63,7 +95,33 @@ class Facebook_Embedded_Post {
 		if ( isset( $values['href'] ) && $values['href'] )
 			$embed->setURL( $values['href'] );
 
+		if ( isset( $values['show_border'] ) && ( $values['show_border'] === false || $values['show_border'] === 'false' || $values['show_border'] == 0 ) )
+			$embed->hideBorder();
+		else
+			$embed->showBorder();
+
 		return $embed;
+	}
+
+	/**
+	 * Convert the class to data-* attribute friendly associative array
+	 * will become data-key="value"
+	 * Exclude values if default
+	 *
+	 * @since 1.5
+	 * @return array associative array
+	 */
+	public function toHTMLDataArray() {
+		$data = array();
+		if ( ! ( isset( $this->href ) && $this->href ) )
+			return $data;
+
+		$data['href'] = $this->href;
+
+		if ( isset( $this->show_border ) && $this->show_border === false )
+			$data['show-border'] = 'false';
+
+		return $data;
 	}
 
 	/**
@@ -74,14 +132,16 @@ class Facebook_Embedded_Post {
 	 * @return HTML div or empty string
 	 */
 	public function asHTML( $div_attributes = array() ) {
-		if ( ! ( isset( $this->href ) && $this->href ) )
+		$data = $this->toHTMLDataArray();
+		// if no target href then do nothing
+		if ( empty( $data ) )
 			return '';
 
 		if ( ! class_exists( 'Facebook_Social_Plugin' ) )
 			require_once( dirname(__FILE__) . '/class-facebook-social-plugin.php' );
 
 		$div_attributes = Facebook_Social_Plugin::add_required_class( 'fb-' . self::ID, $div_attributes );
-		$div_attributes['data'] = array( 'href' => $this->href );
+		$div_attributes['data'] = $data;
 
 		return Facebook_Social_Plugin::div_builder( $div_attributes );
 	}
@@ -93,13 +153,15 @@ class Facebook_Embedded_Post {
 	 * @return string XFBML markup
 	 */
 	public function asXFBML() {
-		if ( ! ( isset( $this->href ) && $this->href ) )
+		$data = $this->toHTMLDataArray();
+		// if no target href then do nothing
+		if ( empty( $data ) )
 			return '';
 
 		if ( ! class_exists( 'Facebook_Social_Plugin' ) )
 			require_once( dirname(__FILE__) . '/class-facebook-social-plugin.php' );
 
-		return Facebook_Social_Plugin::xfbml_builder( self::ID, array( 'href' => $this->href ) );
+		return Facebook_Social_Plugin::xfbml_builder( self::ID, $data );
 	}
 }
 

--- a/social-plugins/shortcodes.php
+++ b/social-plugins/shortcodes.php
@@ -21,6 +21,8 @@ class Facebook_Shortcodes {
 		// Convert a Facebook URL possibly representing a public post into Facebook embedded post markup
 		wp_embed_register_handler( 'facebook_embedded_post_vanity', '#^https?://www\.facebook\.com/([A-Za-z0-9\.-]{2,50})/posts/([\d]+)#i', array( 'Facebook_Shortcodes', 'wp_embed_handler_embedded_post' ) );
 		wp_embed_register_handler( 'facebook_embedded_post_no_vanity', '#^https?://www\.facebook\.com/permalink\.php\?story_fbid=([\d]+)&id=([\d]+)#i', array( 'Facebook_Shortcodes', 'wp_embed_handler_embedded_post' ) );
+		wp_embed_register_handler( 'facebook_embedded_post_activity', '#^https?://www\.facebook\.com/([A-Za-z0-9\.-]{2,50})/activity/([\d]+)#i', array( 'Facebook_Shortcodes', 'wp_embed_handler_embedded_post' ) );
+		wp_embed_register_handler( 'facebook_embedded_post_question', '#^https?://www\.facebook\.com/questions/([\d]+)#i', array( 'Facebook_Shortcodes', 'wp_embed_handler_embedded_post' ) );
 		wp_embed_register_handler( 'facebook_embedded_post_photo', '#^https?://www\.facebook\.com/photo\.php\?fbid=([\d]+)#i', array( 'Facebook_Shortcodes', 'wp_embed_handler_embedded_post' ) );
 		wp_embed_register_handler( 'facebook_embedded_post_video', '#^https?://www\.facebook\.com/photo\.php\?v=([\d]+)#i', array( 'Facebook_Shortcodes', 'wp_embed_handler_embedded_post' ) );
 	}
@@ -195,7 +197,8 @@ class Facebook_Shortcodes {
 	 */
 	public static function embedded_post( $attributes, $content = null ) {
 		$options = shortcode_atts( array(
-			'href' => ''
+			'href' => '',
+			'show_border' => true
 		), $attributes, 'facebook_embed_post' );
 
 		$options['href'] = trim( $options['href'] );
@@ -203,10 +206,11 @@ class Facebook_Shortcodes {
 			return '';
 
 		if ( ! class_exists( 'Facebook_Embedded_Post' ) )
-		require_once( dirname(__FILE__) . '/class-facebook-embedded-post.php' );
+			require_once( dirname(__FILE__) . '/class-facebook-embedded-post.php' );
 
-		$embed = new Facebook_Embedded_Post();
-		$embed->setURL( $options['href'] );
+		$embed = Facebook_Embedded_Post::fromArray( $options );
+		if ( ! $embed )
+			return '';
 		return $embed->asHTML( array( 'class' => array( 'fb-social-plugin' ) ) );
 	}
 }


### PR DESCRIPTION
Support Facebook's new [Embedded Post social plugin](https://developers.facebook.com/docs/plugins/embedded-posts/) markup.

Introduces a new [shortcode](http://codex.wordpress.org/Shortcode), `facebook_embedded_post`, accepting a single required parameter: `href`.

The plugin will attempt to recognize possible Facebook post URLs capable of display inside the Embedded Post social plugin and register each URL pattern through [wp_embed_register_handler](https://codex.wordpress.org/Function_Reference/wp_embed_register_handler).

Embedded Post display is limited to [Facebook public content](https://www.facebook.com/help/203805466323736/) and may be initially limited to specific Facebook partners. The plugin acts as a helper for URLs that could be Facebook content URLs by passing the values to the Facebook SDK for JavaScript for interpretation and possible rendering of post content.
