### PR TITLE
Display admin notice on app settings page if no HTTPS

### DIFF
--- a/admin/settings-app.php
+++ b/admin/settings-app.php
@@ -91,9 +91,24 @@ class Facebook_Application_Settings {
 			$options = array();
 		$this->existing_options = $options;
 
+		if ( ! wp_http_supports( array( 'ssl' => true ) ) )
+			add_action( 'admin_notices', array( 'Facebook_Application_Settings', 'admin_notice' ) );
+
 		$this->settings_api_init();
 
 		add_action( 'admin_enqueue_scripts', array( 'Facebook_Application_Settings', 'enqueue_scripts' ) );
+	}
+
+	/**
+	 * Warn of minimum requirements not met for app access token
+	 *
+	 * @since 1.5
+	 */
+	public static function admin_notice() {
+		echo '<div class="error">';
+		echo '<p>' . esc_html( __( 'Your server does not support communication with Facebook servers over HTTPS.', 'facebook' ) ) . '</p>';
+		echo '<p>' . esc_html( __( 'Facebook application functionality such as posting to your Facebook Timeline requires a HTTPS connection to Facebook servers.', 'facebook' ) ) . '</p>';
+		echo '</div>';
 	}
 
 	/**


### PR DESCRIPTION
Warn a site administrator if his server configuration does not support HTTPS over the [WordPress HTTP API](http://codex.wordpress.org/HTTP_API) before we attempt to exchange a supplied app id and app secret for an app access token during the settings sanitization process.
