### PR TITLE
replace Facebook SDK for PHP with app access tokens

### DIFF
--- a/admin/profile.php
+++ b/admin/profile.php
@@ -56,13 +56,17 @@ class Facebook_User_Profile {
 	 * @param $wordpress_user WP_User object for the current profile
 	 */
 	public static function personal_options( $wordpress_user ) {
-		echo '<tr class="facebook-post-to-timeline"><th scope="row">Facebook</th><td><input class="checkbox" type="checkbox" name="facebook_timeline" id="facebook-timeline" value="1"';
+		if ( ! ( $wordpress_user && isset( $wordpress_user->ID ) ) )
+			return;
 
-		if ( $wordpress_user && isset( $wordpress_user->ID ) ) {
-			if ( ! class_exists( 'Facebook_User' ) )
-				require_once( dirname( dirname(__FILE__) ) . '/facebook-user.php' );
-			checked( ! Facebook_User::get_user_meta( $wordpress_user->ID, 'facebook_timeline_disabled', true ) );
-		}
+		if ( ! class_exists( 'Facebook_User' ) )
+			require_once( dirname( dirname(__FILE__) ) . '/facebook-user.php' );
+
+		if ( ! Facebook_User::can_publish_to_facebook( $wordpress_user->ID, false /* do not check for the presence of publish override in this option field */ ) )
+			return;
+
+		echo '<tr class="facebook-post-to-timeline"><th scope="row">Facebook</th><td><input class="checkbox" type="checkbox" name="facebook_timeline" id="facebook-timeline" value="1"';
+		checked( ! Facebook_User::get_user_meta( $wordpress_user->ID, 'facebook_timeline_disabled', true ) );
 
 		echo ' /> <label for="facebook-timeline">' . esc_html( __( 'Post an article to my Facebook Timeline after it is public.', 'facebook' ) ) . '</label><br /></td></tr>';
 	}

--- a/admin/settings-social-publisher.php
+++ b/admin/settings-social-publisher.php
@@ -331,6 +331,10 @@ class Facebook_Social_Publisher_Settings {
 		if ( $this->user_associated_with_facebook_account ) {
 			// edits only avaialble to WordPress accounts connected with a Facebook account
 			echo '<div id="facebook-login" data-option="' . self::PUBLISH_OPTION_NAME . '[page_timeline]"></div>';
+			if ( ! class_exists( 'Facebook_User' ) )
+				require_once( dirname( dirname(__FILE__) ) . '/facebook-user.php' );
+			// page permissions require active user access token
+			Facebook_User::extend_access_token();
 		} else {
 			// send to profile page to connect an account if no connected account stored for current WP user
 			echo '<p><a href="' . esc_url( self_admin_url( 'profile.php' ), array( 'http', 'https' ) ) . '" target="_blank">' . esc_html( 'Add a Facebook account to your WordPress account' ) . '</a></p>';

--- a/admin/social-publisher/publish-box-profile.php
+++ b/admin/social-publisher/publish-box-profile.php
@@ -68,16 +68,8 @@ class Facebook_Social_Publisher_Meta_Box_Profile {
 			require_once( dirname( dirname( __FILE__ ) ) . '/settings-social-publisher.php' );
 
 		// only load mentions-specific features if Facebook app configuration supports tags
-		if ( get_option( Facebook_Social_Publisher_Settings::OPTION_OG_ACTION ) ) {
+		if ( get_option( Facebook_Social_Publisher_Settings::OPTION_OG_ACTION ) )
 			add_action( 'admin_enqueue_scripts', array( 'Facebook_Social_Publisher_Meta_Box_Profile', 'enqueue_scripts' ) );
-
-			// attempt to extend the access token while suppressing errors and warnings such as headers sent on session start
-			// extended session used to match friends on mentions search
-			try {
-				if ( isset( $facebook ) || ( isset( $facebook_loader ) && $facebook_loader->load_php_sdk() ) )
-					$facebook->setExtendedAccessToken();
-			}catch(Exception $e){}
-		}
 	}
 
 	/**
@@ -169,7 +161,7 @@ class Facebook_Social_Publisher_Meta_Box_Profile {
 		if ( ! class_exists( 'Facebook_Social_Publisher' ) )
 			require_once( dirname(__FILE__) . '/social_publisher.php' );
 		$capability_singular_base = Facebook_Social_Publisher::post_type_capability_base( $post_type );
-	
+
 		if ( ! current_user_can( 'edit_' . $capability_singular_base, $post_id ) )
 			return;
 

--- a/admin/social-publisher/social-publisher.php
+++ b/admin/social-publisher/social-publisher.php
@@ -76,17 +76,7 @@ class Facebook_Social_Publisher {
 		if ( ! class_exists( 'Facebook_User' ) )
 			require_once( $facebook_loader->plugin_directory . 'facebook-user.php' );
 
-		if ( ! ( is_int( $wordpress_user_id ) && $wordpress_user_id ) ) {
-			$current_user = wp_get_current_user();
-			if ( isset( $current_user->ID ) )
-				$wordpress_user_id = (int) $current_user->ID;
-			unset( $current_user );
-		}
-
-		if ( is_int( $wordpress_user_id ) && $wordpress_user_id && Facebook_User::get_facebook_profile_id( $wordpress_user_id ) && ! Facebook_User::get_user_meta( $wordpress_user_id, 'facebook_timeline_disabled', true ) )
-			return true;
-
-		return false;
+		return Facebook_User::can_publish_to_facebook( $wordpress_user_id );
 	}
 
 	/**

--- a/includes/facebook-php-sdk/class-facebook-wp.php
+++ b/includes/facebook-php-sdk/class-facebook-wp.php
@@ -184,47 +184,6 @@ class Facebook_WP_Extend extends WP_Facebook {
 	}
 
 	/**
-	 * Request current application permissions for an authenticated Facebook user
-	 *
-	 * @since 1.1
-	 * @return array user permissions as flat array
-	 */
-	public function get_current_user_permissions( $current_user = '' ) {
-		if ( ! $current_user ) {
-			// load user functions
-			if ( ! class_exists( 'Facebook_User' ) )
-				require_once( dirname( dirname( dirname(__FILE__) ) ) . '/facebook-user.php' );
-
-			// simply verify a connection between user and app
-			$current_user = Facebook_User::get_current_user( array( 'id' ) );
-			if ( ! $current_user )
-				return array();
-		}
-
-		try {
-			$response = $this->api( '/me/permissions', 'GET', array( 'ref' => 'fbwpp' ) );
-		} catch ( WP_FacebookApiException $e ) {
-			$error_result = $e->getResult();
-			if ( $error_result && isset( $error_result['error_code'] ) ) {
-				// try to extend access token if request failed
-				if ( $error_result['error_code'] === 2500 )
-					$this->setExtendedAccessToken();
-			}
-			return array();
-		}
-
-		if ( is_array( $response ) && isset( $response['data'][0] ) ) {
-			$permissions = array();
-			foreach( $response['data'][0] as $permission => $exists ) {
-				$permissions[$permission] = true;
-			}
-			return $permissions;
-		}
-
-		return array();
-	}
-
-	/**
 	 * Retrieve Facebook permissions assigned to the application by a specific Facebook user id
 	 *
 	 * @since 1.2


### PR DESCRIPTION
Server-to-server requests using app access tokens are preferred over an active Facebook client session using the Facebook SDK for PHP.

Convert additional plugin calls to app access token requests:
- Facebook user permissions
- Facebook friend mentions
- Facebook page mentions

Publish to page setting validation continues to use the Facebook SDK for PHP due to the user access token requirement of the accounts API.

The publish to Facebook timeline override on the WordPress profile page is only shown if the profile's Facebook account has granted the site's Facebook application `publish_actions` permission.
