### PR TITLE
store and send an appsecret_proof with Page access token

### DIFF
--- a/admin/settings-app.php
+++ b/admin/settings-app.php
@@ -367,6 +367,7 @@ class Facebook_Application_Settings {
 							$clean_options['appsecret_proof'] = $app_secret_proof;
 					}
 					unset( $app_info );
+					unset( $app_secret_proof );
 				} else {
 					if ( function_exists( 'add_settings_error' ) )
 						add_settings_error( 'facebook-app-auth', 'facebook-app-auth-error', __( 'Application ID and secret failed on authentication with Facebook.', 'facebook' ) );

--- a/admin/settings-social-publisher.php
+++ b/admin/settings-social-publisher.php
@@ -397,6 +397,8 @@ class Facebook_Social_Publisher_Settings {
 	 * @param array $page_data data returned from Facebook Graph API permissions call
 	 */
 	public static function update_publish_to_page( $page_data ) {
+		global $facebook_loader;
+
 		if ( ! ( is_array( $page_data ) && ! empty( $page_data ) && isset( $page_data['id'] ) ) )
 			return;
 
@@ -428,6 +430,8 @@ class Facebook_Social_Publisher_Settings {
 		);
 		if ( isset( $write_pages[ $page_data['id'] ]['link'] ) )
 			$value['link'] = $write_pages[ $page_data['id'] ]['link'];
+		if ( isset( $facebook_loader->credentials['app_secret'] ) )
+			$value['appsecret_proof'] = hash_hmac( 'sha256', $access_token, $facebook_loader->credentials['app_secret'] );
 
 		update_option( self::OPTION_PUBLISH_TO_PAGE, $value );
 	}

--- a/admin/social-publisher/social-publisher.php
+++ b/admin/social-publisher/social-publisher.php
@@ -293,6 +293,8 @@ class Facebook_Social_Publisher {
 			'access_token' => $facebook_page['access_token'],
 			'link' => $link
 		);
+		if ( isset( $facebook_page['appsecret_proof'] ) && $facebook_page['appsecret_proof'] )
+			$args['appsecret_proof'] = $facebook_page['appsecret_proof'];
 
 		if ( $meta_box_present )
 			$args['fb:explicitly_shared'] = 'true';


### PR DESCRIPTION
include an [app secret proof](https://developers.facebook.com/docs/reference/api/securing-graph-api/) with new posts to a Facebook Page
