### PR TITLE
Use publish_actions as publish to Timeline permissions check in admin and Facebook_User

### DIFF
--- a/facebook-user.php
+++ b/facebook-user.php
@@ -174,7 +174,7 @@ class Facebook_User {
 			return false;
 
 		$permissions = $facebook->get_current_user_permissions( $current_user );
-		if ( ! ( is_array( $permissions ) && ! empty( $permissions ) && isset( $permissions['publish_stream'] ) && isset( $permissions['publish_actions'] ) ) )
+		if ( ! ( is_array( $permissions ) && ! empty( $permissions ) && isset( $permissions['publish_actions'] ) ) )
 			return false;
 
 		return true;


### PR DESCRIPTION
Test for post to Facebook Timeline capability using the `publish_actions` extended permission, not `publish_stream`.
