### PR TITLE
remove conflicts alert for list of WP plugins with OGP output

### DIFF
--- a/admin/settings-app.php
+++ b/admin/settings-app.php
@@ -120,10 +120,6 @@ class Facebook_Application_Settings {
 		if ( ! isset( $this->hook_suffix ) )
 			return;
 
-		// notify of conflicts on the main settings page
-		// tie to an action to allow easy removal on sites/networks that rather not run checks
-		add_action( 'facebook_notify_plugin_conflicts', array( 'Facebook_Settings', 'plugin_conflicts' ) );
-
 		add_action( 'facebook_settings_after_header_' . $this->hook_suffix, array( 'Facebook_Application_Settings', 'after_header' ) );
 
 		Facebook_Settings::settings_page_template( $this->hook_suffix, __( 'Facebook for WordPress', 'facebook' ) );
@@ -156,8 +152,6 @@ class Facebook_Application_Settings {
 		$like_button->setFont( 'arial' );
 		$like_button->setReference( 'wp-admin' );
 		echo $like_button->asHTML();
-
-		do_action( 'facebook_notify_plugin_conflicts' );
 	}
 
 	/**

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -359,47 +359,5 @@ class Facebook_Settings {
 
 		return array();
 	}
-
-	/**
-	 * Check if the wordpress user has plugins that may conflict with the Facebook plugin due to Open Graph.
-	 * Display an admin dialog if conflicts found
-	 */
-	public static function plugin_conflicts() {
-		$og_conflicting_plugins = apply_filters( 'fb_conflicting_plugins', array(
-			'http://wordpress.org/extend/plugins/opengraph/' => true,
-			'http://wordbooker.tty.org.uk' => true,
-			'http://ottopress.com/wordpress-plugins/simple-facebook-connect/' => true,
-			'http://www.whiletrue.it' => true,
-			'http://aaroncollegeman.com/sharepress' => true
-		) );
-
-		// allow for short circuit
-		if ( ! is_array( $og_conflicting_plugins ) || empty( $og_conflicting_plugins ) )
-			return;
-
-		//fetch activated plugins
-		$plugins_list = get_option( 'active_plugins' );
-		if ( ! is_array( $plugins_list ) )
-			$plugins_list = array();
-
-		$conflicting_plugins = array();
-
-		// iterate through activated plugins, checking if they are in the list of conflict plugins
-		foreach ( $plugins_list as $val ) {
-			$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/' . $val );
-			if ( ! ( isset( $plugin_data['PluginURI'] ) && isset( $plugin_data['Name'] ) ) || $plugin_data['PluginURI'] === 'http://wordpress.org/extend/plugins/facebook/' )
-				continue;
-
-			if ( isset( $og_conflicting_plugins[ $plugin_data['PluginURI'] ] ) )
-				$conflicting_plugins[] = esc_html( $plugin_data['Name'] );
-
-			unset( $plugin_data );
-		}
-
-		//if there are more than 1 plugins relying on Open Graph, warn the user on this plugins page
-		if ( ! empty( $conflicting_plugins ) ) {
-			echo '<div id="facebook-warning" class="error fade"><p>' . sprintf( esc_html( __( 'You have plugins installed that could potentially conflict with the Facebook plugin. Please consider disabling the following plugins on the %s:', 'facebook' ) . '<br />' . implode( ', ', $conflicting_plugins ) ), '<a href="' . admin_url( 'plugins.php' ) .'">' . esc_html( __( 'Plugins Settings page', 'facebook' ) ) . '</a>' ) . '</p></div>';
-		}
-	}
 }
 ?>

--- a/readme.txt
+++ b/readme.txt
@@ -60,7 +60,6 @@ The development [source code for this plugin is available on Facebook's GitHub a
 
 = Actions =
 
-* `facebook_notify_plugin_conflicts` - executes code to notify site administrators of possible conflicts with other plugins by iterating through a list of all installed plugins and highlighting known conflicts at the time the Facebook plugin for WordPress was released. Some publishers may wish to remove this check for efficiency.
 * `facebook_settings_before_header_$hook_suffix` - add content to a settings page before the main page header section
 * `facebook_settings_after_header_$hook_suffix` - add content to a settings page after the main page header section
 * `facebook_settings_footer_$hook_suffix` - add content to a settings page below the wrapper div


### PR DESCRIPTION
Remove check of activated plugins against a list of known Open Graph protocol conflicts. The list is non-exhaustive; OGP conflicts are likely to persist from themes or many other plugins.
