### PR TITLE
remove photo OG type for image post format

### DIFF
--- a/open-graph-protocol.php
+++ b/open-graph-protocol.php
@@ -388,8 +388,7 @@ class Facebook_Open_Graph_Protocol {
 		// treat video post format as OG type video
 		if ( has_post_format( 'video', $post ) )
 			$og_type = 'video.other';
-		else if ( has_post_format( 'image', $post ) )
-			$og_type = 'photo';
+
 		$og_type = apply_filters( 'facebook_og_type', $og_type, $post );
 		if ( ! $og_type )
 			$og_type = 'article';


### PR DESCRIPTION
Remove photo global for image post formats. Let apps inherit from their custom object instead.
