### PR TITLE
update docs links

### DIFF
--- a/admin/settings-app.php
+++ b/admin/settings-app.php
@@ -146,7 +146,7 @@ class Facebook_Application_Settings {
 
 		// promote Facebook for WordPress page on Facebook Developers site
 		$like_button = new Facebook_Like_Button(false);
-		$like_button->setURL( 'http://developers.facebook.com/wordpress/' );
+		$like_button->setURL( 'https://developers.facebook.com/docs/wordpress/' );
 		$like_button->setLayout( 'button_count' );
 		$like_button->includeSendButton();
 		$like_button->setFont( 'arial' );

--- a/admin/settings-social-publisher.php
+++ b/admin/settings-social-publisher.php
@@ -235,7 +235,7 @@ class Facebook_Social_Publisher_Settings {
 
 		echo '<p>' . esc_html( __( 'Promote social engagement and readership by publishing new posts to the Facebook Timeline of a connected author.', 'facebook' ) ) . '</p>';
 
-		echo '<p>' . sprintf( esc_html( __( 'Open Graph %s', 'facebook' ) ), '<a href="' . esc_url( 'https://developers.facebook.com/wordpress/open-graph-action/', array( 'http', 'https' ) ) . '" target="_blank" title="' . esc_attr( __( 'Facebook Open Graph action submission process', 'facebook' ) ) . '">' . esc_html( __( 'prerequisites', 'facebook' ) ) . '</a>' ) . ': </p>';
+		echo '<p>' . sprintf( esc_html( __( 'Open Graph %s', 'facebook' ) ), '<a href="' . esc_url( 'https://developers.facebook.com/docs/wordpress/open-graph-action/', array( 'http', 'https' ) ) . '" target="_blank" title="' . esc_attr( __( 'Facebook Open Graph action submission process', 'facebook' ) ) . '">' . esc_html( __( 'prerequisites', 'facebook' ) ) . '</a>' ) . ': </p>';
 
 		echo '<ol>';
 
@@ -386,7 +386,7 @@ class Facebook_Social_Publisher_Settings {
 			'content' => self::help_tab_publisher()
 		) );
 
-		$screen->set_help_sidebar( '<p><a href="' . esc_url( 'https://developers.facebook.com/apps/', array( 'http', 'https' ) ) . '" target="_blank">' . esc_html( __( 'Facebook Apps Tool', 'facebook' ) ) . '</a></p><p><a href="' . esc_url( 'https://developers.facebook.com/wordpress/', array( 'http', 'https' ) ) . '" target="_blank">' . esc_html( __( 'Plugin help page', 'facebook' ) ) . '</a></p>' );
+		$screen->set_help_sidebar( '<p><a href="' . esc_url( 'https://developers.facebook.com/apps/', array( 'http', 'https' ) ) . '" target="_blank">' . esc_html( __( 'Facebook Apps Tool', 'facebook' ) ) . '</a></p><p><a href="' . esc_url( 'https://developers.facebook.com/docs/wordpress/', array( 'http', 'https' ) ) . '" target="_blank">' . esc_html( __( 'Plugin help page', 'facebook' ) ) . '</a></p>' );
 	}
 
 	/**

--- a/facebook.php
+++ b/facebook.php
@@ -8,7 +8,7 @@ Plugin Name: Facebook
 Plugin URI: http://wordpress.org/plugins/facebook/
 Description: Add Facebook social plugins and the ability to publish new posts to a Facebook Timeline or Facebook Page. Official Facebook plugin.
 Author: Facebook
-Author URI: https://developers.facebook.com/wordpress/
+Author URI: https://developers.facebook.com/docs/wordpress/
 Version: 1.5.2
 License: GPL2
 License URI: license.txt

--- a/readme.txt
+++ b/readme.txt
@@ -45,7 +45,7 @@ The development [source code for this plugin is available on Facebook's GitHub a
 1. Install Facebook for WordPress either via the WordPress.org plugin directory, or by uploading the files to your server (in the `/wp-content/plugins/` directory).
 1. You should be able to start using social plugins (Like Button, Send Button, etc.) right away.
 1. After activating the plugin, you will be asked to set up your Facebook application or enter existing credentials copied from the [Facebook Developers site](http://developers.facebook.com/apps/) to unlock additional features such as publishing posts to an author Timeline or site Page.
-1. Optionally set up a Facebook Open Graph action with user message, mentions tagging, and explicitly shared action capabilities. See the [Facebook for WordPress help page](https://developers.facebook.com/wordpress/) for more information.
+1. Optionally set up a Facebook Open Graph action with user message, mentions tagging, and explicitly shared action capabilities. See the [Facebook for WordPress help page](https://developers.facebook.com/docs/wordpress/) for more information.
 1. That's it. You're ready to go!
 
 == Screenshots ==
@@ -125,7 +125,7 @@ The [Facebook Comments Box social plugin](https://developers.facebook.com/docs/r
 
 = What additional configuration steps do I need to complete to enable an Open Graph action for my Facebook application? =
 
-Visit the [Facebook plugin for WordPress getting started page](https://developers.facebook.com/wordpress/) for more details and screenshots of each step in the process. You will need to create an Open Graph action-object pair for your Facebook application: publish an article. You will need to submit the new publish action for approval with support for [action capabilities](https://developers.facebook.com/docs/submission-process/opengraph/guidelines/action-properties/ "Facebook action capabilities") allowing custom messages on an author's Timeline, mentioning Facebook friends and Facebook pages within that message, and marking the new post as explicitly shared.
+Visit the [Facebook plugin for WordPress getting started page](https://developers.facebook.com/docs/wordpress/) for more details and screenshots of each step in the process. You will need to create an Open Graph action-object pair for your Facebook application: publish an article. You will need to submit the new publish action for approval with support for [action capabilities](https://developers.facebook.com/docs/submission-process/opengraph/guidelines/action-properties/ "Facebook action capabilities") allowing custom messages on an author's Timeline, mentioning Facebook friends and Facebook pages within that message, and marking the new post as explicitly shared.
 
 = I set up my social plugin but nothing happened =
 


### PR DESCRIPTION
before: developers.facebook.com/wordpress
after: developers.facebook.com/docs/wordpress

avoids redirects
