### PR TITLE
use attached image and gallery functions from WP 3.6 if present

### DIFF
--- a/open-graph-protocol.php
+++ b/open-graph-protocol.php
@@ -416,7 +416,7 @@ class Facebook_Open_Graph_Protocol {
 
 		// get image attachments
 		if ( function_exists( 'get_attached_media' ) ) {
-			$images = get_attached_media( 'image' );
+			$images = get_attached_media( 'image', $post->ID );
 			if ( ! empty( $images ) ) {
 				foreach( $images as $i ) {
 					if ( ! isset( $i->ID ) )


### PR DESCRIPTION
Discover additional eligible full-sized images in a WordPress post using new functions from WordPress 3.6, if present. 

Use [get_attached_media](http://codex.wordpress.org/Function_Reference/get_attached_media) to highlight child image attachments of the current post.

Use [get_post_galleries](http://codex.wordpress.org/Function_Reference/get_post_galleries) to extract the attachment identifiers of images in post galleries.
