### PR TITLE
Use Facebook_User profile url builder for Follow Button

### DIFF
--- a/social-plugins/social-plugins.php
+++ b/social-plugins/social-plugins.php
@@ -222,10 +222,9 @@ function facebook_the_content_follow_button( $content ) {
 	if ( ! ( $facebook_user && isset( $facebook_user['fb_uid'] ) ) )
 		return $content;
 
-	if ( isset( $facebook_user['username'] ) )
-		$options['href'] = 'https://www.facebook.com/' . $facebook_user['username'];
-	else
-		$options['href'] = 'https://www.facebook.com/profile.php?' . http_build_query( array( 'id' => $facebook_user['fb_uid'] ) );
+	$options['href'] = Facebook_User::facebook_profile_link( $facebook_user );
+	if ( ! $options['href'] )
+		return $content;
 
 	if ( $options['position'] === 'top' ) {
 		$options['ref'] = 'above-post';


### PR DESCRIPTION
Use the Facebook profile URL builder in `Facebook_User` to construct a Facebook profile URL from stored WP user data instead of repeating profile URL logic in Follow Button code.
