### PR TITLE
update code documentation for PSR-5 and WordPress PHP standards

### DIFF
--- a/admin/profile.php
+++ b/admin/profile.php
@@ -1,15 +1,17 @@
 <?php
 /**
- * Add content to a WordPress user profile
+ * Add content to a WordPress user profile.
  *
  * @since 1.2
  */
 class Facebook_User_Profile {
 
 	/**
-	 * Conditionally load features on the edit profile page
+	 * Conditionally load features on the edit profile page.
 	 *
 	 * @since 1.2
+	 *
+	 * @return void
 	 */
 	public static function init() {
 		if ( ! current_user_can( 'edit_posts' ) )
@@ -26,10 +28,13 @@ class Facebook_User_Profile {
 	}
 
 	/**
-	 * Add the login JavaScript to the WordPress script queue
+	 * Add the login JavaScript to the WordPress script queue.
 	 *
 	 * @since 1.5
+	 *
 	 * @uses wp_enqueue_script()
+	 * @global \WP_Scripts $wp_scripts Add a script block to the enqueued script handle
+	 * @return void
 	 */
 	public static function enqueue_scripts() {
 		global $wp_scripts;
@@ -50,10 +55,12 @@ class Facebook_User_Profile {
 	}
 
 	/**
-	 * Allow an author to disable posting to Timeline by default
+	 * Allow an author to disable posting to Timeline by default.
 	 *
 	 * @since 1.2
-	 * @param $wordpress_user WP_User object for the current profile
+	 *
+	 * @param WP_User $wordpress_user WordPress user object for the current profile.
+	 * @return void
 	 */
 	public static function personal_options( $wordpress_user ) {
 		if ( ! ( $wordpress_user && isset( $wordpress_user->ID ) ) )
@@ -72,10 +79,13 @@ class Facebook_User_Profile {
 	}
 
 	/**
-	 * Add a Facebook section to the WordPress user profile page
+	 * Add a Facebook section to the WordPress user profile page.
 	 *
 	 * @since 1.5
-	 * @param WP_User $wp_user WordPress user for the current profile page
+	 *
+	 * @global \Facebook_Loader $facebook_loader Access Facebook application credentials.
+	 * @param WP_User $wp_user WordPress user for the current profile page.
+	 * @return void
 	 */
 	public static function facebook_section( $wp_user ) {
 		global $facebook_loader;
@@ -133,9 +143,10 @@ class Facebook_User_Profile {
 	}
 
 	/**
-	 * Save custom user information
+	 * Save custom user information.
 	 *
 	 * @since 1.2
+	 *
 	 * @uses current_user_can() current user must be able to edit the passed WordPress user ID
 	 * @param int $wordpress_user_id WordPress user identifier
 	 * @return void

--- a/admin/settings-app.php
+++ b/admin/settings-app.php
@@ -7,25 +7,28 @@
  */
 class Facebook_Application_Settings {
 	/**
-	 * Settings page identifier
+	 * Settings page identifier.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const PAGE_SLUG = 'facebook-application-settings';
 
 	/**
-	 * Define our option array value
+	 * Define our option array value.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const OPTION_NAME = 'facebook_application';
 
 	/**
-	 * Define the kid-directed option value
+	 * Define the kid-directed option value.
 	 *
 	 * @since 1.5
+	 *
 	 * @var string
 	 */
 	const OPTION_NAME_KID_DIRECTED = 'facebook_kid_directed_site';
@@ -34,14 +37,16 @@ class Facebook_Application_Settings {
 	 * The hook suffix assigned by add_submenu_page()
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	protected $hook_suffix = '';
 
 	/**
-	 * Initialize with an options array
+	 * Initialize with an options array.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $options existing options
 	 */
 	public function __construct( $options = array() ) {
@@ -52,9 +57,10 @@ class Facebook_Application_Settings {
 	}
 
 	/**
-	 * Add a menu item to WordPress admin
+	 * Add a menu item to WordPress admin.
 	 *
 	 * @since 1.1
+	 *
 	 * @uses add_utility_page()
 	 * @return string page hook
 	 */
@@ -81,9 +87,12 @@ class Facebook_Application_Settings {
 	}
 
 	/**
-	 * Load stored options and scripts on settings page view
+	 * Load stored options and scripts on settings page view.
 	 *
 	 * @since 1.1
+	 *
+	 * @uses get_option() load existing options
+	 * @return void
 	 */
 	public function onload() {
 		$options = get_option( self::OPTION_NAME );
@@ -91,6 +100,7 @@ class Facebook_Application_Settings {
 			$options = array();
 		$this->existing_options = $options;
 
+		// notify of lack of HTTPS
 		if ( ! wp_http_supports( array( 'ssl' => true ) ) )
 			add_action( 'admin_notices', array( 'Facebook_Application_Settings', 'admin_notice' ) );
 
@@ -100,9 +110,11 @@ class Facebook_Application_Settings {
 	}
 
 	/**
-	 * Warn of minimum requirements not met for app access token
+	 * Warn of minimum requirements not met for app access token.
 	 *
 	 * @since 1.5
+	 *
+	 * @return void
 	 */
 	public static function admin_notice() {
 		echo '<div class="error">';
@@ -112,9 +124,11 @@ class Facebook_Application_Settings {
 	}
 
 	/**
-	 * Load the settings page
+	 * Load the settings page.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function settings_page() {
 		if ( ! isset( $this->hook_suffix ) )
@@ -126,21 +140,26 @@ class Facebook_Application_Settings {
 	}
 
 	/**
-	 * Enhance settings page with JavaScript
+	 * Enhance settings page with JavaScript.
 	 *
 	 * @since 1.1
+	 *
 	 * @uses wp_enqueue_script()
+	 * @return void
 	 */
 	public static function enqueue_scripts() {
 		wp_enqueue_script( 'facebook-jssdk' );
 	}
 
 	/**
-	 * Facebook Like Button after header
+	 * Facebook Like Button after header.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public static function after_header() {
+		// Facebook Like Button social plugin markup builder
 		if ( ! class_exists( 'Facebook_Like_Button' ) )
 			require_once( dirname( dirname(__FILE__) ) . '/social-plugins/class-facebook-like-button.php' );
 
@@ -155,11 +174,13 @@ class Facebook_Application_Settings {
 	}
 
 	/**
-	 * Hook into the settings API
+	 * Hook into the settings API.
 	 *
 	 * @since 1.1
+	 *
 	 * @uses add_settings_section()
 	 * @uses add_settings_field()
+	 * @return void
 	 */
 	private function settings_api_init() {
 		if ( ! isset( $this->hook_suffix ) )
@@ -215,9 +236,11 @@ class Facebook_Application_Settings {
 	}
 
 	/**
-	 * Introduction to the application settings section
+	 * Introduction to the application settings section.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function section_header() {
 		if ( ! empty( $this->existing_options['app_id'] ) )
@@ -227,18 +250,22 @@ class Facebook_Application_Settings {
 	}
 
 	/**
-	 * Introduction to Facebook restrictions configurations
+	 * Introduction to Facebook restrictions configurations.
 	 *
 	 * @since 1.5
+	 *
+	 * @return void
 	 */
 	public static function restriction_section_header() {
 		echo '<p>' . esc_html( __( 'Limit Facebook functionality', 'facebook' ) ) . '</p>';
 	}
 
 	/**
-	 * Display the application ID input field
+	 * Display the application ID input field.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function display_app_id() {
 		$key = 'app_id';
@@ -259,9 +286,11 @@ class Facebook_Application_Settings {
 	}
 
 	/**
-	 * Display the Facebook application secret input field
+	 * Display the Facebook application secret input field.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function display_app_secret() {
 		$key = 'app_secret';
@@ -282,9 +311,12 @@ class Facebook_Application_Settings {
 	}
 
 	/**
-	 * Display a checkbox to designate the site as child-focused
+	 * Display a checkbox to designate the site as child-focused.
 	 *
-	 * @since 1.3
+	 * @since 1.5
+	 *
+	 * @global Facebook_Loader $facebook_loader determine child directed site status
+	 * @return void
 	 */
 	public static function display_kid_directed_site() {
 		global $facebook_loader;
@@ -297,9 +329,10 @@ class Facebook_Application_Settings {
 	}
 
 	/**
-	 * Clean user inputs before saving to database
+	 * Clean user inputs before saving to database.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $options form options values
 	 * @return array $options sanitized options
 	 */
@@ -396,9 +429,10 @@ class Facebook_Application_Settings {
 	}
 
 	/**
-	 * Display helpful information about setting up a new application
+	 * Display helpful information about setting up a new application.
 	 *
 	 * @since 1.1
+	 *
 	 * @return string HTML content
 	 */
 	public static function help_tab_new_app() {
@@ -430,9 +464,10 @@ class Facebook_Application_Settings {
 	}
 
 	/**
-	 * Display helpful information about retrieving application credentials from Facebook Developers site
+	 * Display helpful information about retrieving application credentials from Facebook Developers site.
 	 *
 	 * @since 1.1
+	 *
 	 * @return string HTML content
 	 */
 	public static function help_tab_existing_app() {
@@ -451,9 +486,10 @@ class Facebook_Application_Settings {
 	}
 
 	/**
-	 * Help applications associate basic data with their Facebook application
+	 * Help applications associate basic data with their Facebook application.
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $app_id application identifier. used to construct a link to the Facebook Developers site
 	 * @return string HTML content
 	 */
@@ -505,6 +541,7 @@ class Facebook_Application_Settings {
 	 * Explain the child-directed site option
 	 *
 	 * @since 1.5
+	 *
 	 * @return string HTML string
 	 */
 	public static function help_tab_kid_directed() {
@@ -519,6 +556,9 @@ class Facebook_Application_Settings {
 	 * Display help content on the settings page
 	 *
 	 * @since 1.1
+	 *
+	 * @uses get_current_screen()
+	 * @return void
 	 */
 	private function inline_help_content() {
 		$screen = get_current_screen();

--- a/admin/settings-comments.php
+++ b/admin/settings-comments.php
@@ -11,17 +11,19 @@ if ( ! class_exists( 'Facebook_Social_Plugin_Settings' ) )
 class Facebook_Comments_Settings extends Facebook_Social_Plugin_Settings {
 
 	/**
-	 * Setting page identifier
+	 * Setting page identifier.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const PAGE_SLUG = 'facebook-comments';
 
 	/**
-	 * Define our option array value
+	 * Define our option array value.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const OPTION_NAME = 'facebook_comments';
@@ -30,14 +32,16 @@ class Facebook_Comments_Settings extends Facebook_Social_Plugin_Settings {
 	 * The hook suffix assigned by add_submenu_page()
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	protected $hook_suffix = '';
 
 	/**
-	 * Initialize with an options array
+	 * Initialize with an options array.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $options existing options
 	 */
 	public function __construct( $options = array() ) {
@@ -50,9 +54,10 @@ class Facebook_Comments_Settings extends Facebook_Social_Plugin_Settings {
 	}
 
 	/**
-	 * Reference the social plugin by name
+	 * Reference the social plugin by name.
 	 *
 	 * @since 1.1
+	 *
 	 * @return string social plugin name
 	 */
 	public static function social_plugin_name() {
@@ -60,9 +65,10 @@ class Facebook_Comments_Settings extends Facebook_Social_Plugin_Settings {
 	}
 
 	/**
-	 * Navigate to the settings page through the Facebook top-level menu item
+	 * Navigate to the settings page through the Facebook top-level menu item.
 	 *
 	 * @since 1.1
+	 *
 	 * @uses add_submenu_page()
 	 * @param string $parent_slug Facebook top-level menu item slug
 	 * @return string submenu hook suffix
@@ -93,9 +99,11 @@ class Facebook_Comments_Settings extends Facebook_Social_Plugin_Settings {
 	}
 
 	/**
-	 * Load stored options and scripts on settings page view
+	 * Load stored options and scripts on settings page view.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function onload() {
 		$options = get_option( self::OPTION_NAME );
@@ -107,9 +115,11 @@ class Facebook_Comments_Settings extends Facebook_Social_Plugin_Settings {
 	}
 
 	/**
-	 * Load the page
+	 * Load the page.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function settings_page() {
 		if ( ! isset( $this->hook_suffix ) )
@@ -119,11 +129,13 @@ class Facebook_Comments_Settings extends Facebook_Social_Plugin_Settings {
 	}
 
 	/**
-	 * Hook into the settings API
+	 * Hook into the settings API.
 	 *
 	 * @since 1.1
+	 *
 	 * @uses add_settings_section()
 	 * @uses add_settings_field()
+	 * @return void
 	 */
 	private function settings_api_init() {
 		if ( ! isset( $this->hook_suffix ) )
@@ -179,9 +191,11 @@ class Facebook_Comments_Settings extends Facebook_Social_Plugin_Settings {
 	}
 
 	/**
-	 * Introduce publishers to the Comments Box social plugin
+	 * Introduce publishers to the Comments Box social plugin.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function section_header() {
 		global $facebook_loader;
@@ -192,9 +206,11 @@ class Facebook_Comments_Settings extends Facebook_Social_Plugin_Settings {
 	}
 
 	/**
-	 * Return a list of all public post types supporting the comments feature
+	 * Return a list of all public post types supporting the comments feature.
 	 *
 	 * @since 1.1
+	 *
+	 * @uses get_post_types()
 	 * @return array post type names supporting comments feature
 	 */
 	public static function post_types_supporting_comments() {
@@ -214,6 +230,8 @@ class Facebook_Comments_Settings extends Facebook_Social_Plugin_Settings {
 	 * On which single pages should the comments box appear?
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function display_show_on() {
 		$existing_value = self::get_display_conditionals_by_feature( 'comments', 'posts' );
@@ -240,9 +258,11 @@ class Facebook_Comments_Settings extends Facebook_Social_Plugin_Settings {
 	}
 
 	/**
-	 * Maximum number of posts displayed before viewer expansion
+	 * Maximum number of posts displayed before viewer expansion.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function display_num_posts() {
 		$key = 'num_posts';
@@ -260,9 +280,12 @@ class Facebook_Comments_Settings extends Facebook_Social_Plugin_Settings {
 	}
 
 	/**
-	 * Allow the publisher to customize the width of the Comments Box
+	 * Allow the publisher to customize the width of the Comments Box.
 	 *
 	 * @since 1.1
+	 *
+	 * @global int $content_width content width of the theme
+	 * @return void
 	 */
 	public function display_width() {
 		global $content_width;
@@ -289,9 +312,11 @@ class Facebook_Comments_Settings extends Facebook_Social_Plugin_Settings {
 	}
 
 	/**
-	 * Customize the color scheme
+	 * Customize the color scheme.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function display_colorscheme() {
 		$key = 'colorscheme';
@@ -300,9 +325,10 @@ class Facebook_Comments_Settings extends Facebook_Social_Plugin_Settings {
 	}
 
 	/**
-	 * Ordering choices
+	 * Ordering choices.
 	 *
 	 * @since 1.3
+	 *
 	 * @return array associative array of social plugin field value and translated label
 	 */
 	public static function order_by_choices() {
@@ -314,9 +340,11 @@ class Facebook_Comments_Settings extends Facebook_Social_Plugin_Settings {
 	}
 
 	/**
-	 * Customize comment order
+	 * Customize comment order.
 	 *
 	 * @since 1.3
+	 *
+	 * @return void
 	 */
 	public function display_order_by() {
 		$key = 'order_by';
@@ -336,9 +364,10 @@ class Facebook_Comments_Settings extends Facebook_Social_Plugin_Settings {
 	}
 
 	/**
-	 * Translate HTML data response returned from Facebook social plugin builder into underscored keys and PHP values before saving
+	 * Translate HTML data response returned from Facebook social plugin builder into underscored keys and PHP values before saving.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $options data-* options returned from Facebook social plugin builder
 	 * @return array $options options to store in WordPress
 	 */
@@ -364,6 +393,7 @@ class Facebook_Comments_Settings extends Facebook_Social_Plugin_Settings {
 	 * Sanitize Comments Box settings before they are saved to the database
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $options Comments Box options
 	 * @return array clean option sets. note: we remove Comments Box social plugin default options, storing only custom settings (e.g. dark color scheme stored, light is default and therefore not stored)
 	 */

--- a/admin/settings-debug.php
+++ b/admin/settings-debug.php
@@ -8,33 +8,37 @@
 class Facebook_Settings_Debugger {
 
 	/**
-	 * Page identifier
+	 * Page identifier.
 	 *
 	 * @since 1.1.6
+	 *
 	 * @var string
 	 */
 	const PAGE_SLUG = 'facebook-debug';
 
 	/**
-	 * HTML span noting a feature exists
+	 * HTML span noting a feature exists.
 	 *
 	 * @since 1.1.6
+	 *
 	 * @var string
 	 */
 	const EXISTS = '<span class="feature-present">&#10003;</span>';
 
 	/**
-	 * HTML span noting a feature does not exist
+	 * HTML span noting a feature does not exist.
 	 *
 	 * @since 1.1.6
+	 *
 	 * @var string
 	 */
 	const DOES_NOT_EXIST = '<span class="feature-not-present">X</span>';
 
 	/**
-	 * Reference the social plugin by name
+	 * Reference the social plugin by name.
 	 *
 	 * @since 1.1.6
+	 *
 	 * @return string social plugin name
 	 */
 	public static function social_plugin_name() {
@@ -42,9 +46,10 @@ class Facebook_Settings_Debugger {
 	}
 
 	/**
-	 * Navigate to the debugger page through the Facebook top-level menu item
+	 * Navigate to the debugger page through the Facebook top-level menu item.
 	 *
 	 * @since 1.1.6
+	 *
 	 * @uses add_submenu_page()
 	 * @param string $parent_slug Facebook top-level menu item slug
 	 * @return string submenu hook suffix
@@ -67,25 +72,34 @@ class Facebook_Settings_Debugger {
 	}
 
 	/**
-	 * Load scripts and other setup functions on page load
+	 * Load scripts and other setup functions on page load.
+	 *
+	 * @since 1.1.6
+	 *
+	 * @return void
 	 */
 	public static function onload() {
 		add_action( 'admin_enqueue_scripts', array( 'Facebook_Settings_Debugger', 'enqueue_scripts' ) );
 	}
 
 	/**
-	 * Enqueue scripts and styles
+	 * Enqueue scripts and styles.
 	 *
 	 * @since 1.1.6
+	 *
+	 * @return void
 	 */
 	public static function enqueue_scripts() {
 		wp_enqueue_style( self::PAGE_SLUG, plugins_url( 'static/css/admin/debug' . ( ( defined('SCRIPT_DEBUG') && SCRIPT_DEBUG ) ? '' : '.min' )  . '.css', dirname( __FILE__ ) ), array(), '1.5' );
 	}
 
 	/**
-	 * Page content
+	 * Page content.
 	 *
 	 * @since 1.1.6
+	 *
+	 * @global Facebook_Loader $facebook_loader test if Facebook app access token exists
+	 * @return void
 	 */
 	public static function content() {
 		global $facebook_loader;
@@ -113,9 +127,12 @@ class Facebook_Settings_Debugger {
 	}
 
 	/**
-	 * Get all users with edit_posts capabilities broken out into Facebook-permissioned users and non-Facebook permissioned users
+	 * Get all users with edit_posts capabilities broken out into Facebook-permissioned users and non-Facebook permissioned users.
 	 *
 	 * @since 1.1.6
+	 *
+	 * @see Facebook_User::get_wordpress_users_associated_with_facebook_accounts()
+	 * @return array WordPress users with and without Facebook data stored.
 	 */
 	public static function get_all_wordpress_facebook_users() {
 		if ( ! class_exists( 'Facebook_User' ) )
@@ -156,6 +173,7 @@ class Facebook_Settings_Debugger {
 	 * URL of the Facebook app editor for a specific Facebook app id
 	 *
 	 * @since 1.5.3
+	 *
 	 * @param string Facebook application identifier
 	 * @return string absolute URI of the passed Facebook app_id editor
 	 */
@@ -164,11 +182,12 @@ class Facebook_Settings_Debugger {
 	}
 
 	/**
-	 * Display Facebook application settings, prompt for missing values
+	 * Display Facebook application settings, prompt for missing values.
 	 *
 	 * Help WordPress administrators troubleshoot missing minimum requirements for a Facebook app using Facebook Login and/or an approved Open Graph action.
 	 *
 	 * @since 1.5.3
+	 *
 	 * @global \Facebook_Loader $facebook_loader access Facebook app id
 	 * @return void
 	 */
@@ -191,6 +210,7 @@ class Facebook_Settings_Debugger {
 	 * Mention WordPress users with manage_options capability who can also edit the Facebook app
 	 *
 	 * @since 1.5.3
+	 *
 	 * @param string $app_id Facebook application identifier
 	 * @return void
 	 */
@@ -278,6 +298,7 @@ class Facebook_Settings_Debugger {
 	 * Request stored details for the site's stored Facebook application. Highlight values relevant to a proper functioning Facebook Login experience
 	 *
 	 * @since 1.5.3
+	 *
 	 * @param string $app_id Facebook application identifier
 	 * @return void
 	 */
@@ -411,6 +432,9 @@ class Facebook_Settings_Debugger {
 	 * Detail site users and their association with Facebook
 	 *
 	 * @since 1.1.6
+	 *
+	 * @global wpdb $wpdb escape SQL
+	 * @return void
 	 */
 	public static function users_section() {
 		global $wpdb;
@@ -509,6 +533,8 @@ class Facebook_Settings_Debugger {
 	 * Display the currently associated Facebook page, if one exists.
 	 *
 	 * @since 1.1.6
+	 *
+	 * @return void
 	 */
 	public static function post_to_page_section() {
 		if ( ! class_exists( 'Facebook_Social_Publisher_Settings' ) )
@@ -548,6 +574,8 @@ class Facebook_Settings_Debugger {
 	 * Which features are enabled for the site on each major view type?
 	 *
 	 * @since 1.1.6
+	 *
+	 * @return void
 	 */
 	public static function enabled_features_by_view_type() {
 		if ( ! class_exists( 'Facebook_Social_Plugin_Settings' ) )
@@ -615,9 +643,11 @@ class Facebook_Settings_Debugger {
 	}
 
 	/**
-	 * Widgets enabled for the site
+	 * Widgets enabled for the site.
 	 *
 	 * @since 1.1.6
+	 *
+	 * @return void
 	 */
 	public static function widgets_section() {
 		if ( ! class_exists( 'Facebook_Settings' ) )
@@ -667,6 +697,8 @@ class Facebook_Settings_Debugger {
 	 * How does the site communicate with Facebook?
 	 *
 	 * @since 1.1.6
+	 *
+	 * @return void
 	 */
 	public static function server_info() {
 		echo '<section id="debug-server"><header><h3>' . esc_html( __( 'Server configuration', 'facebook' ) ) . '</h3></header><table><thead><th>' . esc_html( __( 'Feature', 'facebook' ) ) . '</th><th>' . esc_html( _x( 'Info', 'Information', 'facebook' ) ) . '</th></thead><tbody>';

--- a/admin/settings-follow-button.php
+++ b/admin/settings-follow-button.php
@@ -4,24 +4,26 @@ if ( ! class_exists( 'Facebook_Social_Plugin_Button_Settings' ) )
 	require_once( dirname(__FILE__) . '/settings-social-plugin-button.php' );
 
 /**
- * Site settings for the Facebook Send Button social plugin
+ * Site settings for the Facebook Send Button social plugin.
  *
  * @since 1.1
  */
 class Facebook_Follow_Button_Settings extends Facebook_Social_Plugin_Button_Settings {
 
 	/**
-	 * Setting page identifier
+	 * Setting page identifier.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const PAGE_SLUG = 'facebook-follow-button';
 
 	/**
-	 * Define our option array value
+	 * Define our option array value.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const OPTION_NAME = 'facebook_follow_button';
@@ -30,14 +32,16 @@ class Facebook_Follow_Button_Settings extends Facebook_Social_Plugin_Button_Sett
 	 * The hook suffix assigned by add_submenu_page()
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	protected $hook_suffix = '';
 
 	/**
-	 * Initialize with an options array
+	 * Initialize with an options array.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $options existing options
 	 */
 	public function __construct( $options = array() ) {
@@ -48,9 +52,10 @@ class Facebook_Follow_Button_Settings extends Facebook_Social_Plugin_Button_Sett
 	}
 
 	/**
-	 * Reference the social plugin by name
+	 * Reference the social plugin by name.
 	 *
 	 * @since 1.1
+	 *
 	 * @return string social plugin name
 	 */
 	public static function social_plugin_name() {
@@ -58,9 +63,11 @@ class Facebook_Follow_Button_Settings extends Facebook_Social_Plugin_Button_Sett
 	}
 
 	/**
-	 * Evaluate the Facebook_Follow_Button class file if it is not already loaded
+	 * Evaluate the Facebook_Follow_Button class file if it is not already loaded.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public static function require_follow_button_builder() {
 		if ( ! class_exists( 'Facebook_Follow_Button' ) )
@@ -68,9 +75,10 @@ class Facebook_Follow_Button_Settings extends Facebook_Social_Plugin_Button_Sett
 	}
 
 	/**
-	 * Navigate to the settings page through the Facebook top-level menu item
+	 * Navigate to the settings page through the Facebook top-level menu item.
 	 *
 	 * @since 1.1
+	 *
 	 * @uses add_submenu_page()
 	 * @param string $parent_slug Facebook top-level menu item slug
 	 * @return string submenu hook suffix
@@ -97,9 +105,11 @@ class Facebook_Follow_Button_Settings extends Facebook_Social_Plugin_Button_Sett
 	}
 
 	/**
-	 * Load stored options and scripts on settings page view
+	 * Load stored options and scripts on settings page view.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function onload() {
 		$options = get_option( self::OPTION_NAME );
@@ -111,9 +121,11 @@ class Facebook_Follow_Button_Settings extends Facebook_Social_Plugin_Button_Sett
 	}
 
 	/**
-	 * Load the page
+	 * Load the page.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function settings_page() {
 		if ( ! isset( $this->hook_suffix ) )
@@ -123,11 +135,13 @@ class Facebook_Follow_Button_Settings extends Facebook_Social_Plugin_Button_Sett
 	}
 
 	/**
-	 * Hook into the settings API
+	 * Hook into the settings API.
 	 *
 	 * @since 1.1
+	 *
 	 * @uses add_settings_section()
 	 * @uses add_settings_field()
+	 * @return void
 	 */
 	private function settings_api_init() {
 		if ( ! isset( $this->hook_suffix ) )
@@ -200,18 +214,21 @@ class Facebook_Follow_Button_Settings extends Facebook_Social_Plugin_Button_Sett
 	}
 
 	/**
-	 * Introduce publishers to the Follow Button social plugin
+	 * Introduce publishers to the Follow Button social plugin.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function section_header() {
 		echo '<p>' . esc_html( __( "Encourage visitors to follow to public updates from an author's Facebook account.", 'facebook' ) ) . ' <a href="https://developers.facebook.com/docs/reference/plugins/follow/" title="' . esc_attr( sprintf( __( '%s social plugin documentation', 'facebook' ), 'Facebook ' . self::social_plugin_name() ) ) . '">' . esc_html( __( 'Read more...', 'facebook' ) ) . '</a></p>';
 	}
 
 	/**
-	 * Archive choices and post type choices
+	 * Archive choices and post type choices.
 	 *
 	 * @since 1.1.9
+	 *
 	 * @param string $scope accept the same number of parameters as the parent class function. no effect
 	 * @return array list of archive names and public post type names
 	 */
@@ -220,10 +237,12 @@ class Facebook_Follow_Button_Settings extends Facebook_Social_Plugin_Button_Sett
 	}
 
 	/**
-	 * Not all post types support the concept of an author
-	 * Limit selectable post types to just public post types supporting authors
+	 * Limit selectable post types to just public post types supporting authors.
+	 *
+	 * Not all post types support the concept of an author.
 	 *
 	 * @since 1.1.9
+	 *
 	 * @return array list of public post types supporting author feature
 	 */
 	public static function post_types_supporting_authorship() {
@@ -245,7 +264,9 @@ class Facebook_Follow_Button_Settings extends Facebook_Social_Plugin_Button_Sett
 	 * Where should the button appear?
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $extra_attributes custom form attributes
+	 * @return void
 	 */
 	public function display_show_on( $extra_attributes = array() ) {
 		$key = 'show_on';
@@ -282,9 +303,10 @@ class Facebook_Follow_Button_Settings extends Facebook_Social_Plugin_Button_Sett
 	}
 
 	/**
-	 * Describe layout choices
+	 * Describe layout choices.
 	 *
 	 * @since 1.1
+	 *
 	 * @return array layout descriptions keyed by layout choice
 	 */
 	public static function layout_descriptions() {
@@ -297,10 +319,12 @@ class Facebook_Follow_Button_Settings extends Facebook_Social_Plugin_Button_Sett
 	}
 
 	/**
-	 * Choose a Follow Button layout option
+	 * Choose a Follow Button layout option.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $extra_attributes custom form attributes
+	 * @return void
 	 */
 	public function display_layout( $extra_attributes = array() ) {
 		$key = 'layout';
@@ -351,10 +375,12 @@ class Facebook_Follow_Button_Settings extends Facebook_Social_Plugin_Button_Sett
 	}
 
 	/**
-	 * Option to display faces of friends below the Follow Button
+	 * Option to display faces of friends below the Follow Button.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $extra_attributes custom form attributes
+	 * @return void
 	 */
 	public function display_show_faces( $extra_attributes = array() ) {
 		$key = 'show_faces';
@@ -376,10 +402,13 @@ class Facebook_Follow_Button_Settings extends Facebook_Social_Plugin_Button_Sett
 	}
 
 	/**
-	 * Allow the publisher to customize the width of the Follow Button
+	 * Allow the publisher to customize the width of the Follow Button.
 	 *
 	 * @since 1.1
+	 *
+	 * @global int $content_width theme content width used as default width value
 	 * @param array $extra_attributes custom form attributes
+	 * @return void
 	 */
 	public function display_width( $extra_attributes = array() ) {
 		global $content_width;
@@ -413,10 +442,12 @@ class Facebook_Follow_Button_Settings extends Facebook_Social_Plugin_Button_Sett
 	}
 
 	/**
-	 * Customize the color scheme
+	 * Customize the color scheme.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $extra_attributes custom form attributes
+	 * @return void
 	 */
 	public function display_colorscheme( $extra_attributes = array() ) {
 		$key = 'colorscheme';
@@ -437,10 +468,12 @@ class Facebook_Follow_Button_Settings extends Facebook_Social_Plugin_Button_Sett
 	}
 
 	/**
-	 * Choose a custom font
+	 * Choose a custom font.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $extra_attributes custom form attributes
+	 * @return void
 	 */
 	public function display_font( $extra_attributes = array() ) {
 		$key = 'font';
@@ -464,7 +497,9 @@ class Facebook_Follow_Button_Settings extends Facebook_Social_Plugin_Button_Sett
 	 * Where would you like it?
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $extra_attributes custom form attributes
+	 * @return void
 	 */
 	public function display_position( $extra_attributes = array() ) {
 		$key = 'position';
@@ -485,9 +520,10 @@ class Facebook_Follow_Button_Settings extends Facebook_Social_Plugin_Button_Sett
 	}
 
 	/**
-	 * Translate HTML data response returned from Facebook social plugin builder into underscored keys and PHP values before saving
+	 * Translate HTML data response returned from Facebook social plugin builder into underscored keys and PHP values before saving.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $options data-* options returned from Facebook social plugin builder
 	 * @return array $options options to store in WordPress
 	 */
@@ -510,9 +546,10 @@ class Facebook_Follow_Button_Settings extends Facebook_Social_Plugin_Button_Sett
 	}
 
 	/**
-	 * Sanitize Follow Button settings before they are saved to the database
+	 * Sanitize Follow Button settings before they are saved to the database.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $options Follow Button options
 	 * @return array clean option sets. note: we remove Follow Button social plugin default options, storing only custom settings (e.g. dark color scheme stored, light is default and therefore not stored)
 	 */

--- a/admin/settings-like-button.php
+++ b/admin/settings-like-button.php
@@ -11,17 +11,19 @@ if ( ! class_exists( 'Facebook_Social_Plugin_Button_Settings' ) )
 class Facebook_Like_Button_Settings extends Facebook_Social_Plugin_Button_Settings {
 
 	/**
-	 * Setting page identifier
+	 * Setting page identifier.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const PAGE_SLUG = 'facebook-like-button';
 
 	/**
-	 * Define our option array value
+	 * Define our option array value.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const OPTION_NAME = 'facebook_like_button';
@@ -30,14 +32,16 @@ class Facebook_Like_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	 * The hook suffix assigned by add_submenu_page()
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	protected $hook_suffix = '';
 
 	/**
-	 * Initialize with an options array
+	 * Initialize with an options array.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $options existing options
 	 */
 	public function __construct( $options = array() ) {
@@ -51,6 +55,8 @@ class Facebook_Like_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	 * Evaluate the Facebook_Like_Button class file if it is not already loaded
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public static function require_like_button_builder() {
 		if ( ! class_exists( 'Facebook_Like_Button' ) )
@@ -58,7 +64,7 @@ class Facebook_Like_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	}
 
 	/**
-	 * Reference the social plugin by name
+	 * Reference the social plugin by name.
 	 *
 	 * @since 1.1
 	 * @return string social plugin name
@@ -68,9 +74,10 @@ class Facebook_Like_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	}
 
 	/**
-	 * Navigate to the settings page through the Facebook top-level menu item
+	 * Navigate to the settings page through the Facebook top-level menu item.
 	 *
 	 * @since 1.1
+	 *
 	 * @uses add_submenu_page()
 	 * @param string $parent_slug Facebook top-level menu item slug
 	 * @return string submenu hook suffix
@@ -97,9 +104,11 @@ class Facebook_Like_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	}
 
 	/**
-	 * Load stored options and scripts on settings page view
+	 * Load stored options and scripts on settings page view.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function onload() {
 		$options = get_option( self::OPTION_NAME );
@@ -111,9 +120,11 @@ class Facebook_Like_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	}
 
 	/**
-	 * Load the page
+	 * Load the page.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function settings_page() {
 		if ( ! isset( $this->hook_suffix ) )
@@ -123,11 +134,13 @@ class Facebook_Like_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	}
 
 	/**
-	 * Hook into the settings API
+	 * Hook into the settings API.
 	 *
 	 * @since 1.1
+	 *
 	 * @uses add_settings_section()
 	 * @uses add_settings_field()
+	 * @return void
 	 */
 	private function settings_api_init() {
 		if ( ! isset( $this->hook_suffix ) )
@@ -218,6 +231,8 @@ class Facebook_Like_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	 * Introduce publishers to the Like Button social plugin
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function section_header() {
 		echo '<p>' . esc_html( __( 'Help your visitors share your pages on their Facebook profile with one click.', 'facebook' ) ) . ' <a href="https://developers.facebook.com/docs/reference/plugins/like/" title="' . esc_attr( sprintf( __( '%s social plugin documentation', 'facebook' ), 'Facebook ' . self::social_plugin_name() ) ) . '">' . esc_html( __( 'Read more...', 'facebook' ) ) . '</a></p>';
@@ -227,7 +242,9 @@ class Facebook_Like_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	 * Where should the button appear?
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $extra_attributes custom form attributes
+	 * @return void
 	 */
 	public function display_show_on( $extra_attributes = array() ) {
 		$key = 'show_on';
@@ -253,7 +270,9 @@ class Facebook_Like_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	 * Where would you like it?
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $extra_attributes custom form attributes
+	 * @return void
 	 */
 	public function display_position( $extra_attributes = array() ) {
 		$key = 'position';
@@ -274,10 +293,12 @@ class Facebook_Like_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	}
 
 	/**
-	 * Display the send button option checkbox
+	 * Display the send button option checkbox.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $extra_attributes custom form attributes
+	 * @return void
 	 */
 	public function display_send( $extra_attributes = array() ) {
 		$key = 'send';
@@ -303,9 +324,10 @@ class Facebook_Like_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	}
 
 	/**
-	 * Describe layout choices
+	 * Describe layout choices.
 	 *
 	 * @since 1.1
+	 *
 	 * @return array layout descriptions keyed by layout choice
 	 */
 	public static function layout_descriptions() {
@@ -318,10 +340,12 @@ class Facebook_Like_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	}
 
 	/**
-	 * Choose a Like Button layout option
+	 * Choose a Like Button layout option.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $extra_attributes custom form attributes
+	 * @return void
 	 */
 	public function display_layout( $extra_attributes = array() ) {
 		$key = 'layout';
@@ -375,7 +399,9 @@ class Facebook_Like_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	 * Option to display faces of friends below the Like Button
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $extra_attributes custom form attributes
+	 * @return void
 	 */
 	public function display_show_faces( $extra_attributes = array() ) {
 		$key = 'show_faces';
@@ -400,7 +426,9 @@ class Facebook_Like_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	 * Allow the publisher to customize the width of the Like Button
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $extra_attributes custom form attributes
+	 * @return void
 	 */
 	public function display_width( $extra_attributes = array() ) {
 		global $content_width;
@@ -438,7 +466,9 @@ class Facebook_Like_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	 * Choose action text.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $extra_attributes custom form attributes
+	 * @return void
 	 */
 	public function display_action( $extra_attributes = array() ) {
 		$key = 'action';
@@ -475,10 +505,12 @@ class Facebook_Like_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	}
 
 	/**
-	 * Choose a custom font
+	 * Choose a custom font.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $extra_attributes custom form attributes
+	 * @return void
 	 */
 	public function display_font( $extra_attributes = array() ) {
 		$key = 'font';
@@ -499,10 +531,12 @@ class Facebook_Like_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	}
 
 	/**
-	 * Customize the color scheme
+	 * Customize the color scheme.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $extra_attributes custom form attributes
+	 * @return void
 	 */
 	public function display_colorscheme( $extra_attributes = array() ) {
 		$key = 'colorscheme';
@@ -523,9 +557,10 @@ class Facebook_Like_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	}
 
 	/**
-	 * Translate HTML data response returned from Facebook social plugin builder into underscored keys and PHP values before saving
+	 * Translate HTML data response returned from Facebook social plugin builder into underscored keys and PHP values before saving.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $options data-* options returned from Facebook social plugin builder
 	 * @return array $options options to store in WordPress
 	 */
@@ -555,9 +590,10 @@ class Facebook_Like_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	}
 
 	/**
-	 * Sanitize Like Button settings before they are saved to the database
+	 * Sanitize Like Button settings before they are saved to the database.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $options Like Button options
 	 * @return array clean option sets. note: we remove Like Button social plugin default options, storing only custom settings (e.g. dark color scheme stored, light is default and therefore not stored)
 	 */

--- a/admin/settings-recommendations-bar.php
+++ b/admin/settings-recommendations-bar.php
@@ -11,17 +11,19 @@ if ( ! class_exists( 'Facebook_Social_Plugin_Settings' ) )
 class Facebook_Recommendations_Bar_Settings extends Facebook_Social_Plugin_Settings {
 
 	/**
-	 * Setting page identifier
+	 * Setting page identifier.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const PAGE_SLUG = 'facebook-recommendations-bar';
 
 	/**
-	 * Define our option array value
+	 * Define our option array value.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const OPTION_NAME = 'facebook_recommendations_bar';
@@ -30,14 +32,16 @@ class Facebook_Recommendations_Bar_Settings extends Facebook_Social_Plugin_Setti
 	 * The hook suffix assigned by add_submenu_page()
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	protected $hook_suffix = '';
 
 	/**
-	 * Initialize with an options array
+	 * Initialize with an options array.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $options existing options
 	 */
 	public function __construct( $options = array() ) {
@@ -48,9 +52,10 @@ class Facebook_Recommendations_Bar_Settings extends Facebook_Social_Plugin_Setti
 	}
 
 	/**
-	 * Reference the social plugin by name
+	 * Reference the social plugin by name.
 	 *
 	 * @since 1.1
+	 *
 	 * @return string social plugin name
 	 */
 	public static function social_plugin_name() {
@@ -58,9 +63,11 @@ class Facebook_Recommendations_Bar_Settings extends Facebook_Social_Plugin_Setti
 	}
 
 	/**
-	 * Evaluate the Facebook_Recommendations_Bar class file if it is not already loaded
+	 * Evaluate the Facebook_Recommendations_Bar class file if it is not already loaded.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public static function require_recommendations_bar_builder() {
 		if ( ! class_exists( 'Facebook_Recommendations_Bar' ) )
@@ -71,6 +78,7 @@ class Facebook_Recommendations_Bar_Settings extends Facebook_Social_Plugin_Setti
 	 * Navigate to the settings page through the Facebook top-level menu item
 	 *
 	 * @since 1.1
+	 *
 	 * @uses add_submenu_page()
 	 * @param string $parent_slug Facebook top-level menu item slug
 	 * @return string submenu hook suffix
@@ -100,6 +108,8 @@ class Facebook_Recommendations_Bar_Settings extends Facebook_Social_Plugin_Setti
 	 * Load stored options and scripts on settings page view
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function onload() {
 		$options = get_option( self::OPTION_NAME );
@@ -114,6 +124,8 @@ class Facebook_Recommendations_Bar_Settings extends Facebook_Social_Plugin_Setti
 	 * Load the page
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function settings_page() {
 		if ( ! isset( $this->hook_suffix ) )
@@ -126,9 +138,11 @@ class Facebook_Recommendations_Bar_Settings extends Facebook_Social_Plugin_Setti
 	 * Hook into the settings API
 	 *
 	 * @since 1.1
+	 *
 	 * @uses add_settings_section()
 	 * @uses add_settings_field()
 	 * @param string $options_group target grouping
+	 * @return void
 	 */
 	private function settings_api_init() {
 		if ( ! isset( $this->hook_suffix ) )
@@ -203,6 +217,8 @@ class Facebook_Recommendations_Bar_Settings extends Facebook_Social_Plugin_Setti
 	 * Introduce publishers to the Recommendations Bar social plugin
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function section_header() {
 		echo '<p>' . esc_html( __( 'Encourage additional pageviews with site recommendations based on social context.', 'facebook' ) ) . ' ' . esc_html( sprintf( __( 'Adds a %s overlay to the bottom of your page with an expanded list of recommendations triggered by time or position on the page.', 'facebook' ), __( 'Like Button', 'facebook' ) ) ) . '<br /><a href="https://developers.facebook.com/docs/reference/plugins/recommendationsbar/" title="' . esc_attr( sprintf( __( '%s social plugin documentation', 'facebook' ), 'Facebook ' . self::social_plugin_name() ) ) . '">' . esc_html( __( 'Read more...', 'facebook' ) ) . '</a></p>';
@@ -212,6 +228,8 @@ class Facebook_Recommendations_Bar_Settings extends Facebook_Social_Plugin_Setti
 	 * Where should the button appear?
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function display_show_on() {
 		echo '<fieldset id="facebook-recommendations-bar-show-on">' . self::show_on_choices( self::OPTION_NAME . '[show_on]', self::get_display_conditionals_by_feature( 'recommendations_bar', 'all' ) ) . '</fieldset>';
@@ -223,6 +241,8 @@ class Facebook_Recommendations_Bar_Settings extends Facebook_Social_Plugin_Setti
 	 * Choose to display the recommendations bar on the left or right side
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function display_side() {
 		$key = 'side';
@@ -248,6 +268,8 @@ class Facebook_Recommendations_Bar_Settings extends Facebook_Social_Plugin_Setti
 	 * Choose action text.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function display_action() {
 		$key = 'action';
@@ -274,6 +296,8 @@ class Facebook_Recommendations_Bar_Settings extends Facebook_Social_Plugin_Setti
 	 * What page progression should trigger the recommendations bar?
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function display_trigger() {
 		$key = 'trigger';
@@ -305,9 +329,11 @@ class Facebook_Recommendations_Bar_Settings extends Facebook_Social_Plugin_Setti
 	}
 
 	/**
-	 * Trigger the recommendations bar after a given number of seconds
+	 * Trigger the recommendations bar after a given number of seconds.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function display_read_time() {
 		$key = 'read_time';
@@ -324,9 +350,11 @@ class Facebook_Recommendations_Bar_Settings extends Facebook_Social_Plugin_Setti
 	}
 
 	/**
-	 * Maximum number of recommendations displayed
+	 * Maximum number of recommendations displayed.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function display_num_recommendations() {
 		$key = 'num_recommendations';
@@ -342,9 +370,11 @@ class Facebook_Recommendations_Bar_Settings extends Facebook_Social_Plugin_Setti
 	}
 
 	/**
-	 * Maximum age of a recommended article
+	 * Maximum age of a recommended article.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function display_max_age() {
 		$key = 'max_age';
@@ -366,9 +396,10 @@ class Facebook_Recommendations_Bar_Settings extends Facebook_Social_Plugin_Setti
 	}
 
 	/**
-	 * Translate HTML data response returned from Facebook social plugin builder into underscored keys and PHP values before saving
+	 * Translate HTML data response returned from Facebook social plugin builder into underscored keys and PHP values before saving.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $options data-* options returned from Facebook social plugin builder
 	 * @return array $options options to store in WordPress
 	 */
@@ -387,9 +418,10 @@ class Facebook_Recommendations_Bar_Settings extends Facebook_Social_Plugin_Setti
 	}
 
 	/**
-	 * Sanitize Recommendations Bar settings before they are saved to the database
+	 * Sanitize Recommendations Bar settings before they are saved to the database.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $options recommendation bar options
 	 * @return array clean option sets. note: we remove Recommendation Button social plugin default options, storing only custom settings (e.g. recommend action preference value stored, like is not stored)
 	 */

--- a/admin/settings-send-button.php
+++ b/admin/settings-send-button.php
@@ -11,17 +11,19 @@ if ( ! class_exists( 'Facebook_Social_Plugin_Button_Settings' ) )
 class Facebook_Send_Button_Settings extends Facebook_Social_Plugin_Button_Settings {
 
 	/**
-	 * Setting page identifier
+	 * Setting page identifier.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const PAGE_SLUG = 'facebook-send-button';
 
 	/**
-	 * Define our option array value
+	 * Define our option array value.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const OPTION_NAME = 'facebook_send_button';
@@ -30,14 +32,16 @@ class Facebook_Send_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	 * The hook suffix assigned by add_submenu_page()
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	protected $hook_suffix = '';
 
 	/**
-	 * Initialize with an options array
+	 * Initialize with an options array.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $options existing options
 	 */
 	public function __construct( $options = array() ) {
@@ -48,9 +52,10 @@ class Facebook_Send_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	}
 
 	/**
-	 * Reference the social plugin by name
+	 * Reference the social plugin by name.
 	 *
 	 * @since 1.1
+	 *
 	 * @return string social plugin name
 	 */
 	public static function social_plugin_name() {
@@ -58,9 +63,10 @@ class Facebook_Send_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	}
 
 	/**
-	 * Navigate to the settings page through the Facebook top-level menu item
+	 * Navigate to the settings page through the Facebook top-level menu item.
 	 *
 	 * @since 1.1
+	 *
 	 * @uses add_submenu_page()
 	 * @param string $parent_slug Facebook top-level menu item slug
 	 * @return string submenu hook suffix
@@ -87,7 +93,7 @@ class Facebook_Send_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	}
 
 	/**
-	 * Load stored options and scripts on settings page view
+	 * Load stored options and scripts on settings page view.
 	 *
 	 * @since 1.1
 	 */
@@ -101,9 +107,11 @@ class Facebook_Send_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	}
 
 	/**
-	 * Load the page
+	 * Load the page.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function settings_page() {
 		if ( ! isset( $this->hook_suffix ) )
@@ -113,11 +121,13 @@ class Facebook_Send_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	}
 
 	/**
-	 * Hook into the settings API
+	 * Hook into the settings API.
 	 *
 	 * @since 1.1
+	 *
 	 * @uses add_settings_section()
 	 * @uses add_settings_field()
+	 * @return void
 	 */
 	private function settings_api_init() {
 		if ( ! isset( $this->hook_suffix ) )
@@ -167,9 +177,11 @@ class Facebook_Send_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	}
 
 	/**
-	 * Introduce publishers to the Send Button social plugin
+	 * Introduce publishers to the Send Button social plugin.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function section_header() {
 		echo '<p>';
@@ -182,7 +194,9 @@ class Facebook_Send_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	 * Where should the button appear?
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $extra_attributes custom form attributes
+	 * @return void
 	 */
 	public function display_show_on( $extra_attributes = array() ) {
 		$key = 'show_on';
@@ -234,10 +248,12 @@ class Facebook_Send_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	}
 
 	/**
-	 * Choose a custom font
+	 * Choose a custom font.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $extra_attributes custom form attributes
+	 * @return void
 	 */
 	public function display_font( $extra_attributes = array() ) {
 		$key = 'font';
@@ -258,10 +274,12 @@ class Facebook_Send_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	}
 
 	/**
-	 * Customize the color scheme
+	 * Customize the color scheme.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $extra_attributes custom form attributes
+	 * @return void
 	 */
 	public function display_colorscheme( $extra_attributes = array() ) {
 		$key = 'colorscheme';
@@ -285,6 +303,7 @@ class Facebook_Send_Button_Settings extends Facebook_Social_Plugin_Button_Settin
 	 * Sanitize Send Button settings before they are saved to the database
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $options Send Button options
 	 * @return array clean option sets. note: we remove Send Button social plugin default options, storing only custom settings (e.g. dark color scheme stored, light is default and therefore not stored)
 	 */

--- a/admin/settings-social-plugin-button.php
+++ b/admin/settings-social-plugin-button.php
@@ -10,17 +10,19 @@ if ( ! class_exists( 'Facebook_Social_Plugin_Settings' ) )
  */
 class Facebook_Social_Plugin_Button_Settings extends Facebook_Social_Plugin_Settings {
 	/**
-	 * Place a social plugin button above, below, or both above and below post content
+	 * Place a social plugin button above, below, or both above and below post content.
 	 *
 	 * @since 1.1
+	 *
 	 * @var array
 	 */
 	public static $position_choices = array( 'both', 'top', 'bottom' );
 
 	/**
-	 * Choose the position of a social plugin button above, below, or above and below your content
+	 * Choose the position of a social plugin button above, below, or above and below your content.
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $existing_value stored option value
 	 * @return string HTML <option>s
 	 */
@@ -51,6 +53,8 @@ class Facebook_Social_Plugin_Button_Settings extends Facebook_Social_Plugin_Sett
 	 * Sanitize social plugin button common settings before they are saved to the database
 	 *
 	 * @since 1.1
+	 *
+	 * @uses Facebook_Social_Plugin_Settings::sanitize_options()
 	 * @param array $options social plugin button options
 	 * @return array clean option set
 	 */

--- a/admin/settings-social-publisher.php
+++ b/admin/settings-social-publisher.php
@@ -7,33 +7,37 @@
  */
 class Facebook_Social_Publisher_Settings {
 	/**
-	 * Setting page identifier
+	 * Setting page identifier.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const PAGE_SLUG = 'facebook-social-publisher';
 
 	/**
-	 * Define the option name used to process the form
+	 * Define the option name used to process the form.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const PUBLISH_OPTION_NAME = 'facebook_publish';
 
 	/**
-	 * Option name for target Facebook page
+	 * Option name for target Facebook page.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const OPTION_PUBLISH_TO_PAGE = 'facebook_publish_page';
 
 	/**
-	 * Option name for advanced Facebook Open Graph action functionality
+	 * Option name for advanced Facebook Open Graph action functionality.
 	 *
 	 * @since 1.2.4
+	 *
 	 * @var string
 	 */
 	const OPTION_OG_ACTION = 'facebook_og_action';
@@ -48,7 +52,9 @@ class Facebook_Social_Publisher_Settings {
 	protected $hook_suffix = '';
 
 	/**
-	 * The current user object
+	 * The current user object.
+	 *
+	 * @since 1.1
 	 *
 	 * @var WP_User
 	 */
@@ -58,6 +64,7 @@ class Facebook_Social_Publisher_Settings {
 	 * Does the current WordPress user have an associated Facebook account stored?
 	 *
 	 * @since 1.1
+	 *
 	 * @var boolean
 	 */
 	protected $user_associated_with_facebook_account = false;
@@ -66,6 +73,7 @@ class Facebook_Social_Publisher_Settings {
 	 * Reference the social plugin by name
 	 *
 	 * @since 1.1
+	 *
 	 * @return string social plugin name
 	 */
 	public static function social_plugin_name() {
@@ -73,9 +81,10 @@ class Facebook_Social_Publisher_Settings {
 	}
 
 	/**
-	 * Navigate to the settings page through the Facebook top-level menu item
+	 * Navigate to the settings page through the Facebook top-level menu item.
 	 *
 	 * @since 1.1
+	 *
 	 * @uses add_submenu_page()
 	 * @param string $parent_slug Facebook top-level menu item slug
 	 * @return string submenu hook suffix
@@ -105,6 +114,8 @@ class Facebook_Social_Publisher_Settings {
 	 * Load extra assets early in the page build process to tap into proper hooks
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function onload() {
 		// prep user-specific functionality and comparisons
@@ -128,6 +139,8 @@ class Facebook_Social_Publisher_Settings {
 	 * Load the page
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function settings_page() {
 		if ( ! isset( $this->hook_suffix ) )
@@ -137,11 +150,13 @@ class Facebook_Social_Publisher_Settings {
 	}
 
 	/**
-	 * Hook into the settings API
+	 * Hook into the settings API.
 	 *
 	 * @since 1.1
+	 *
 	 * @uses add_settings_section()
 	 * @uses add_settings_field()
+	 * @return void
 	 */
 	private function settings_api_init() {
 		if ( ! isset( $this->hook_suffix ) )
@@ -195,10 +210,12 @@ class Facebook_Social_Publisher_Settings {
 	}
 
 	/**
-	 * Add the login JavaScript to the WordPress script queue
+	 * Add the login JavaScript to the WordPress script queue.
 	 *
 	 * @since 1.5
+	 *
 	 * @uses wp_enqueue_script()
+	 * @return void
 	 */
 	public static function enqueue_scripts() {
 		global $wp_scripts;
@@ -219,9 +236,12 @@ class Facebook_Social_Publisher_Settings {
 	}
 
 	/**
-	 * Introduce the publish to Facebook feature
+	 * Introduce the publish to Facebook feature.
 	 *
 	 * @since 1.1
+	 *
+	 * @global Facebook_Loader $facebook_loader Facebook application id
+	 * @return void
 	 */
 	public function section_timeline_publish() {
 		global $facebook_loader;
@@ -274,27 +294,33 @@ class Facebook_Social_Publisher_Settings {
 	}
 
 	/**
-	 * Describe publish to Facebook Page functionality
+	 * Describe publish to Facebook Page functionality.
 	 *
 	 * @since 1.2.4
+	 *
+	 * @return void
 	 */
 	public function section_page_publish() {
 		echo '<p>' . sprintf( esc_html( __( 'Publish to a Facebook Page using the credentials of a Facebook account with %s permissions for the Page.', 'facebook' ) ), '<a href="' . esc_html( 'https://www.facebook.com/help/289207354498410/', array( 'http', 'https' ) ) . '" target="_blank">' . esc_html( __( 'content creator', 'facebook' ) ) . '</a>' ) . '</p>';
 	}
 
 	/**
-	 * Publish new posts to your Facebook timeline
+	 * Publish new posts to your Facebook timeline.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public static function display_publish_author() {
 		echo '<p>' . sprintf( esc_html( __( 'An author can associate his or her WordPress account with a Facebook account on his or her %s', 'facebook' ) ), '<a href="' . esc_url( self_admin_url( 'profile.php' ), array( 'http', 'https' ) ) . '" target="_blank">' . esc_html( __( 'profile page', 'facebook' ) ) . '</a>' ) . '</p>';
 	}
 
 	/**
-	 * Publish new posts to your Facebook page
+	 * Publish new posts to your Facebook page.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function display_publish_page() {
 		$existing_page = get_option( self::OPTION_PUBLISH_TO_PAGE );
@@ -344,9 +370,11 @@ class Facebook_Social_Publisher_Settings {
 	}
 
 	/**
-	 * Display an option for the publisher to enable advanced Open Graph action functionality
+	 * Display an option for the publisher to enable advanced Open Graph action functionality.
 	 *
 	 * @since 1.2.4
+	 *
+	 * @return void
 	 */
 	public function display_og_action() {
 		$id = 'og-action';
@@ -357,9 +385,10 @@ class Facebook_Social_Publisher_Settings {
 	}
 
 	/**
-	 * Display inline help for publisher functionality
+	 * Display inline help for publisher functionality.
 	 *
 	 * @since 1.1.11
+	 *
 	 * @return string HTML
 	 */
 	public static function help_tab_publisher() {
@@ -371,9 +400,12 @@ class Facebook_Social_Publisher_Settings {
 	}
 
 	/**
-	 * Display help content on the settings page
+	 * Display help content on the settings page.
 	 *
 	 * @since 1.1
+	 *
+	 * @uses get_current_screen()
+	 * @return void
 	 */
 	public static function inline_help_content() {
 		$screen = get_current_screen();
@@ -390,11 +422,14 @@ class Facebook_Social_Publisher_Settings {
 	}
 
 	/**
-	 * Update the Facebook page information stored for the site
+	 * Update the Facebook page information stored for the site.
 	 *
 	 * @since 1.1
+	 *
 	 * @uses update_option()
+	 * @global Facebook_Loader $facebook_loader request app access secret to hash app access token
 	 * @param array $page_data data returned from Facebook Graph API permissions call
+	 * @return void
 	 */
 	public static function update_publish_to_page( $page_data ) {
 		global $facebook_loader;
@@ -437,9 +472,10 @@ class Facebook_Social_Publisher_Settings {
 	}
 
 	/**
-	 * Set the appropriate settings for each form component
+	 * Set the appropriate settings for each form component.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $options social publisher options
 	 * @return array clean option sets.
 	 */

--- a/admin/social-publisher/mentions/mentions-search.php
+++ b/admin/social-publisher/mentions/mentions-search.php
@@ -7,28 +7,36 @@
  */
 class Facebook_Mentions_Search {
 	/**
-	 * Maximum number of search results to return
+	 * Maximum number of search results to return.
 	 *
 	 * @since 1.2
+	 *
 	 * @var int
 	 */
 	const MAX_RESULTS = 8;
 
 	/**
-	 * Respond to WordPress admin AJAX requests
-	 * Adds custom wp_ajax_* actions
+	 * Respond to WordPress admin AJAX requests.
+	 *
+	 * Adds custom wp_ajax_* actions.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public static function wp_ajax_handlers() {
 		add_action( 'wp_ajax_facebook_mentions_search_autocomplete', array( 'Facebook_Mentions_Search', 'search_endpoint' ) );
 	}
 
 	/**
-	 * Check for minimum requirements before conducting a Facebook search
-	 * Populate result set with up to MAX_RESULTS results from current user's Facebook friends or Facebook pages
+	 * Check for minimum requirements before conducting a Facebook search.
+	 *
+	 * Populate result set with up to MAX_RESULTS results from current user's Facebook friends or Facebook pages.
 	 *
 	 * @since 1.2
+	 *
+	 * @global \Facebook_Loader $facebook_loader Determine if app access token exists
+	 * @return void
 	 */
 	public static function search_endpoint() {
 		global $facebook_loader;
@@ -76,9 +84,17 @@ class Facebook_Mentions_Search {
 	 * Search Facebook friends with names matching a given string up to a maximum number of results
 	 *
 	 * @since 1.2
+	 *
 	 * @param string $search_term search string
 	 * @param int $limit maximum number of results
-	 * @return array friend results
+	 * @return array {
+	 *     friend results
+	 *
+	 *     @type string 'object_type' user. Differentiate between User and Page results combined in one search.
+	 *     @type string 'id' Facebook User identifier.
+	 *     @type string 'name' Facebook User name.
+	 *     @type string 'picture' Facebook User picture URL.
+	 * }
 	 */
 	public static function search_friends( $search_term, $limit = 4 ) {
 		if ( ! class_exists( 'Facebook_User' ) )
@@ -154,9 +170,21 @@ class Facebook_Mentions_Search {
 	 * Search for Facebook pages matching a given string up to maximum number of results
 	 *
 	 * @since 1.2
+	 *
 	 * @param string $search_term search string
 	 * @param int $limit maximum number of results
-	 * @return array pages results
+	 * @return array {
+	 *     friend results
+	 *
+	 *     @type string 'object_type' page. Differentiate between Page and User objects in the same search results set
+	 *     @type string 'id' Facebook Page id.
+	 *     @type string 'name' Facebook Page name.
+	 *     @type string 'image' Facebook Page image URL
+	 *     @type int 'likes' Number of Likes received by the Page.
+	 *     @type int 'talking_about_count' Number of Facebook Users talking about the Page.
+	 *     @type string 'category' Page category.
+	 *     @type string 'location' Page location (if a physical place).
+	 * }
 	 */
 	public static function search_pages( $search_term, $limit = 4 ) {
 		global $facebook_loader;

--- a/admin/social-publisher/publish-box-page.php
+++ b/admin/social-publisher/publish-box-page.php
@@ -7,51 +7,59 @@
  */
 class Facebook_Social_Publisher_Meta_Box_Page {
 	/**
-	 * Check page origin before saving
+	 * Check page origin before saving.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const NONCE_NAME = 'facebook_fan_page_message_box_noncename';
 
 	/**
-	 * Post meta key for the message
+	 * Post meta key for the message.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const POST_META_KEY = 'fb_fan_page_message';
 
 	/**
-	 * Post meta key for post to Facebook feature enabled / disabled
+	 * Post meta key for post to Facebook feature enabled / disabled.
 	 *
 	 * @since 1.2
+	 *
 	 * @var string
 	 */
 	const POST_META_KEY_FEATURE_ENABLED = 'post_to_facebook_page';
 
 	/**
-	 * Form field name for page message
+	 * Form field name for page message.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const FIELD_MESSAGE = 'facebook_page_message_box_message';
 
 	/**
-	 * Form field name for feature enabled or disabled
+	 * Form field name for feature enabled or disabled.
 	 *
 	 * @since 1.2
+	 *
 	 * @var string
 	 */
 	const FIELD_FEATURE_ENABLED = 'facebook_page_enabled';
 
 	/**
-	 * Add a meta box to the post editor
+	 * Add a meta box to the post editor.
 	 *
 	 * @since 1.1
+	 *
+	 * @uses add_meta_box()
 	 * @param string $post_type target page post type
-	 * @param array Facebook page info
+	 * @param array $page Facebook page info
+	 * @return void
 	 */
 	public static function add_meta_box( $post_type, $page ) {
 		add_meta_box(
@@ -63,10 +71,12 @@ class Facebook_Social_Publisher_Meta_Box_Page {
 	}
 
 	/**
-	 * Add content to the page publisher meta box
+	 * Add content to the page publisher meta box.
 	 *
 	 * @since 1.0
+	 *
 	 * @param stdClass $post current post
+	 * @return void
 	 */
 	public static function content( $post ) {
 		$page = get_option( 'facebook_publish_page' );
@@ -91,10 +101,12 @@ class Facebook_Social_Publisher_Meta_Box_Page {
 	}
 
 	/**
-	 * Save the custom Status, used when posting to an Fan Page's Timeline
+	 * Save the custom Status, used when posting to an Fan Page's Timeline.
 	 *
 	 * @since 1.0
-	 * @param int $post_id post identifier
+	 *
+	 * @param int $post_id WordPress post identifier
+	 * @return void
 	 */
 	public static function save( $post_id ) {
 		// verify if this is an auto save routine.
@@ -116,7 +128,7 @@ class Facebook_Social_Publisher_Meta_Box_Page {
 		if ( ! class_exists( 'Facebook_Social_Publisher' ) )
 			require_once( dirname(__FILE__) . '/social_publisher.php' );
 		$capability_singular_base = Facebook_Social_Publisher::post_type_capability_base( $post_type );
-	
+
 		if ( ! current_user_can( 'edit_' . $capability_singular_base, $post_id ) )
 			return;
 

--- a/admin/social-publisher/publish-box-profile.php
+++ b/admin/social-publisher/publish-box-profile.php
@@ -8,55 +8,60 @@
 class Facebook_Social_Publisher_Meta_Box_Profile {
 
 	/**
-	 * Check page origin before saving
+	 * Check page origin before saving.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const NONCE_NAME = 'facebook_profile_meta_box_noncename';
 
 	/**
-	 * Post meta key for the message
+	 * Post meta key for the message.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const POST_META_KEY_MESSAGE = 'fb_author_message';
 
 	/**
-	 * Post meta key for post to Facebook feature enabled / disabled
+	 * Post meta key for post to Facebook feature enabled / disabled.
 	 *
 	 * @since 1.2
+	 *
 	 * @var string
 	 */
 	const POST_META_KEY_FEATURE_ENABLED = 'post_to_facebook_timeline';
 
 	/**
-	 * Form field name for author profile message
+	 * Form field name for author profile message.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const FIELD_MESSAGE = 'facebook_author_message_box_message';
 
 	/**
-	 * Form field name for feature enabled or disabled
+	 * Form field name for feature enabled or disabled.
 	 *
 	 * @since 1.2
+	 *
 	 * @var string
 	 */
 	const FIELD_FEATURE_ENABLED = 'facebook_author_enabled';
 
 	/**
-	 * Add a meta box to the post editor
+	 * Add a meta box to the post editor.
 	 *
 	 * @since 1.1
+	 *
+	 * @uses add_meta_box()
 	 * @param string $post_type target page post type
-	 * @param array Facebook page info
+	 * @return void
 	 */
 	public static function add_meta_box( $post_type ) {
-		global $facebook, $facebook_loader;
-
 		add_meta_box(
 			'facebook-author-message-box-id',
 			__( 'Facebook Status on Your Timeline', 'facebook' ),
@@ -73,10 +78,13 @@ class Facebook_Social_Publisher_Meta_Box_Profile {
 	}
 
 	/**
-	 * Load mentions typeahead JavaScript and jQuery UI requirements
+	 * Load mentions typeahead JavaScript and jQuery UI requirements.
 	 *
 	 * @since 1.2
+	 *
+	 * @global \Facebook_Loader $facebook_loader reference plugin directory
 	 * @uses wp_enqueue_script()
+	 * @return void
 	 */
 	public static function enqueue_scripts( ) {
 		global $facebook_loader;
@@ -93,7 +101,10 @@ class Facebook_Social_Publisher_Meta_Box_Profile {
 	 * Add content to the profile publisher meta box
 	 *
 	 * @since 1.0
+	 *
+	 * @global WP_Locale $wp_locale display Like counts in the number format of the current locale
 	 * @param stdClass $post current post
+	 * @return void
 	 */
 	public static function content( $post ) {
 		global $wp_locale;
@@ -136,10 +147,12 @@ class Facebook_Social_Publisher_Meta_Box_Profile {
 	}
 
 	/**
-	 * Save the custom Status, used when posting to an Fan Page's Timeline
+	 * Save the custom Status, used when posting to a User's Timeline.
 	 *
 	 * @since 1.0
-	 * @param int $post_id post identifier
+	 *
+	 * @param int $post_id WordPress post identifier
+	 * @global void
 	 */
 	public static function save( $post_id ) {
 		// verify if this is an auto save routine.

--- a/admin/social-publisher/social-publisher.php
+++ b/admin/social-publisher/social-publisher.php
@@ -10,7 +10,9 @@ class Facebook_Social_Publisher {
 	 * Initialize social publisher hooks
 	 *
 	 * @since 1.2
-	 * @return Facebook_Social_Publisher new Facebook_Social_Publisher object
+	 *
+	 * @global \Facebook_Loader $facebook_loader test if Facebook app access token exists
+	 * @return void
 	 */
 	public static function init() {
 		global $facebook_loader;
@@ -31,9 +33,11 @@ class Facebook_Social_Publisher {
 	}
 
 	/**
-	 * Check for meta box content on post save
+	 * Check for meta box content on post save.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public static function add_save_post_hooks() {
 		// verify if this is an auto save routine.
@@ -51,9 +55,11 @@ class Facebook_Social_Publisher {
 	}
 
 	/**
-	 * Add actions to post edit page
+	 * Add actions to post edit page.
 	 *
 	 * @since 1.2.3
+	 *
+	 * @return void
 	 */
 	public static function load() {
 		// on post pages
@@ -67,6 +73,7 @@ class Facebook_Social_Publisher {
 	 * Can the current user publish to Facebook?
 	 *
 	 * @since 1.1
+	 *
 	 * @param int $wordpress_user_id WordPress user identifier
 	 * @return bool true if Facebook data stored for user and permissions exist
 	 */
@@ -81,9 +88,11 @@ class Facebook_Social_Publisher {
 
 	/**
 	 * Can the site possibly publish to Facebook on behalf of a WordPress user?
-	 * Access token stored along with the token may fail, but its existence is an indicator of possible success
+	 *
+	 * Access token stored along with the token may fail, but its existence is an indicator of possible success.
 	 *
 	 * @since 1.1
+	 *
 	 * @return array associative array of stored page data or empty array
 	 */
 	public static function get_publish_page() {
@@ -94,12 +103,14 @@ class Facebook_Social_Publisher {
 	}
 
 	/**
-	 * Test if a post type is intended for use publicly
-	 * If not explicitly declared as public a post type is considered non-public (default false)
+	 * Test if a post type is intended for use publicly.
+	 *
+	 * If not explicitly declared as public a post type is considered non-public (default false).
 	 *
 	 * @since 1.2.3
+	 *
 	 * @see register_post_type()
-	 * @param string $post_type post type
+	 * @param string $post_type WordPress post type
 	 * @return bool true if public else false
 	 */
 	public static function post_type_is_public( $post_type ) {
@@ -115,10 +126,11 @@ class Facebook_Social_Publisher {
 	}
 
 	/**
-	 * Test if a post's post status is public
+	 * Test if a post's post status is public.
 	 *
 	 * @since 1.2.3
-	 * @param int $post_id post identifier
+	 *
+	 * @param int $post_id WordPress post identifier
 	 * @return bool true if public, else false
 	 */
 	public static function post_status_is_public( $post_id ) {
@@ -133,9 +145,10 @@ class Facebook_Social_Publisher {
 	}
 
 	/**
-	 * Get post capability singular base to be used when gating access
+	 * Get post capability singular base to be used when gating access.
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $post_type post type
 	 * @return string post type object capability type or empty string
 	 */
@@ -156,9 +169,12 @@ class Facebook_Social_Publisher {
 	}
 
 	/**
-	 * Load post meta boxes and actions after post data loaded if post matches publisher preferences and capabilities
+	 * Load post meta boxes and actions after post data loaded if post matches publisher preferences and capabilities.
 	 *
 	 * @since 1.2.3
+	 *
+	 * @global stdClass|WP_Post $post WordPress post object
+	 * @return void
 	 */
 	public static function load_post_features() {
 		global $post;
@@ -202,13 +218,16 @@ class Facebook_Social_Publisher {
 	}
 
 	/**
-	 * Act on the publish action
-	 * Attempt to post to author timeline if Facebook data exists for author
-	 * Attempt to post to associated site page if page data saved
+	 * Act on the publish action.
+	 *
+	 * Attempt to post to author timeline if Facebook data exists for author. Attempt to post to associated site page if page data saved.
 	 *
 	 * @since 1.1
-	 * @param int $post_id post identifier
-	 * @param stdClass $post post object
+	 *
+	 * @param string $new_status name of the new WordPress post status
+	 * @param string $old_status name of the old WordPress post status
+	 * @param stdClass|W{_Post $post WordPress post object
+	 * @return void
 	 */
 	public static function publish( $new_status, $old_status, $post ) {
 		// content not public even if status public
@@ -238,12 +257,14 @@ class Facebook_Social_Publisher {
 	}
 
 	/**
-	 * Publish a post to a Facebook page
+	 * Publish a post to a Facebook Page.
 	 *
 	 * @since 1.0
+	 *
 	 * @link https://developers.facebook.com/docs/reference/api/page/#posts Facebook Graph API create page post
-	 * @param int $post_id post identifier
-	 * @param stdClass $post post object
+	 * @param int $post_id WordPress post identifier
+	 * @param stdClass|WP_Post $post WordPress post object
+	 * @return void
 	 */
 	public static function publish_to_facebook_page( $post_id, $post ) {
 		global $facebook_loader;
@@ -357,11 +378,14 @@ class Facebook_Social_Publisher {
 	}
 
 	/**
-	 * Publish a post to a Facebook Timeline
+	 * Publish a post to a Facebook User Timeline.
 	 *
 	 * @since 1.0
-	 * @param int $post_id post identifier
-	 * @param stdClass $post post object
+	 *
+	 * @global \Facebook_Loader $facebook_loader Access Facebook application credentials
+	 * @param int $post_id WordPress post identifier
+	 * @param stdClass|WP_Post $post WordPress post object
+	 * @return void
 	 */
 	public static function publish_to_facebook_profile( $post_id, $post ) {
 		global $facebook_loader;
@@ -473,9 +497,10 @@ class Facebook_Social_Publisher {
 	}
 
 	/**
-	 * Parse the unique post id from a feed
+	 * Parse the unique post id from a feed.
 	 *
 	 * @since 1.0
+	 *
 	 * @param string $id feed publish identifier
 	 * @return string Facebook URL
 	 */
@@ -486,9 +511,10 @@ class Facebook_Social_Publisher {
 	}
 
 	/**
-	 * Add a query argument to trigger displaying admin messages on the front-end
+	 * Add a query argument to trigger displaying admin messages on the front-end.
 	 *
 	 * @since 1.0
+	 *
 	 * @param string $loc URL
 	 * $return string URL with facebook_message query parameter appended
 	 */
@@ -497,10 +523,14 @@ class Facebook_Social_Publisher {
 	}
 
 	/**
-	 * Output admin notices saved to post data during the Facebook publish process
-	 * Triggers if our GET argument is present from redirecting the post location
+	 * Output admin notices saved to post data during the Facebook publish process.
+	 *
+	 * Triggers if our GET argument is present from redirecting the post location.
 	 *
 	 * @since 1.1
+	 *
+	 * @global stdClass|WP_Post WordPress post object
+	 * @return void
 	 */
 	public static function output_post_admin_notices() {
 		global $post;
@@ -541,7 +571,10 @@ class Facebook_Social_Publisher {
 	 * Delete post data from Facebook when deleted in WordPress
 	 *
 	 * @since 1.0
-	 * @param int $post_id post identifer
+	 *
+	 * @global \Facebook_Loader $facebook_loader Reference plugin directory
+	 * @param int $post_id WordPress post identifer
+	 * @return void
 	 */
 	public static function delete_facebook_post( $post_id ) {
 		global $facebook_loader;

--- a/channel.php
+++ b/channel.php
@@ -8,7 +8,7 @@
 
 if ( ! headers_sent() ) {
 	header( 'Content-Type: text/html; charset=utf-8', true );
-	// cache me	
+	// cache for a year
 	$cache_expire = 60 * 60 * 24 * 365;
 	header( 'Pragma: public', true );
 	header( 'Cache-Control: max-age=' . $cache_expire, true );

--- a/extras/google-analytics.php
+++ b/extras/google-analytics.php
@@ -2,16 +2,19 @@
 
 /**
  * Support for Google Analytics Social Interaction Analytics
+ *
  * Queues Facebook-specific calls to the _trackSocial method via the _gaq queue
  *
  * @since 1.1.9
+ *
  * @link https://developers.google.com/analytics/devguides/collection/gajs/gaTrackingSocial Google Analytics Social Interaction Analytics
  */
 class Facebook_Google_Analytics {
 	/**
-	 * Handle used in WordPress script queue
+	 * Handle used in WordPress script queue.
 	 *
 	 * @since 1.1.9
+	 *
 	 * @var string
 	 */
 	const SCRIPT_HANDLE = 'facebook-google-analytics';
@@ -20,6 +23,7 @@ class Facebook_Google_Analytics {
 	 * Add the Google Analytics initialization function to the Facebook for WordPress JavaScript queue to be executed after initialization of the Facebook JavaScript SDK
 	 *
 	 * @since 1.1.9
+	 *
 	 * @return string JavaScript code snippet
 	 */
 	public static function add_to_queue() {
@@ -30,6 +34,7 @@ class Facebook_Google_Analytics {
 	 * Relative path to Facebook Google Analytics JavaScript file
 	 *
 	 * @since 1.1.9
+	 *
 	 * @return string file path relative to the plugin directory
 	 */
 	public static function javascript_file_path() {
@@ -40,6 +45,7 @@ class Facebook_Google_Analytics {
 	 * Echo JavaScript inline to match the style of the plugin
 	 *
 	 * @since 1.1.9
+	 * @return void
 	 */
 	public static function inline() {
 		$js_file = dirname( dirname( __FILE__ ) ) . '/' . self::javascript_file_path();
@@ -51,9 +57,11 @@ class Facebook_Google_Analytics {
 
 	/**
 	 * Act on queued Google Analytics tracker commands.
+	 *
 	 * Used to customize Google Analytics for WordPress by Yoast. The plugin only supports filters adding tracker object methods. We must echo our own JavaScript block to pass a function to the Google Analytics queue.
 	 *
 	 * @since 1.1.9
+	 *
 	 * @param array $command_array flat array of strings. each value includes a tracker object method and parameters later wrapped in brackets for conversion to an array
 	 * @return array flat array of strings
 	 */
@@ -66,7 +74,9 @@ class Facebook_Google_Analytics {
 	 * Enqueue our Google Analytics script
 	 *
 	 * @since 1.1.9
+	 *
 	 * @uses wp_enqueue_script()
+	 * @return void
 	 */
 	public static function enqueue() {
 		wp_enqueue_script( self::SCRIPT_HANDLE, plugins_url( self::javascript_file_path(), dirname(__FILE__) ), array('facebook-jssdk'), '1.1.9', true );
@@ -77,6 +87,9 @@ class Facebook_Google_Analytics {
 	 * Add a Facebook queue item to the Google Analytics queue after Facebook Google Analytics code has loaded
 	 *
 	 * @since 1.1.9
+	 *
+	 * @global WP_Scripts $wp_scripts check if script has been loaded
+	 * @return void
 	 */
 	public static function gaq_push() {
 		global $wp_scripts;

--- a/social-plugins/class-facebook-activity-feed.php
+++ b/social-plugins/class-facebook-activity-feed.php
@@ -4,9 +4,10 @@ if ( ! class_exists( 'Facebook_Recommendations_Box' ) )
 	require_once( dirname(__FILE__) . '/class-facebook-recommendations-box.php' );
 
 /**
- * Display activity happening on your site including likes and comments in a social context
+ * Display activity happening on your site including likes and comments in a social context.
  *
  * @since 1.1
+ *
  * @link https://developers.facebook.com/docs/reference/plugins/activity/ Activity Feed social plugin documentation
  */
 class Facebook_Activity_Feed extends Facebook_Recommendations_Box {
@@ -15,6 +16,7 @@ class Facebook_Activity_Feed extends Facebook_Recommendations_Box {
 	 * Element and class name used in markup builders
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const ID = 'activity';
@@ -23,15 +25,18 @@ class Facebook_Activity_Feed extends Facebook_Recommendations_Box {
 	 * Include recommendations?
 	 *
 	 * @since 1.1
+	 *
 	 * @var bool
 	 */
 	protected $recommendations;
 
 	/**
 	 * Filter which URLs are shown in the plugin
+	 *
 	 * Up to two path directories: e.g. /section1/section2
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	protected $filter;
@@ -40,6 +45,7 @@ class Facebook_Activity_Feed extends Facebook_Recommendations_Box {
 	 * I am an activity feed
 	 *
 	 * @since 1.1
+	 * @return string name of the social plugin
 	 */
 	public function __toString() {
 		return 'Facebook Activity Feed';
@@ -49,6 +55,7 @@ class Facebook_Activity_Feed extends Facebook_Recommendations_Box {
 	 * Always show recommendations?
 	 *
 	 * @since 1.1
+	 *
 	 * @return Facebook_Activity_Feed support chaining
 	 */
 	public function includeRecommendations() {
@@ -57,11 +64,13 @@ class Facebook_Activity_Feed extends Facebook_Recommendations_Box {
 	}
 
 	/**
-	 * Filter which URLs are shown in the plugin by including a directory path
+	 * Filter which URLs are shown in the plugin by including a directory path.
+	 *
 	 * Facebook will parse up to two directories deep: e.g. /section1/section2
 	 * Does not apply to recommendations
 	 *
 	 * @since 1.1
+	 *
 	 * @var string $path URL path in current site
 	 * @return Facebook_Activity_Feed support chaining
 	 */
@@ -75,7 +84,8 @@ class Facebook_Activity_Feed extends Facebook_Recommendations_Box {
 	}
 
 	/**
-	 * Convert the class to data-* attribute friendly associative array
+	 * Convert the class to data-* attribute friendly associative array.
+	 *
 	 * will become data-key="value"
 	 * Exclude values if default
 	 *
@@ -94,9 +104,10 @@ class Facebook_Activity_Feed extends Facebook_Recommendations_Box {
 	}
 
 	/**
-	 * convert an options array into an object
+	 * convert an options array into an object.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $values associative array
 	 * @return Facebook_Activity_Feed activity feed object
 	 */
@@ -161,6 +172,7 @@ class Facebook_Activity_Feed extends Facebook_Recommendations_Box {
 	 * Output Activity Feed div with data-* attributes
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $div_attributes associative array. customize the returned div with id, class, or style attributes
 	 * @return HTML div or empty string
 	 */
@@ -175,6 +187,7 @@ class Facebook_Activity_Feed extends Facebook_Recommendations_Box {
 	 * Output Activity Feed as XFBML
 	 *
 	 * @since 1.1
+	 *
 	 * @return string XFBML markup
 	 */
 	public function asXFBML() {

--- a/social-plugins/class-facebook-comments-box.php
+++ b/social-plugins/class-facebook-comments-box.php
@@ -4,6 +4,7 @@
  * Enable user commenting for a URL
  *
  * @since 1.1
+ *
  * @link https://developers.facebook.com/docs/reference/plugins/comments/ Facebook Comments Box
  */
 class Facebook_Comments_Box {
@@ -12,40 +13,47 @@ class Facebook_Comments_Box {
 	 * Element and class name used in markup builders
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const ID = 'comments';
 
 	/**
 	 * Override the URL related to this comment.
+	 *
 	 * Default is og:url or link[rel=canonical] or document.URL
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	protected $href;
 
 	/**
-	 * Define a custom width in whole pixels
-	 * Minimum recommended width: 400 pixels
+	 * Define a custom width in whole pixels.
+	 *
+	 * Minimum recommended width: 400 pixels.
 	 *
 	 * @since 1.1
+	 *
 	 * @var int
 	 */
 	protected $width;
 
 	/**
-	 * Choose a light or dark color scheme to match your site style
+	 * Choose a light or dark color scheme to match your site style.
 	 *
 	 * @since 1.1.11
+	 *
 	 * @param string
 	 */
 	protected $colorscheme;
 
 	/**
-	 * Use a light or dark color scheme
+	 * Use a light or dark color scheme.
 	 *
 	 * @since 1.1.11
+	 *
 	 * @var array
 	 */
 	public static $colorscheme_choices = array( 'light' => true, 'dark' => true );
@@ -54,6 +62,7 @@ class Facebook_Comments_Box {
 	 * The number of comments to show by default
 	 *
 	 * @since 1.1
+	 *
 	 * @var int
 	 */
 	protected $num_posts;
@@ -62,6 +71,7 @@ class Facebook_Comments_Box {
 	 * The order to use when displaying comments
 	 *
 	 * @since 1.3
+	 *
 	 * @var string
 	 */
 	protected $order_by;
@@ -70,12 +80,14 @@ class Facebook_Comments_Box {
 	 * Choices for the order_by property
 	 *
 	 * @since 1.3
+	 *
 	 * @var string
 	 */
 	public static $order_by_choices = array( 'social' => true, 'time' => true, 'reverse_time' => true );
 
 	/**
 	 * Should we force the mobile-optimized version?
+	 *
 	 * Default is auto-detect
 	 *
 	 * @var bool
@@ -83,18 +95,21 @@ class Facebook_Comments_Box {
 	protected $mobile;
 
 	/**
-	 * I am a comments box
+	 * I am a comments box.
 	 *
 	 * @since 1.1
+	 *
+	 * @return string name of the social plugin
 	 */
 	public function __toString() {
 		return 'Facebook Comments Box Social Plugin';
 	}
 
 	/**
-	 * Setter for href attribute
+	 * Setter for href attribute.
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $url absolute URL
 	 * @return Facebook_Comments_Box support chaining
 	 */
@@ -106,10 +121,12 @@ class Facebook_Comments_Box {
 	}
 
 	/**
-	 * Width of the like button
-	 * Should be greater than the minimum width of layout + send button (if enabled) + recommend text (if chosen)
+	 * Width of the like button.
+	 *
+	 * Should be greater than the minimum width of layout + send button (if enabled) + recommend text (if chosen).
 	 *
 	 * @since 1.1
+	 *
 	 * @param int $width width in whole pixels
 	 * @return Facebook_Comments_Box support chaining
 	 */
@@ -124,6 +141,7 @@ class Facebook_Comments_Box {
 	 * Choose a light or dark color scheme
 	 *
 	 * @since 1.1
+	 *
 	 * @see self::colorscheme_choices
 	 * @param string $color_scheme light|dark
 	 * @return Facebook_Comments_Box support chaining
@@ -138,6 +156,7 @@ class Facebook_Comments_Box {
 	 * The maximum number of comments to display by default
 	 *
 	 * @since 1.1
+	 *
 	 * @param int $num positive number of comments
 	 * @return Facebook_Comments_Box support chaining
 	 */
@@ -151,6 +170,7 @@ class Facebook_Comments_Box {
 	 * Choose a social, chronological, or reverse chronological comment ordering
 	 *
 	 * @since 1.3
+	 *
 	 * @see self::order_by_choices
 	 * @param string $order_by social|time|
 	 * @return Facebook_Comments_Box support chaining
@@ -164,6 +184,8 @@ class Facebook_Comments_Box {
 	/**
 	 * Force the mobile view of comments
 	 *
+	 * @since 1.1
+	 *
 	 * @return Facebook_Comments_Box support chaining
 	 */
 	public function forceMobile() {
@@ -175,6 +197,7 @@ class Facebook_Comments_Box {
 	 * convert an options array into an object
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $values associative array
 	 * @return Facebook_Comments_Box comments box object
 	 */
@@ -210,6 +233,8 @@ class Facebook_Comments_Box {
 	 * will become data-key="value"
 	 * Exclude values if default
 	 *
+	 * @since 1.1
+	 *
 	 * @return array associative array
 	 */
 	public function toHTMLDataArray() {
@@ -239,6 +264,8 @@ class Facebook_Comments_Box {
 	/**
 	 * Output Like button with data-* attributes
 	 *
+	 * @since 1.1
+	 *
 	 * @param array $div_attributes associative array. customize the returned div with id, class, or style attributes. social plugin parameters in data.
 	 * @return string HTML div or empty string
 	 */
@@ -256,6 +283,7 @@ class Facebook_Comments_Box {
 	 * Output XFBML element with attributes
 	 *
 	 * @since 1.1
+	 *
 	 * @return string XFBML element or empty string
 	 */
 	public function asXFBML() {

--- a/social-plugins/class-facebook-comments.php
+++ b/social-plugins/class-facebook-comments.php
@@ -8,17 +8,19 @@
 class Facebook_Comments {
 
 	/**
-	 * Limit the strings allowed as an element name wrapping comments retrieved from Facebook servers
+	 * Limit the strings allowed as an element name wrapping comments retrieved from Facebook servers.
 	 *
 	 * @since 1.3
+	 *
 	 * @var array
 	 */
 	public static $allowed_comment_wrapper_elements = array( 'noscript' => true, 'div' => true, 'section' => true );
 
 	/**
-	 * Override default comments template with a Facebook-specific comments template
+	 * Override default comments template with a Facebook-specific comments template.
 	 *
 	 * @since 1.3
+	 *
 	 * @return string file path to plugin comments template PHP
 	 */
 	public static function comments_template() {
@@ -29,7 +31,8 @@ class Facebook_Comments {
 	 * Is Comments Box enabled for the current post type?
 	 *
 	 * @since 1.1.7
-	 * @param object $post post object
+	 *
+	 * @param stdClass|WP_Post $post WordPress post object
 	 * @return bool true if Comments Box enabled
 	 */
 	public static function comments_enabled_for_post_type( $post = null ) {
@@ -45,13 +48,15 @@ class Facebook_Comments {
 	}
 
 	/**
-	 * Turn on comments open if Comments Box enabled for the post type
-	 * A Comment Box always solicits new comments
+	 * Turn on comments open if Comments Box enabled for the post type.
+	 *
+	 * A Comments Box always solicits new comments
 	 *
 	 * @since 1.1.7
+	 *
 	 * @see comments_open()
 	 * @param bool $open comment status == 'open'
-	 * @param int $post_id post identifier
+	 * @param int $post_id WordPress post identifier
 	 * @return bool are comments open?
 	 */
 	public static function comments_open_filter( $open, $post_id = null ) {
@@ -64,10 +69,12 @@ class Facebook_Comments {
 	}
 
 	/**
-	 * Kill attempts to comment on a post managed by Facebook Comments Box
+	 * Kill attempts to comment on a post managed by Facebook Comments Box.
 	 *
 	 * @since 1.3.1
+	 *
 	 * @param int post_id post identifer
+	 * @return void
 	 */
 	public static function pre_comment_on_post( $post_id ) {
 		if ( ! $post_id )
@@ -81,13 +88,15 @@ class Facebook_Comments {
 	}
 
 	/**
-	 * Add Facebook comment count to the built-in WordPress comment count
+	 * Add Facebook comment count to the built-in WordPress comment count.
 	 *
 	 * @since 1.4
+	 *
 	 * @see get_comments_number()
-	 * @param int $count The number of WordPress comments a post has
-	 * @param int $post_id The Post ID
-	 * @return int The number of WordPress comments + Facebook comments a post has
+	 * @global \Facebook_Loader $facebook_loader test for app access token needed to request comments count from Facebook servers
+	 * @param int $count The number of WordPress comments for the post
+	 * @param int $post_id WordPress Post ID
+	 * @return int The number of WordPress comments + Facebook comments for the post
 	 */
 	public static function get_comments_number_filter( $count, $post_id ) {
 		global $facebook_loader;
@@ -134,8 +143,11 @@ class Facebook_Comments {
 	}
 
 	/**
-	 * Overrides text displayed with comments number, inserting Facebook XFBML to be replaced by a number with the Facebook JavaScript SDK
+	 * Overrides text displayed with comments number, inserting Facebook XFBML to be replaced by a number with the Facebook SDK for JavaScript.
 	 *
+	 * @since 1.1
+	 *
+	 * @global stdClass|WP_Post WordPress post object
 	 * @param string $output number of comments text
 	 * @param number of comments returned by get_comments_number()
 	 * @return string passed output or XFBML string
@@ -149,12 +161,14 @@ class Facebook_Comments {
 	}
 
 	/**
-	 * Build a XFBML string to place on the page for interpretation by the Facebook JavaScript SDK at runtime
+	 * Build a XFBML string to place on the page for interpretation by the Facebook SDK for JavaScript at runtime.
 	 *
 	 * @since 1.1
+	 *
 	 * @return string XFBML string or empty string if no post permalink context or publisher short-circuits via filter
 	 */
 	public static function comments_count_xfbml() {
+		// duplicate_hook
 		$url = esc_url( apply_filters( 'facebook_rel_canonical', get_permalink() ), array( 'http', 'https' ) );
 
 		if ( $url ) {
@@ -166,11 +180,14 @@ class Facebook_Comments {
 	}
 
 	/**
-	 * Remove the WordPress comments menu bar item, replacing with a Facebook comments link
-	 * Check if Facebook comments enabled and if the current user might be able to view a comments edit screen on Facebook
+	 * Remove the WordPress comments menu bar item, replacing with a Facebook comments link.
+	 *
+	 * Check if Facebook comments enabled and if the current user might be able to view a comments edit screen on Facebook.
 	 *
 	 * @since 1.1
+	 *
 	 * @see WP_Admin_Bar->add_menus()
+	 * @return void
 	 */
 	public static function admin_bar_menu() {
 		global $facebook_loader;
@@ -202,8 +219,11 @@ class Facebook_Comments {
 	 * Add a Facebook Comments menu item to the WordPress admin bar
 	 *
 	 * @since 1.1
+	 *
+	 * @global \Facebook_Loader $facebook_loader access Facebook application identifier
  	 * @see wp_admin_bar_comments_menu()
 	 * @param WP_Admin_Bar $wp_admin_bar WordPress admin bar to modify
+	 * @return void
 	 */
 	public static function admin_bar_add_comments_menu( $wp_admin_bar ) {
 		global $facebook_loader;
@@ -217,9 +237,11 @@ class Facebook_Comments {
 	}
 
 	/**
-	 * Retrieve a list of comments for the given URL from the Facebook Graph API
+	 * Retrieve a list of comments for the given URL from the Facebook Graph API.
 	 *
 	 * @since 1.1
+	 *
+	 * @link https://developers.facebook.com/docs/reference/api/Comment/ Individual Facebook Comment object
 	 * @param string $url absolute URL
 	 * @return array list of comments
 	 */
@@ -244,9 +266,10 @@ class Facebook_Comments {
 	}
 
 	/**
-	 * Remap Facebook comment fields to WordPress comment object
+	 * Remap Facebook comment fields to WordPress comment object.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $comment comment array returned from Facebook Graph API
 	 * @param int $post_id optional. sets comment_post_ID if present
 	 * @return stdClass WordPress style comment object
@@ -276,12 +299,13 @@ class Facebook_Comments {
 	}
 
 	/**
-	 * Generate HTML for a single Facebook comment
+	 * Generate HTML for a single Facebook comment.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $comment Facebook comment data
 	 * @param bool include Schema.org comment markup for semantic meaning
-	 * @return string comment markup
+	 * @return string comment HTML markup as a <li>
 	 */
 	public static function single_comment( $comment, $schema_org = true ) {
 		if ( ! is_array( $comment ) )
@@ -348,9 +372,10 @@ class Facebook_Comments {
 	}
 
 	/**
-	 * Possibly generate a nested ol of comments from a comments array
+	 * Possibly generate a nested ol of comments from a comments array.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $comments comments returned by Facebook
 	 * @return string ol.commentlist or empty string
 	 */
@@ -360,8 +385,13 @@ class Facebook_Comments {
 
 		$comment_list = array();
 
-		// mark up comments in Schema.org structured data
-		// allow publishers to override by returning false for the filter
+		/**
+		 * Mark up comments in Schema.org structured data
+		 *
+		 * @since 1.1
+		 *
+		 * @param bool Default: true
+		 */
 		$schema_org = apply_filters( 'facebook_comment_schema_org', true );
 		if ( ! is_bool( $schema_org ) )
 			$schema_org = true;
@@ -380,11 +410,13 @@ class Facebook_Comments {
 	}
 
 	/**
-	 * Retrieve a list of comments for the current post permalink from Facebook servers
-	 * Generate threaded comment markup for the comments
-	 * Cache the generated HTML for 15 minutes for speed
+	 * Retrieve a list of comments for the current post permalink from Facebook servers.
+	 *
+	 * Generate threaded comment markup for the comments. Cache the generated HTML for 15 minutes for speed.
 	 *
 	 * @since 1.1
+	 *
+	 * @global stdClass|WP_Post WordPress post object
 	 * @param string $wrapper_element the parent element of the list of comments, if any comments exist. noscript (default), div, or section
 	 * @return string list of comments possibly wrapped in a valid wrapper
 	 */
@@ -394,6 +426,7 @@ class Facebook_Comments {
 		if ( ! ( isset( $post ) && empty( $post->post_password ) ) )
 			return '';
 
+		// duplicate_hook
 		$url = apply_filters( 'facebook_rel_canonical', get_permalink( $post->ID ) );
 		if ( ! $url ) // could happen. kill it early
 			return '';
@@ -425,11 +458,12 @@ class Facebook_Comments {
 	}
 
 	/**
-	 * Generate markup suitable for the Facebook JavaScript SDK based on site options
+	 * Generate markup suitable for the Facebook SDK for JavaScript based on site options.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $options site options for the comments box social plugin
-	 * @return string HTML5 div with data attributes for interpretation by the Facebook JavaScript SDK at runtime
+	 * @return string HTML5 div with data attributes for interpretation by the Facebook SDK for JavaScript at runtime
 	 */
 	public static function js_sdk_markup( $options ) {
 		if ( ! is_array( $options ) )
@@ -456,10 +490,12 @@ class Facebook_Comments {
 	}
 
 	/**
-	 * Generate Facebook Comments Box social plugin markup for interpretation by the Facebook JavaScript SDK at runtime
-	 * Includes a list of existing plugins wrapped in a noscript by default to better reflect full page content to search engines and other noscript users
+	 * Generate Facebook Comments Box social plugin markup for interpretation by the Facebook JavaScript SDK at runtime.
+	 *
+	 * Includes a list of existing plugins wrapped in a noscript by default to better reflect full page content to search engines and other noscript users.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $options chosen options from the Facebook settings page
 	 * @param bool $with_noscript include a list of comments in your page markup wrapped in a noscript element. disable if you publish your posts in a non-dynamic environment such as a HTTP small object CDN and would like all content rendered dynamically at runtime
 	 * @return string Facebook Comments Box markup for interpretation by the Facebook JavaScript SDK + (optional) noscript markup of existing comments
@@ -477,10 +513,13 @@ class Facebook_Comments {
 	}
 
 	/**
-	 * Display comments and comments box
-	 * Existing Facebook comments are wrapped in a noscript for search engine indexing and styling
+	 * Display comments and comments box.
+	 *
+	 * Existing Facebook comments are wrapped in a noscript for search engine indexing and styling.
 	 *
 	 * @since 1.3
+	 *
+	 * @global stdClass|WP_Post WordPress post object
 	 * @return string noscript Facebook comments content and/or Comments Box markup to be interpreted by the Facebook JavaScript SDK
 	 */
 	public static function comments_box() {
@@ -500,12 +539,21 @@ class Facebook_Comments {
 		if ( ! is_array( $options ) || empty( $options ) )
 			return $content;
 
-		// closed posts can have comments from their previous open state
-		// display noscript version of these comments, or display on page if filter override exists
+		/**
+		 * Output existing Facebook comments as HTML wrapped in the given HTML element.
+		 *
+		 * Display a static HTML fallback version of existing comments stored on Facebook servers for SEO purposes. Wrap in a <noscript> element by default to only display when the Facebook Comments Box social plugin would not display. Set to an empty string to prevent display of static markup fallback and a sometimes lengthy call to Facebook servers to retrieve comments.
+		 *
+		 * @since 1.3
+		 *
+		 * @see Facebook_Comments::$allowed_comment_wrapper_elements list of allowed values
+		 * @param string HTML element wrapper. Default: noscript.
+		 * @param int current WordPress post idenifier
+		 */
 		$comments_wrapper = apply_filters( 'facebook_comments_wrapper', 'noscript', $post_id );
 
 		if ( $comments_wrapper && isset( self::$allowed_comment_wrapper_elements[$comments_wrapper] ) ) {
-			$comments_markup = self::comments_markup( 'noscript' );
+			$comments_markup = self::comments_markup( $comments_wrapper );
 			if ( $comments_markup )
 				$content .= $comments_markup;
 			else
@@ -517,6 +565,7 @@ class Facebook_Comments {
 		// no option via JS SDK to display comments yet not accept new comments
 		// only display JS SDK version of comments box display if we would like more comments
 		if ( comments_open( $post_id ) ) {
+			// duplicate_hook
 			$url = apply_filters( 'facebook_rel_canonical', get_permalink( $post_id ) );
 			if ( $url ) // false could happen. let JS SDK handle compatibility mode
 				$options['href'] = $url;

--- a/social-plugins/class-facebook-embedded-post.php
+++ b/social-plugins/class-facebook-embedded-post.php
@@ -4,31 +4,35 @@
  * Facebook Embedded post
  *
  * @since 1.5
+ *
  * @link https://developers.facebook.com/docs/plugins/embedded-posts/ Facebook Embedded Posts
  */
 class Facebook_Embedded_Post {
 	/**
-	 * Element and class name used in markup builders
+	 * Element and class name used in markup builders.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const ID = 'post';
 
 	/**
-	 * The Facebook URL representing public post by a person or page
+	 * The Facebook URL representing public post by a person or page.
 	 *
 	 * @since 1.5
+	 *
 	 * @var string
 	 */
 	protected $href;
 
 	/**
 	 * Show a border around the plugin
-	 * Default: true
+	 *
 	 * Set to false to style the resulting iframe with your custom CSS
 	 *
 	 * @since 1.5
+	 *
 	 * @var bool
 	 */
 	protected $show_border = true;
@@ -37,16 +41,18 @@ class Facebook_Embedded_Post {
 	 * I am an embedded post
 	 *
 	 * @since 1.5
-	 * @return string
+	 *
+	 * @return string Facebook social plugin name
 	 */
 	public function __toString() {
 		return 'Facebook Embedded Post';
 	}
 
 	/**
-	 * Setter for href attribute
+	 * Setter for href attribute.
 	 *
 	 * @since 1.5
+	 *
 	 * @param string $url absolute URL
 	 * @return Facebook_Embedded_Post support chaining
 	 */
@@ -58,9 +64,10 @@ class Facebook_Embedded_Post {
 	}
 
 	/**
-	 * Add a border to the box
+	 * Add a border to the box.
 	 *
 	 * @since 1.5
+	 *
 	 * @return Facebook_Embedded_Post support chaining
 	 */
 	public function showBorder() {
@@ -69,9 +76,10 @@ class Facebook_Embedded_Post {
 	}
 
 	/**
-	 * Hide the box border
+	 * Hide the box border.
 	 *
 	 * @since 1.5
+	 *
 	 * @return Facebook_Embedded_Post support chaining
 	 */
 	public function hideBorder() {
@@ -83,6 +91,7 @@ class Facebook_Embedded_Post {
 	 * convert an options array into an object
 	 *
 	 * @since 1.5
+	 *
 	 * @param array $values associative array
 	 * @return Facebook_Embedded_Post embedded post object
 	 */
@@ -104,11 +113,12 @@ class Facebook_Embedded_Post {
 	}
 
 	/**
-	 * Convert the class to data-* attribute friendly associative array
-	 * will become data-key="value"
-	 * Exclude values if default
+	 * Convert the class to data-* attribute friendly associative array.
+	 *
+	 * Will become data-key="value". Exclude values if default
 	 *
 	 * @since 1.5
+	 *
 	 * @return array associative array
 	 */
 	public function toHTMLDataArray() {
@@ -125,9 +135,10 @@ class Facebook_Embedded_Post {
 	}
 
 	/**
-	 * Output Embedded Post with data-* attributes
+	 * Output Embedded Post with data-* attributes.
 	 *
 	 * @since 1.5
+	 *
 	 * @param array $div_attributes associative array. customize the returned div with id, class, or style attributes
 	 * @return HTML div or empty string
 	 */
@@ -150,6 +161,7 @@ class Facebook_Embedded_Post {
 	 * Output Embedded Post as XFBML
 	 *
 	 * @since 1.5
+	 *
 	 * @return string XFBML markup
 	 */
 	public function asXFBML() {

--- a/social-plugins/class-facebook-follow-button.php
+++ b/social-plugins/class-facebook-follow-button.php
@@ -7,6 +7,7 @@ if ( ! class_exists( 'Facebook_Social_Plugin' ) )
  * Encourage visitors to follow your public updates on Facebook with a Follow Button
  *
  * @since 1.1
+ *
  * @link https://developers.facebook.com/docs/reference/plugins/follow/ Facebook Follow Button
  */
 class Facebook_Follow_Button extends Facebook_Social_Plugin {
@@ -15,58 +16,68 @@ class Facebook_Follow_Button extends Facebook_Social_Plugin {
 	 * Element and class name used in markup builders
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const ID = 'follow';
 
 	/**
-	 * The Facebook URL representing a user profile or page open to new followers
-	 * Your account must allow followers. Follow ability only available for accounts belonging to a user over 18 years of age
+	 * The Facebook URL representing a user profile or page open to new followers.
+	 *
+	 * Your account must allow followers. Follow ability only available for accounts belonging to a user over 18 years of age.
+	 *
+	 * @since 1.1
 	 *
 	 * @link https://www.facebook.com/about/follow About Facebook Follow
-	 * @since 1.1
 	 * @var string
 	 */
 	protected $href;
 
 	/**
-	 * Which style follow button you would like displayed
+	 * Which style follow button you would like displayed.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	protected $layout;
 
 	/**
-	 * Choose your follow button
+	 * Choose your follow button.
 	 *
 	 * @since 1.1
+	 *
 	 * @var array
 	 */
 	public static $layout_choices = array( 'standard' => true, 'button_count' => true, 'box_count' => true );
 
 	/**
 	 * Show faces of the viewer's friends already following?
+	 *
 	 * Only applies to standard layout. Needs the extra width.
 	 *
 	 * @since 1.1
+	 *
 	 * @var bool
 	 */
 	protected $show_faces;
 
 	/**
-	 * Define a custom width in whole pixels
+	 * Define a custom width in whole pixels.
 	 *
 	 * @since 1.1
+	 *
 	 * @var int
 	 */
 	protected $width;
 
 	/**
 	 * Option to bypass validation.
-	 * You might validate when changing settings but choose not to validate on future generators
+	 *
+	 * You might validate when changing settings but choose not to validate on future generators.
 	 *
 	 * @since 1.1
+	 *
 	 * @param bool $validate false if object should not be validated
 	 */
 	public function __construct( $validate = true ) {
@@ -77,19 +88,21 @@ class Facebook_Follow_Button extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * I am a follow button
+	 * I am a follow button.
 	 *
 	 * @since 1.1
-	 * @return string
+	 *
+	 * @return string Facebook social plugin
 	 */
 	public function __toString() {
 		return 'Facebook Follow Button';
 	}
 
 	/**
-	 * Setter for href attribute
+	 * Setter for href attribute.
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $url absolute URL
 	 * @return Facebook_Follow_Button support chaining
 	 */
@@ -104,9 +117,10 @@ class Facebook_Follow_Button extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Choose a layout option
+	 * Choose a layout option.
 	 *
 	 * @since 1.1
+	 *
 	 * @see self::$layout_choices
 	 * @param string $layout a supported layout option
 	 * @return Facebook_Follow_Button support chaining
@@ -118,9 +132,10 @@ class Facebook_Follow_Button extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Show the faces of a logged-on Facebook user's friends
+	 * Show the faces of a logged-on Facebook user's friends.
 	 *
 	 * @since 1.1
+	 *
 	 * @return Facebook_Follow_Button support chaining
 	 */
 	public function showFaces() {
@@ -129,10 +144,12 @@ class Facebook_Follow_Button extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Width of the follow button
-	 * Should be greater than the minimum width of layout option
+	 * Width of the follow button.
+	 *
+	 * Should be greater than the minimum width of layout option.
 	 *
 	 * @since 1.1
+	 *
 	 * @param int $width width in whole pixels
 	 * @return Facebook_Follow_Button support chaining
 	 */
@@ -144,9 +161,10 @@ class Facebook_Follow_Button extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Compute a minimum width of a follow button based on configured options
+	 * Compute a minimum width of a follow button based on configured options.
 	 *
 	 * @since 1.1
+	 *
 	 * @return int minimum width of the current configuration in whole pixels
 	 */
 	private function compute_minimum_width() {
@@ -162,10 +180,13 @@ class Facebook_Follow_Button extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Some options may be in conflict with other options or not available for main choices
-	 * Reset customizations if we can detect non-compliance to avoid later confusion and/or layout issues
+	 * Some options may be in conflict with other options or not available for main choices.
+	 *
+	 * Reset customizations if we can detect non-compliance to avoid later confusion and/or layout issues.
 	 *
 	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function validate() {
 		// allow overrides
@@ -188,9 +209,10 @@ class Facebook_Follow_Button extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * convert an options array into an object
+	 * convert an options array into an object.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $values associative array
 	 * @return Facebook_Follow_Button follow object
 	 */
@@ -225,11 +247,12 @@ class Facebook_Follow_Button extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Convert the class to data-* attribute friendly associative array
-	 * will become data-key="value"
-	 * Exclude values if default
+	 * Convert the class to data-* attribute friendly associative array.
+	 *
+	 * will become data-key="value". Exclude values if default.
 	 *
 	 * @since 1.1
+	 *
 	 * @return array associative array
 	 */
 	public function toHTMLDataArray() {
@@ -253,9 +276,10 @@ class Facebook_Follow_Button extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Output Follow button with data-* attributes
+	 * Output Follow button with data-* attributes.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $div_attributes associative array. customize the returned div with id, class, or style attributes
 	 * @return HTML div or empty string
 	 */
@@ -272,9 +296,10 @@ class Facebook_Follow_Button extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Output Follow button as XFBML
+	 * Output Follow button as XFBML.
 	 *
 	 * @since 1.1
+	 *
 	 * @return string XFBML markup
 	 */
 	public function asXFBML() {

--- a/social-plugins/class-facebook-like-box.php
+++ b/social-plugins/class-facebook-like-box.php
@@ -1,9 +1,11 @@
 <?php
 /**
- * Encourage visitors to Like a Facebook Page
- * Optionally display profile photos of friends who already like your page or latest updates from your page
+ * Encourage visitors to Like a Facebook Page.
+ *
+ * Optionally display profile photos of friends who already like your page or latest updates from your page.
  *
  * @since 1.1
+ *
  * @link https://developers.facebook.com/docs/reference/plugins/like-box/ Like Box social plugin
  */
 class Facebook_Like_Box {
@@ -11,20 +13,23 @@ class Facebook_Like_Box {
 	 * Element and class name used in markup builders
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const ID = 'like-box';
 
 	/**
-	 * Minimum allowed width of the Like Box in whole pixels
+	 * Minimum allowed width of the Like Box in whole pixels.
 	 *
 	 * @since 1.1.11
+	 *
 	 * @var int
 	 */
 	const MIN_WIDTH = 292;
 
 	/**
-	 * Minimum allowed height of the Like Box in whole pixels
+	 * Minimum allowed height of the Like Box in whole pixels.
+	 *
 	 * No faces, no stream.
 	 *
 	 * @since 1.1.11
@@ -33,9 +38,10 @@ class Facebook_Like_Box {
 	const MIN_HEIGHT = 63;
 
 	/**
-	 * Use a light or dark color scheme
+	 * Use a light or dark color scheme.
 	 *
 	 * @since 1.1
+	 *
 	 * @var array
 	 */
 	public static $colorscheme_choices = array( 'light' => true, 'dark' => true );
@@ -44,25 +50,29 @@ class Facebook_Like_Box {
 	 * URL of a Facebook Page. The target of the Like action.
 	 *
 	 * @since 1.1.11
+	 *
 	 * @var string
 	 */
 	protected $href;
 
 	/**
-	 * Define a custom width in whole pixels
-	 * Min: 292
-	 * Default: 300
+	 * Define a custom width in whole pixels.
+	 *
+	 * Min: 292. Default: 300.
 	 *
 	 * @since 1.1.11
+	 *
 	 * @var int
 	 */
 	protected $width;
 
 	/**
-	 * Define a custom height in whole pixels
-	 * Default height varies
+	 * Define a custom height in whole pixels.
+	 *
+	 * Default height varies.
 	 *
 	 * @since 1.1.11
+	 *
 	 * @var int
 	 */
 	protected $height;
@@ -71,6 +81,7 @@ class Facebook_Like_Box {
 	 * Choose a light or dark color scheme to match your site style
 	 *
 	 * @since 1.1.11
+	 *
 	 * @param string
 	 */
 	protected $colorscheme;
@@ -79,6 +90,7 @@ class Facebook_Like_Box {
 	 * Show faces of the viewer's friends who have already liked the page?
 	 *
 	 * @since 1.1.11
+	 *
 	 * @var bool
 	 */
 	protected $show_faces;
@@ -87,6 +99,7 @@ class Facebook_Like_Box {
 	 * Display the latest posts from the Facebook Page's wall?
 	 *
 	 * @since 1.1.11
+	 *
 	 * @var bool
 	 */
 	protected $stream;
@@ -95,16 +108,18 @@ class Facebook_Like_Box {
 	 * Display a Facebook header at the top of the social plugin. e.g. "Find us on Facebook"
 	 *
 	 * @since 1.1.11
+	 *
 	 * @var bool
 	 */
 	protected $header;
 
 	/**
 	 * Show a border around the plugin
-	 * Default: true
-	 * Set to false to style the resulting iframe with your custom CSS
+	 *
+	 * Default: true. Set to false to style the resulting iframe with your custom CSS.
 	 *
 	 * @since 1.5
+	 *
 	 * @var bool
 	 */
 	protected $show_border;
@@ -113,6 +128,7 @@ class Facebook_Like_Box {
 	 * Places-specific features: should the stream contain posts from a Pages' walls instead of checkins by friends?
 	 *
 	 * @since 1.1.11
+	 *
 	 * @var bool
 	 */
 	protected $force_wall;
@@ -121,15 +137,17 @@ class Facebook_Like_Box {
 	 * I am a Like Box
 	 *
 	 * @since 1.1
+	 * @return string Facebook social plugin name
 	 */
 	public function __toString() {
 		return 'Facebook Like Box';
 	}
 
 	/**
-	 * Setter for href attribute
+	 * Setter for href attribute.
 	 *
 	 * @since 1.1.11
+	 *
 	 * @param string $url absolute URL
 	 * @return Facebook_Like_Box support chaining
 	 */
@@ -141,9 +159,10 @@ class Facebook_Like_Box {
 	}
 
 	/**
-	 * Define the width of the Like Box in whole pixels
+	 * Define the width of the Like Box in whole pixels.
 	 *
 	 * @since 1.1.11
+	 *
 	 * @param int $width width in whole pixels
 	 * @return Facebook_Like_Box support chaining
 	 */
@@ -157,9 +176,10 @@ class Facebook_Like_Box {
 	}
 
 	/**
-	 * Define the height of the recommendations box in whole pixels
+	 * Define the height of the recommendations box in whole pixels.
 	 *
 	 * @since 1.1
+	 *
 	 * @param int $height height in whole pixels
 	 * @return Facebook_Like_Box support chaining
 	 */
@@ -173,9 +193,10 @@ class Facebook_Like_Box {
 	}
 
 	/**
-	 * Choose a light or dark color scheme
+	 * Choose a light or dark color scheme.
 	 *
 	 * @since 1.1.11
+	 *
 	 * @see self::colorscheme_choices
 	 * @param string $color_scheme light|dark
 	 * @return Facebook_Like_Box support chaining
@@ -187,9 +208,10 @@ class Facebook_Like_Box {
 	}
 
 	/**
-	 * Show the faces of a logged-on Facebook user's friends
+	 * Show the faces of a logged-on Facebook user's friends.
 	 *
 	 * @since 1.1.11
+	 *
 	 * @return Facebook_Like_Box support chaining
 	 */
 	public function showFaces() {
@@ -198,10 +220,12 @@ class Facebook_Like_Box {
 	}
 
 	/**
-	 * Do not display the faces of a logged-on Facebook user's friends
-	 * Reverts to default state
+	 * Do not display the faces of a logged-on Facebook user's friends.
+	 *
+	 * Reverts to default state.
 	 *
 	 * @since 1.1.11
+	 *
 	 * @return Facebook_Like_Box support chaining
 	 */
 	public function hideFaces() {
@@ -210,9 +234,10 @@ class Facebook_Like_Box {
 	}
 
 	/**
-	 * Show the Facebook Page stream
+	 * Show the Facebook Page stream.
 	 *
 	 * @since 1.1.11
+	 *
 	 * @return Facebook_Like_Box support chaining
 	 */
 	public function showStream() {
@@ -221,9 +246,10 @@ class Facebook_Like_Box {
 	}
 
 	/**
-	 * Hide the Facebook header
+	 * Hide the Facebook header.
 	 *
 	 * @since 1.1.11
+	 *
 	 * @return Facebook_Like_Box support chaining
 	 */
 	public function hideStream() {
@@ -232,9 +258,10 @@ class Facebook_Like_Box {
 	}
 
 	/**
-	 * Show the Facebook header
+	 * Show the Facebook header.
 	 *
 	 * @since 1.1.11
+	 *
 	 * @return Facebook_Like_Box support chaining
 	 */
 	public function showHeader() {
@@ -243,9 +270,10 @@ class Facebook_Like_Box {
 	}
 
 	/**
-	 * Hide the Facebook header
+	 * Hide the Facebook header.
 	 *
 	 * @since 1.1.11
+	 *
 	 * @return Facebook_Like_Box support chaining
 	 */
 	public function hideHeader() {
@@ -257,6 +285,7 @@ class Facebook_Like_Box {
 	 * Add a border to the box
 	 *
 	 * @since 1.5
+	 *
 	 * @return Facebook_Like_Box support chaining
 	 */
 	public function showBorder() {
@@ -265,9 +294,10 @@ class Facebook_Like_Box {
 	}
 
 	/**
-	 * Hide the box border
+	 * Hide the box border.
 	 *
 	 * @since 1.5
+	 *
 	 * @return Facebook_Like_Box support chaining
 	 */
 	public function hideBorder() {
@@ -279,6 +309,7 @@ class Facebook_Like_Box {
 	 * Place-specific: show latest wall posts instead of checkins.
 	 *
 	 * @since 1.1.11
+	 *
 	 * @return Facebook_Like_Box support chaining
 	 */
 	public function showWall() {
@@ -288,9 +319,11 @@ class Facebook_Like_Box {
 
 	/**
 	 * Place-specific: allow the default state of Place checkins displayed in Page stream.
+	 *
 	 * The counter-function to showWall()
 	 *
 	 * @since 1.1.11
+	 *
 	 * @return Facebook_Like_Box support chaining
 	 */
 	public function showCheckins() {
@@ -299,9 +332,10 @@ class Facebook_Like_Box {
 	}
 
 	/**
-	 * convert an options array into an object
+	 * convert an options array into an object.
 	 *
 	 * @since 1.1.11
+	 *
 	 * @param array $values associative array
 	 * @return Facebook_Like_Box like box object
 	 */
@@ -354,6 +388,8 @@ class Facebook_Like_Box {
 	/**
 	 * Convert the class object into an array, removing default values
 	 *
+	 * @since 1.1.11
+	 *
 	 * @return array associative array
 	 */
 	public function toArray() {
@@ -399,7 +435,10 @@ class Facebook_Like_Box {
 
 	/**
 	 * Convert the class to data-* attribute friendly associative array
-	 * Exclude values if default
+	 *
+	 * Exclude values if default.
+	 *
+	 * @since 1.1.11
 	 *
 	 * @return array associative array
 	 */
@@ -408,9 +447,10 @@ class Facebook_Like_Box {
 	}
 
 	/**
-	 * Output Like Box with data-* attributes
+	 * Output Like Box with data-* attributes.
 	 *
-	 * @since 1.1
+	 * @since 1.1.11
+	 *
 	 * @param array $div_attributes associative array. customize the returned div with id, class, or style attributes
 	 * @return HTML div or empty string
 	 */
@@ -427,7 +467,8 @@ class Facebook_Like_Box {
 	/**
 	 * Output Like Box as XFBML
 	 *
-	 * @since 1.1
+	 * @since 1.1.11
+	 *
 	 * @return string XFBML markup
 	 */
 	public function asXFBML() {

--- a/social-plugins/class-facebook-like-button.php
+++ b/social-plugins/class-facebook-like-button.php
@@ -4,26 +4,30 @@ if ( ! class_exists( 'Facebook_Social_Plugin' ) )
 	require_once( dirname(__FILE__) . '/class-facebook-social-plugin.php' );
 
 /**
- * Allow page visitors to easily share content on Facebook with a Like button
+ * Allow page visitors to easily share content on Facebook with a Like button.
  *
  * @since 1.1
+ *
  * @link https://developers.facebook.com/docs/reference/plugins/like/ Like button social plugin documentation
  */
 class Facebook_Like_Button extends Facebook_Social_Plugin {
 
 	/**
-	 * Element and class name used in markup builders
+	 * Element and class name used in markup builders.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const ID = 'like';
 
 	/**
 	 * Override the URL used for the like action.
+	 *
 	 * Default is og:url or link[rel=canonical] or document.URL
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	protected $href;
@@ -32,14 +36,16 @@ class Facebook_Like_Button extends Facebook_Social_Plugin {
 	 * Display a send button alongside the like button?
 	 *
 	 * @since 1.1
+	 *
 	 * @var bool
 	 */
 	protected $send_button;
 
 	/**
-	 * Which like button you would like displayed
+	 * Which like button you would like displayed.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	protected $layout;
@@ -48,15 +54,18 @@ class Facebook_Like_Button extends Facebook_Social_Plugin {
 	 * Choose your like button
 	 *
 	 * @since 1.1
+	 *
 	 * @var array
 	 */
 	public static $layout_choices = array( 'standard' => true, 'button_count' => true, 'box_count' => true );
 
 	/**
 	 * Show faces of the viewer's friends?
+	 *
 	 * Only applies to standard layout. Needs the extra width.
 	 *
 	 * @since 1.1
+	 *
 	 * @var bool
 	 */
 	protected $show_faces;
@@ -65,6 +74,7 @@ class Facebook_Like_Button extends Facebook_Social_Plugin {
 	 * Define a custom width in whole pixels
 	 *
 	 * @since 1.1
+	 *
 	 * @var int
 	 */
 	protected $width;
@@ -73,6 +83,7 @@ class Facebook_Like_Button extends Facebook_Social_Plugin {
 	 * Like or recommend
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	protected $action;
@@ -81,15 +92,18 @@ class Facebook_Like_Button extends Facebook_Social_Plugin {
 	 * The verb to display on the button
 	 *
 	 * @since 1.1
+	 *
 	 * @var array
 	 */
 	public static $action_choices = array( 'like' => true, 'recommend' => true );
 
 	/**
 	 * Option to bypass validation.
+	 *
 	 * You might validate when changing settings but choose not to validate on future generators
 	 *
 	 * @since 1.1
+	 *
 	 * @param bool $validate false if object should not be validated
 	 */
 	public function __construct( $validate = true ) {
@@ -103,15 +117,18 @@ class Facebook_Like_Button extends Facebook_Social_Plugin {
 	 * I am a like button
 	 *
 	 * @since 1.1
+	 *
+	 * @return string Facebook social plugin name
 	 */
 	public function __toString() {
 		return 'Facebook Like Button';
 	}
 
 	/**
-	 * Setter for href attribute
+	 * Setter for href attribute.
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $url absolute URL
 	 * @return Facebook_Like_Button support chaining
 	 */
@@ -126,6 +143,7 @@ class Facebook_Like_Button extends Facebook_Social_Plugin {
 	 * Should a send button appear next to the like button?
 	 *
 	 * @since 1.1
+	 *
 	 * @return Facebook_Like_Button support chaining
 	 */
 	public function includeSendButton() {
@@ -134,9 +152,10 @@ class Facebook_Like_Button extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Choose a layout option
+	 * Choose a layout option.
 	 *
 	 * @since 1.1
+	 *
 	 * @see self::$layout_choices
 	 * @param string $layout a supported layout option
 	 * @return Facebook_Like_Button support chaining
@@ -151,6 +170,7 @@ class Facebook_Like_Button extends Facebook_Social_Plugin {
 	 * Show the faces of a logged-on Facebook user's friends
 	 *
 	 * @since 1.1
+	 *
 	 * @return Facebook_Like_Button support chaining
 	 */
 	public function showFaces() {
@@ -160,9 +180,11 @@ class Facebook_Like_Button extends Facebook_Social_Plugin {
 
 	/**
 	 * Do not display the faces of a logged-on Facebook user's friends
+	 *
 	 * Reverts to default state
 	 *
 	 * @since 1.1.11
+	 *
 	 * @return Facebook_Like_Button support chaining
 	 */
 	public function hideFaces() {
@@ -172,9 +194,11 @@ class Facebook_Like_Button extends Facebook_Social_Plugin {
 
 	/**
 	 * Width of the like button
-	 * Should be greater than the minimum width of layout + send button (if enabled) + recommend text (if chosen)
+	 *
+	 * Should be greater than the minimum width of layout + send button (if enabled) + recommend text (if chosen).
 	 *
 	 * @since 1.1
+	 *
 	 * @param int $width width in whole pixels
 	 * @return Facebook_Like_Button support chaining
 	 */
@@ -189,6 +213,7 @@ class Facebook_Like_Button extends Facebook_Social_Plugin {
 	 * Override the default "like" text with "recommend"
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $action like|recommend
 	 * @return Facebook_Like_Button support chaining
 	 */
@@ -199,10 +224,12 @@ class Facebook_Like_Button extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Compute a minimum width of a like button based on configured options
-	 * Note: Minimum widths vary based on the language-specific text used for "like" and "recommend" action. Language variances are not factored into this calculation
+	 * Compute a minimum width of a like button based on configured options.
+	 *
+	 * Note: Minimum widths vary based on the language-specific text used for "like" and "recommend" action. Language variances are not factored into this calculation.
 	 *
 	 * @since 1.1
+	 *
 	 * @return int minimum width of the current configuration in whole pixels
 	 */
 	private function compute_minimum_width() {
@@ -224,10 +251,12 @@ class Facebook_Like_Button extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Some options may be in conflict with other options or not available for main choices
-	 * Reset customizations if we can detect non-compliance to avoid later confusion and/or layout issues
+	 * Some options may be in conflict with other options or not available for main choices.
+	 *
+	 * Reset customizations if we can detect non-compliance to avoid later confusion and/or layout issues.
 	 *
 	 * @since 1.1
+	 * @return void
 	 */
 	public function validate() {
 		// allow overrides
@@ -250,9 +279,10 @@ class Facebook_Like_Button extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * convert an options array into an object
+	 * convert an options array into an object.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $values associative array
 	 * @return Facebook_Like_Button like object
 	 */
@@ -297,8 +327,10 @@ class Facebook_Like_Button extends Facebook_Social_Plugin {
 
 	/**
 	 * Convert the class to data-* attribute friendly associative array
-	 * will become data-key="value"
-	 * Exclude values if default
+	 *
+	 * will become data-key="value". Exclude values if default.
+	 *
+	 * @since 1.1
 	 *
 	 * @return array associative array
 	 */
@@ -330,6 +362,7 @@ class Facebook_Like_Button extends Facebook_Social_Plugin {
 	 * Output Like button with data-* attributes
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $div_attributes associative array. customize the returned div with id, class, or style attributes
 	 * @return HTML div or empty string
 	 */
@@ -344,6 +377,7 @@ class Facebook_Like_Button extends Facebook_Social_Plugin {
 	 * Output Like button as XFBML
 	 *
 	 * @since 1.1
+	 *
 	 * @return string XFBML markup
 	 */
 	public function asXFBML() {

--- a/social-plugins/class-facebook-recommendations-bar.php
+++ b/social-plugins/class-facebook-recommendations-bar.php
@@ -7,113 +7,128 @@ if ( ! class_exists( 'Facebook_Social_Plugin' ) )
  * Recommend content to site visitors based on site activity, interests, and a friends
  *
  * @since 1.1
+ *
  * @link https://developers.facebook.com/docs/reference/plugins/recommendationsbar/ Recommendations Bar social plugin documentation
  */
 class Facebook_Recommendations_Bar extends Facebook_Social_Plugin {
 
 	/**
-	 * Element and class name used in markup builders
+	 * Element and class name used in markup builders.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const ID = 'recommendations-bar';
 
 	/**
 	 * Override the URL used for the like action.
-	 * Default is og:url or link[rel=canonical] or document.URL
+	 *
+	 * Default is og:url or link[rel=canonical] or document.URL.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	protected $href;
 
 	/**
-	 * Choose when the plugin expands
+	 * Choose when the plugin expands.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	protected $trigger;
 
 	/**
-	 * Number of seconds to wait before expanding the plugin
+	 * Number of seconds to wait before expanding the plugin.
 	 *
 	 * @since 1.1
+	 *
 	 * @var int
 	 */
 	protected $read_time;
 
 	/**
-	 * Like or recommend
+	 * Like or recommend.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	protected $action;
 
 	/**
-	 * The verb to display on the button
+	 * The verb to display on the button.
 	 *
 	 * @since 1.1
+	 *
 	 * @var array
 	 */
 	public static $action_choices = array( 'like' => true, 'recommend' => true );
 
 	/**
-	 * Display the recommendations bar on the left or right side
+	 * Display the recommendations bar on the left or right side.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	protected $side;
 
 	/**
-	 * Choose to display the recommendations bar on the left or right side
+	 * Choose to display the recommendations bar on the left or right side.
 	 *
 	 * @since 1.1
+	 *
 	 * @var array
 	 */
 	public static $side_choices = array( 'left' => true, 'right' => true );
 
 	/**
-	 * One or more domains to show recommendations for
+	 * One or more domains to show recommendations for.
 	 *
 	 * @since 1.1
+	 *
 	 * @var array
 	 */
 	protected $site = array();
 
 	/**
-	 * Number of recommendations to display
+	 * Number of recommendations to display.
 	 *
 	 * @since 1.1
+	 *
 	 * @var int
 	 */
 	protected $num_recommendations;
 
 	/**
-	 * Only include articles newer than a given number of days
+	 * Only include articles newer than a given number of days.
 	 *
 	 * @since 1.1
+	 *
 	 * @var int
 	 */
 	protected $max_age;
 
 	/**
-	 * I am a recommendations bar
+	 * I am a recommendations bar.
 	 *
 	 * @since 1.1
-	 * @return string
+	 *
+	 * @return string Facebook social plugin name
 	 */
 	public function __toString() {
 		return 'Facebook Recommendations Bar';
 	}
 
 	/**
-	 * Setter for href attribute
+	 * Setter for href attribute.
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $url absolute URL
 	 * @return Facebook_Recommendations_Bar support chaining
 	 */
@@ -126,9 +141,11 @@ class Facebook_Recommendations_Bar extends Facebook_Social_Plugin {
 
 	/**
 	 * Choose when the plugin expands.
-	 * Evaluated in addition to the read_time parameter
+	 *
+	 * Evaluated in addition to the read_time parameter.
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $trigger onvisible|manual|X%
 	 * @return Facebook_Recommendations_Bar support chaining
 	 */
@@ -149,7 +166,8 @@ class Facebook_Recommendations_Bar extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Set the number of seconds before the plugin will expand
+	 * Set the number of seconds before the plugin will expand.
+	 *
 	 * Minimum: 10 seconds
 	 *
 	 * @since 1.1
@@ -166,6 +184,7 @@ class Facebook_Recommendations_Bar extends Facebook_Social_Plugin {
 	 * Override the default "like" text with "recommend"
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $action like|recommend
 	 * @return Facebook_Recommendations_Bar support chaining
 	 */
@@ -177,6 +196,7 @@ class Facebook_Recommendations_Bar extends Facebook_Social_Plugin {
 
 	/**
 	 * Display plugin on the left or right side.
+	 *
 	 * By default the recommendations bar will display at the end of a normal page scan based on the locale (e.g. right side in the left-to-right reading style of English)
 	 *
 	 * @since 1.1
@@ -193,6 +213,7 @@ class Facebook_Recommendations_Bar extends Facebook_Social_Plugin {
 	 * Show recommendations for an additional domain
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $domain domain name
 	 * @return Facebook_Recommendations_Bar support chaining
 	 */
@@ -204,9 +225,11 @@ class Facebook_Recommendations_Bar extends Facebook_Social_Plugin {
 
 	/**
 	 * Set the number of recommendations to display
+	 *
 	 * Accepts a number between 1 and 5
 	 *
-	 * @aince 1.1
+	 * @since 1.1
+	 *
 	 * @param int $num number of recommendations. between 1 and 5
 	 * @return Facebook_Recommendations_Bar support chaining
 	 */
@@ -218,9 +241,11 @@ class Facebook_Recommendations_Bar extends Facebook_Social_Plugin {
 
 	/**
 	 * Limit recommendations to a number of days between 1 and 180
+	 *
 	 * Plugin defaults to no maximum age (age=0)
 	 *
 	 * @since 1.1
+	 *
 	 * @param int $days number of whole days
 	 * @return Facebook_Recommendations_Bar support chaining
 	 */
@@ -232,8 +257,10 @@ class Facebook_Recommendations_Bar extends Facebook_Social_Plugin {
 
 	/**
 	 * Convert the class to data-* attribute friendly associative array
-	 * will become data-key="value"
-	 * Exclude values if default
+	 *
+	 * will become data-key="value". Exclude values if default
+	 *
+	 * @since 1.1
 	 *
 	 * @return array associative array
 	 */
@@ -273,9 +300,10 @@ class Facebook_Recommendations_Bar extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * convert an options array into an object
+	 * convert an options array into an object.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $values associative array
 	 * @return Facebook_Recommendations_Bar recommendations bar object
 	 */
@@ -323,9 +351,10 @@ class Facebook_Recommendations_Bar extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Output Recommendations Box div with data-* attributes
+	 * Output Recommendations Box div with data-* attributes.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $div_attributes associative array. customize the returned div with id, class, or style attributes
 	 * @return HTML div or empty string
 	 */
@@ -337,9 +366,10 @@ class Facebook_Recommendations_Bar extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Output Activity Feed as XFBML
+	 * Output Activity Feed as XFBML.
 	 *
 	 * @since 1.1
+	 *
 	 * @return string XFBML markup
 	 */
 	public function asXFBML() {

--- a/social-plugins/class-facebook-recommendations-box.php
+++ b/social-plugins/class-facebook-recommendations-box.php
@@ -7,104 +7,118 @@ if ( ! class_exists( 'Facebook_Social_Plugin' ) )
  * Display recommended pages based on the browsing history, site interactions, and interests of a Facebook user and friends
  *
  * @since 1.1
+ *
  * @link https://developers.facebook.com/docs/reference/plugins/recommendations/ Recommendations Box social plugin
  */
 class Facebook_Recommendations_Box extends Facebook_Social_Plugin {
 
 	/**
-	 * Element and class name used in markup builders
+	 * Element and class name used in markup builders.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const ID = 'recommendations';
 
 	/**
-	 * The activity domain. Defaults to the current domain
+	 * The activity domain. Defaults to the current domain.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	protected $site;
 
 	/**
-	 * Actions to show activities for
+	 * Actions to show activities for.
 	 *
 	 * @since 1.1
+	 *
 	 * @var array
 	 */
 	protected $action = array();
 
 	/**
-	 * Display all actions, custom and global, associated with this application
+	 * Display all actions, custom and global, associated with this application.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	protected $app_id;
 
 	/**
-	 * Width of the activity feed box in whole pixels
+	 * Width of the activity feed box in whole pixels.
 	 *
 	 * @since 1.1
+	 *
 	 * @var int
 	 */
 	protected $width;
 
 	/**
-	 * Height of the activity feed box in whole pixels
+	 * Height of the activity feed box in whole pixels.
 	 *
 	 * @since 1.1
+	 *
 	 * @var int
 	 */
 	protected $height;
 
 	/**
-	 * Show or hide the Facebook header
+	 * Show or hide the Facebook header.
 	 *
 	 * @since 1.1
+	 *
 	 * @var bool
 	 */
 	protected $header;
 
 	/**
-	 * Define the browsing context of followed links
+	 * Define the browsing context of followed links.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	protected $linktarget;
 
 	/**
-	 * Allowed browsing contexts
+	 * Allowed browsing contexts.
 	 *
 	 * @link http://www.whatwg.org/specs/web-apps/current-work/multipage/browsers.html#browsing-context-names Browsing context names
 	 * @since 1.1
+	 *
 	 * @var array
 	 */
 	public static $linktarget_choices = array( '_blank' => true, '_parent' => true, '_top' => true );
 
 	/**
-	 * Limit the number of days since article creation
+	 * Limit the number of days since article creation.
 	 *
 	 * @since 1.1
+	 *
 	 * @var int
 	 */
 	protected $max_age;
 
 	/**
-	 * I am a recommendation box
+	 * I am a recommendation box.
 	 *
 	 * @since 1.1
+	 *
+	 * @return string Facebook social plugin name
 	 */
 	public function __toString() {
 		return 'Facebook Recommendations Box';
 	}
 
 	/**
-	 * Set the domain for which to show activity
+	 * Set the domain for which to show activity.
      *
      * @since 1.1
+     *
      * @param string $domain domain / hostname
      * @return Facebook_Recommendations_Box support chaining
 	 */
@@ -118,6 +132,7 @@ class Facebook_Recommendations_Box extends Facebook_Social_Plugin {
 	 * Scope the activity feed display to an additional action
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $action action name. global- or app-scoped
 	 * @return Facebook_Recommendations_Box support chaining
 	 */
@@ -128,9 +143,10 @@ class Facebook_Recommendations_Box extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Display actions associated with the specified application
+	 * Display actions associated with the specified application.
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $app_id Facebook application identifer
 	 * @return Facebook_Recommendations_Box support chaining
 	 */
@@ -147,9 +163,10 @@ class Facebook_Recommendations_Box extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Define the width of the activity feed box in whole pixels
+	 * Define the width of the activity feed box in whole pixels.
 	 *
 	 * @since 1.1
+	 *
 	 * @param int $width width in whole pixels
 	 * @return Facebook_Recommendations_Box support chaining
 	 */
@@ -160,9 +177,10 @@ class Facebook_Recommendations_Box extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Define the height of the recommendations box in whole pixels
+	 * Define the height of the recommendations box in whole pixels.
 	 *
 	 * @since 1.1
+	 *
 	 * @param int $height height in whole pixels
 	 * @return Facebook_Recommendations_Box support chaining
 	 */
@@ -176,6 +194,7 @@ class Facebook_Recommendations_Box extends Facebook_Social_Plugin {
 	 * Show the Facebook header
 	 *
 	 * @since 1.1
+	 *
 	 * @return Facebook_Activity_Feed support chaining
 	 */
 	public function showHeader() {
@@ -187,6 +206,7 @@ class Facebook_Recommendations_Box extends Facebook_Social_Plugin {
 	 * Hide the Facebook header
 	 *
 	 * @since 1.1
+	 *
 	 * @return Facebook_Recommendations_Box support chaining
 	 */
 	public function hideHeader() {
@@ -198,6 +218,7 @@ class Facebook_Recommendations_Box extends Facebook_Social_Plugin {
 	 * Define a link target to control browser context on link actions
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $target _blank|_parent|_top
 	 * @return Facebook_Activity_Feed support chaining
 	 */
@@ -212,6 +233,7 @@ class Facebook_Recommendations_Box extends Facebook_Social_Plugin {
 	 * Plugin defaults to no maximum age (age=0)
 	 *
 	 * @since 1.1
+	 *
 	 * @param int $days number of whole days
 	 * @return Facebook_Activity_Feed support chaining
 	 */
@@ -222,9 +244,11 @@ class Facebook_Recommendations_Box extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Convert the class to data-* attribute friendly associative array
-	 * will become data-key="value"
-	 * Exclude values if default
+	 * Convert the class to data-* attribute friendly associative array.
+	 *
+	 * will become data-key="value". Exclude values if default
+	 *
+	 * @since 1.1
 	 *
 	 * @return array associative array
 	 */
@@ -261,9 +285,10 @@ class Facebook_Recommendations_Box extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * convert an options array into an object
+	 * convert an options array into an object.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $values associative array
 	 * @return Facebook_Recommendations_Box recommendations box object
 	 */
@@ -319,9 +344,10 @@ class Facebook_Recommendations_Box extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Output Recommendations Box div with data-* attributes
+	 * Output Recommendations Box div with data-* attributes.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $div_attributes associative array. customize the returned div with id, class, or style attributes
 	 * @return HTML div or empty string
 	 */
@@ -336,6 +362,7 @@ class Facebook_Recommendations_Box extends Facebook_Social_Plugin {
 	 * Output Activity Feed as XFBML
 	 *
 	 * @since 1.1
+	 *
 	 * @return string XFBML markup
 	 */
 	public function asXFBML() {

--- a/social-plugins/class-facebook-send-button.php
+++ b/social-plugins/class-facebook-send-button.php
@@ -7,23 +7,27 @@ if ( ! class_exists( 'Facebook_Social_Plugin' ) )
  * Help visitors send a message to his or her Facebook friend(s) with a send button
  *
  * @since 1.1
+ *
  * @link https://developers.facebook.com/docs/reference/plugins/send/ Send Button docs
  */
 class Facebook_Send_Button extends Facebook_Social_Plugin {
 
 	/**
-	 * Element and class name used in markup builders
+	 * Element and class name used in markup builders.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	const ID = 'send';
 
 	/**
 	 * Override the URL used for the Send action.
+	 *
 	 * Default is og:url or link[rel=canonical] or document.URL
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	protected $href;
@@ -32,6 +36,8 @@ class Facebook_Send_Button extends Facebook_Social_Plugin {
 	 * I am a send button
 	 *
 	 * @since 1.1
+	 *
+	 * @return string Facebook social plugin name
 	 */
 	public function __toString() {
 		return 'Facebook Send Button';
@@ -41,6 +47,7 @@ class Facebook_Send_Button extends Facebook_Social_Plugin {
 	 * Setter for href attribute
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $url absolute URL
 	 * @return Facebook_Send_Button support chaining
 	 */
@@ -55,6 +62,7 @@ class Facebook_Send_Button extends Facebook_Social_Plugin {
 	 * convert an options array into an object
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $values associative array
 	 * @return Facebook_Send_Button send button object
 	 */
@@ -84,8 +92,10 @@ class Facebook_Send_Button extends Facebook_Social_Plugin {
 
 	/**
 	 * Convert the class to data-* attribute friendly associative array
-	 * will become data-key="value"
-	 * Exclude values if default
+	 *
+	 * will become data-key="value". Exclude values if default
+	 *
+	 * @since 1.1
 	 *
 	 * @return array associative array
 	 */
@@ -99,9 +109,10 @@ class Facebook_Send_Button extends Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Output Send button with data-* attributes
+	 * Output Send button with data-* attributes.
 	 *
 	 * @since 1.1
+	 *
 	 * @param array $div_attributes associative array. customize the returned div with id, class, or style attributes
 	 * @return HTML div or empty string
 	 */
@@ -116,6 +127,7 @@ class Facebook_Send_Button extends Facebook_Social_Plugin {
 	 * Output Send button as XFBML
 	 *
 	 * @since 1.1
+	 *
 	 * @return string XFBML markup
 	 */
 	public function asXFBML() {

--- a/social-plugins/class-facebook-social-plugin.php
+++ b/social-plugins/class-facebook-social-plugin.php
@@ -8,59 +8,67 @@
 class Facebook_Social_Plugin {
 
 	/**
-	 * Customize a font displayed in the button to match your site style
+	 * Customize a font displayed in the button to match your site style.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	protected $font;
 
 	/**
-	 * The font to display in the button
+	 * The font to display in the button.
 	 *
 	 * @since 1.1
+	 *
 	 * @var array
 	 */
 	public static $font_choices = array( 'arial' => true, 'lucida grande' => true, 'segoe ui' => true, 'tahoma' => true, 'trebuchet ms' => true, 'verdana' => true );
 
 	/**
-	 * Choose a light or dark color scheme to match your site style
+	 * Choose a light or dark color scheme to match your site style.
 	 *
 	 * @since 1.1
+	 *
 	 * @param string
 	 */
 	protected $colorscheme;
 
 	/**
-	 * Use a light or dark color scheme
+	 * Use a light or dark color scheme.
 	 *
 	 * @since 1.1
+	 *
 	 * @var array
 	 */
 	public static $colorscheme_choices = array( 'light' => true, 'dark' => true );
 
 	/**
 	 * Add a unique reference to track referrals. Facebook passes this parameter to the destination URL when a Facebook user clicks the link.
-	 * Example: 'footer' for a like button in your footer vs. 'banner' for a button in your site banner
+	 *
+	 * Example: 'footer' for a like button in your footer vs. 'banner' for a button in your site banner.
 	 *
 	 * @since 1.1
+	 *
 	 * @var string
 	 */
 	protected $ref;
 
 	/**
 	 * Is your website primarily directed to children in the United States under the age of 13?
-	 * @link https://developers.facebook.com/docs/plugins/restrictions/ Child-directed sites and services
 	 *
+	 * @link https://developers.facebook.com/docs/plugins/restrictions/ Child-directed sites and services
 	 * @since 1.5
+	 *
 	 * @var bool
 	 */
 	protected $kid_directed_site;
 
 	/**
-	 * Choose a font to match your site styling
+	 * Choose a font to match your site styling.
 	 *
 	 * @since 1.1
+	 *
 	 * @see self::$font_choices
 	 * @param string $font a font name from $font_choices
 	 * @return Facebook_Social_Plugin support chaining
@@ -72,9 +80,10 @@ class Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Choose a light or dark color scheme
+	 * Choose a light or dark color scheme.
 	 *
 	 * @since 1.1
+	 *
 	 * @see self::colorscheme_choices
 	 * @param string $color_scheme light|dark
 	 * @return Facebook_Social_Plugin support chaining
@@ -86,9 +95,10 @@ class Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Clean up the ref paramter based on Facebook requirements
+	 * Clean up the ref paramter based on Facebook requirements.
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $ref reference string you would like to track on your site after a Facebook visitor follows a link
 	 * @return string cleaned string
 	 */
@@ -100,9 +110,11 @@ class Facebook_Social_Plugin {
 
 	/**
 	 * Track referrals from Facebook with a string up to 50 chracters.
+	 *
 	 * Characters in string must be alphanumeric or punctuation (currently +/=-.:_)
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $ref reference string
 	 * @return Facebook_Social_Plugin support chaining
 	 */
@@ -114,7 +126,7 @@ class Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Inform Facebook a social plugin will likely be displayed to a child in the United States under the age of 13
+	 * Inform Facebook a social plugin will likely be displayed to a child in the United States under the age of 13.
 	 *
 	 * @since 1.5
 	 * @return Facebook_Social_Plugin support chaining
@@ -125,7 +137,9 @@ class Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Convert the class object into an array, removing default values
+	 * Convert the class object into an array, removing default values.
+	 *
+	 * @since 1.1
 	 *
 	 * @return array associative array
 	 */
@@ -148,9 +162,11 @@ class Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Convert the class to data-* attribute friendly associative array
-	 * will become data-key="value"
-	 * Exclude values if default
+	 * Convert the class to data-* attribute friendly associative array.
+	 *
+	 * will become data-key="value". Exclude values if default
+	 *
+	 * @since 1.1
 	 *
 	 * @return array associative array
 	 */
@@ -167,9 +183,10 @@ class Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Add a class required by the social plugin to an existing set of attributes
+	 * Add a class required by the social plugin to an existing set of attributes.
 	 *
 	 * @since 1.1
+
 	 * @param string $class class name to add to the attributes array
 	 * @param array $attributes existing attributes array
 	 * @return array attributes array with social plugin class
@@ -192,7 +209,9 @@ class Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Output div element with data-* attributes
+	 * Output div element with data-* attributes.
+	 *
+	 * @since 1.1
 	 *
 	 * @param array $div_attributes associative array. customize the returned div with id, class, or style attributes. social plugin parameters in data.
 	 * @return string HTML div or empty string
@@ -232,9 +251,10 @@ class Facebook_Social_Plugin {
 	}
 
 	/**
-	 * Output XFBML element with attributes
+	 * Output XFBML element with attributes.
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $element name of the element, e.g. "like" for fb:like
 	 * @return string XFBML element or empty string
 	 */

--- a/social-plugins/comments.php
+++ b/social-plugins/comments.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * WordPress comments template for the Facebook plugin for WordPress.
+ *
+ * Integrate with the comments display area of WordPress themes by overriding the theme's default comments template with a Facebook plugin-specific comments template including existing WordPress comments, static markup wrapped in a <noscript> based on comments stored on Facebook servers, and Comments Box XFBML markup to be interpreted by the Facebook SDK for JavaScript. Attempt to match CSS-addressable elements of WordPress core themes and customization functions where possible but with Facebook plugin-specific filters to avoid unexpected behaviors.
+ *
+ * @since 1.3
+ */
+
+
 /*
  * If the current post is protected by a password and the visitor has not yet
  * entered the password we will return early without loading the comments.
@@ -15,7 +24,29 @@ if ( post_password_required() )
 	add_filter( 'cancel_comment_reply_link', array( 'Facebook_Loader', '__return_empty_string' ) );
 	add_filter( 'comment_id_fields', array( 'Facebook_Loader', '__return_empty_string' ) );
 ?>
-	<h2 class="comments-title"><?php echo esc_html( apply_filters( 'facebook_wp_comments_title', __( 'Comments' ) ) ); ?></h2><?php
+	<h2 class="comments-title"><?php
+/**
+ * Customize the title shown above the comments area in the comments template
+ *
+ * @since 1.3
+ * @param string Comments title.
+ */
+echo esc_html( apply_filters( 'facebook_wp_comments_title', __( 'Comments' ) ) );
+?></h2><?php
+	/**
+	 * Customize the HTML element style of the static markup wrapper displaying WordPress comments.
+	 *
+	 * Some sites may have accepted WordPress plugins for a post before switching to the Facebook Comments Box social plugin. Display previous comments before displaying the
+	 *
+	 * @since 1.3
+	 *
+	 * @see wp_list_comments() for a full list of options to be passed to wp_list_comments
+	 * @param array {
+	 *     Comments options.
+	 *
+	 *     @type string 'style' Can be either 'div', 'ol', or 'ul', to display comments using divs, ordered, or unordered lists. Default 'ol'.
+	 * }
+	 */
 	$_comment_options = apply_filters( 'facebook_wp_list_comments', array( 'style' => 'ol' ) );
 	// correct filter if broken
 	if ( ! is_array( $_comment_options ) )
@@ -32,12 +63,23 @@ if ( post_password_required() )
 	unset( $_comment_options );
 endif; // have_comments()
 
+// generate Facebook Comments Box markup
 $_facebook_comments = Facebook_Comments::comments_box();
 if ( $_facebook_comments ) {
+	/**
+	 * Output content before the Facebook Comments Box display area
+	 *
+	 * @since 1.3
+	 */
 	do_action( 'facebook_comment_form_before' );
 	echo '<div id="respond" class="comment-respond">';
 	echo $_facebook_comments;
 	echo '</div>';
+	/**
+	 * Output content after the Facebook Comments Box display area
+	 *
+	 * @since 1.3
+	 */
 	do_action( 'facebook_comment_form_after' );
 }
 unset( $_facebook_comments );

--- a/social-plugins/shortcodes.php
+++ b/social-plugins/shortcodes.php
@@ -10,6 +10,10 @@ class Facebook_Shortcodes {
 	 * Register shortcode handlers
 	 *
 	 * @since 1.1.6
+	 *
+	 * @uses add_shortcode()
+	 * @uses wp_embed_register_handler()
+	 * @return void
 	 */
 	public static function init() {
 		// expose social plugin markup using WordPress Shortcode API
@@ -29,10 +33,12 @@ class Facebook_Shortcodes {
 	}
 
 	/**
-	 * Facebook Embedded Post embed handler callback
-	 * Facebook does not support oEmbed
+	 * Facebook Embedded Post embed handler callback.
+	 *
+	 * Facebook does not support oEmbed.
 	 *
 	 * @since 1.5
+	 *
 	 * @param array $matches The regex matches from the provided regex when calling {@link wp_embed_register_handler()}.
 	 * @param array $attr Embed attributes. Not used.
 	 * @param string $url The original URL that was matched by the regex. Not used.
@@ -44,9 +50,10 @@ class Facebook_Shortcodes {
 	}
 
 	/**
-	 * Generate a HTML div element with data-* attributes to be converted into a Like Button by the Facebook JavaScript SDK
+	 * Generate a HTML div element with data-* attributes to be converted into a Like Button by the Facebook JavaScript SDK.
 	 *
 	 * @since 1.1.6
+	 *
 	 * @param array $attributes shortcode attributes. overrides site options for specific button attributes
 	 * @param string $content shortcode content. no effect
 	 * @return string Like Button div HTML or empty string if minimum requirements not met
@@ -102,6 +109,7 @@ class Facebook_Shortcodes {
 	 * Generate a HTML div element with data-* attributes to be converted into a Send Button by the Facebook JavaScript SDK
 	 *
 	 * @since 1.1.6
+	 *
 	 * @param array $attributes shortcode attributes. overrides site options for specific button attributes
 	 * @param string $content shortcode content. no effect
 	 * @return string send button HTML div or empty string if minimum requirements not met
@@ -146,6 +154,7 @@ class Facebook_Shortcodes {
 	 * The passed href URL value must be a Facebook User profile URL; this URL is not validated before attempting to use in a Follow Button parameter
 	 *
 	 * @since 1.5
+	 *
 	 * @param array $attributes shortcode attributes. overrides site options for specific button attributes
 	 * @param string $content shortcode content. no effect
 	 * @return string Follow Button div HTML or empty string if minimum requirements not met
@@ -192,6 +201,7 @@ class Facebook_Shortcodes {
 	 * Generate a HTML div element with data-* attributes to be converted into a Facebook embedded post
 	 *
 	 * @since 1.5
+	 *
 	 * @param array $attributes shortcode attributes. overrides site options for specific button attributes
 	 * @param string $content shortcode content. no effect
 	 * @return string Follow Button div HTML or empty string if minimum requirements not met

--- a/social-plugins/social-plugins.php
+++ b/social-plugins/social-plugins.php
@@ -1,10 +1,12 @@
 <?php
 
 /**
- * Generate HTML for a single Like Button
+ * Generate HTML for a single Like Button.
+ *
+ * @since 1.0
  *
  * @param array $options like button options
- * @return string HTML div for use with the JavaScript SDK
+ * @return string HTML div for use with the Facebook SDK for JavaScript
  */
 function facebook_get_like_button( $options = array() ) {
 	if ( ! class_exists( 'Facebook_Like_Button' ) )
@@ -22,10 +24,13 @@ function facebook_get_like_button( $options = array() ) {
 }
 
 /**
- * Add Like Button(s) to post content
+ * Add Like Button(s) to post content.
+ *
  * Adds a like button above the post, below the post, or both above and below the post depending on stored preferences.
  *
  * @since 1.1
+ *
+ * @global stdClass|WP_Post $post WordPress post. Used to request a post permalink.
  * @param string $content existing content
  * @return string passed content with Like Button markup prepended, appended, or both.
  */
@@ -43,6 +48,7 @@ function facebook_the_content_like_button( $content ) {
 	if ( ! isset( $options['position'] ) )
 		return $content;
 
+	// duplicate_hook
 	$options['href'] = apply_filters( 'facebook_rel_canonical', get_permalink( $post->ID ) );
 
 	if ( $options['position'] === 'top' ) {
@@ -63,9 +69,10 @@ function facebook_the_content_like_button( $content ) {
 }
 
 /**
- * Recommendations Bar markup for use with Facebook JavaScript SDK
+ * Recommendations Bar markup for use with Facebook SDK for JavaScript
  *
  * @since 1.1
+ *
  * @param array $options stored options
  * @return string HTML div markup or empty string
  */
@@ -85,11 +92,13 @@ function facebook_get_recommendations_bar( $options = array() ) {
 }
 
 /**
- * Add Recommendations Bar to the end of post content
+ * Add Recommendations Bar to the end of post content.
  *
- * Triggers the Recommendations Bar display once a visitor scrolls past the end of the post in 'onvisible' trigger mode
+ * Triggers the Recommendations Bar display once a visitor scrolls past the end of the post in 'onvisible' trigger mode.
  *
  * @since 1.1
+ *
+ * @global stdClass|WP_Post WordPress post object. Used to scope to singular post views.
  * @param string $content post content
  * @return string the content with the Recommendations Bar HTML5-style data-* div
  */
@@ -110,11 +119,12 @@ function facebook_the_content_recommendations_bar( $content ) {
 }
 
 /**
- * Generate HTML for a send button based on passed options
+ * Generate HTML for a send button based on passed options.
  *
  * @since 1.1
+ *
  * @param array $options customizations
- * @return string send button HTML for use with the JavaScript SDK
+ * @return string send button HTML for use with the Facebook SDK for JavaScript
  */
 function facebook_get_send_button( $options = array() ) {
 	if ( ! class_exists( 'Facebook_Send_Button' ) )
@@ -132,10 +142,13 @@ function facebook_get_send_button( $options = array() ) {
 }
 
 /**
- * Add Send Button(s) to post content
+ * Add Send Button(s) to post content.
+ *
  * Adds a send button above the post, below the post, or both above and below the post depending on stored preferences.
  *
  * @since 1.1
+ *
+ * @global stdClass|WP_Post WordPress post object. Used to generate a post permalink.
  * @param string $content existing content
  * @return string passed content with Send Button markup prepended, appended, or both.
  */
@@ -171,11 +184,12 @@ function facebook_the_content_send_button( $content ) {
 }
 
 /**
- * Generate HTML for a follow button based on passed options
+ * Generate HTML for a follow button based on passed options.
  *
  * @since 1.1
+ *
  * @param array $options customizations
- * @return string follow button HTML for use with the JavaScript SDK
+ * @return string follow button HTML for use with the Facebook SDK for JavaScript
  */
 function facebook_get_follow_button( $options = array() ) {
 	// need a subscription target
@@ -198,16 +212,16 @@ function facebook_get_follow_button( $options = array() ) {
 
 /**
  * Add Follow Button(s) to post content
+ *
  * Adds a follow button above the post, below the post, or both above and below the post depending on stored preferences.
  *
  * @since 1.1
+ *
  * @param string $content existing content
  * @return string passed content with Follow Button markup prepended, appended, or both.
  */
 function facebook_the_content_follow_button( $content ) {
-	global $post;
-
-	// Send Button should not be the only content
+	// Follow Button should not be the only content
 	if ( ! $content )
 		return $content;
 

--- a/social-plugins/widgets/activity-feed.php
+++ b/social-plugins/widgets/activity-feed.php
@@ -8,7 +8,11 @@
 class Facebook_Activity_Feed_Widget extends WP_Widget {
 
 	/**
-	 * Register widget with WordPress
+	 * Register widget with WordPress.
+	 *
+	 * @since 1.0
+	 *
+	 * @return void
 	 */
 	public function __construct() {
 		parent::__construct(
@@ -21,10 +25,13 @@ class Facebook_Activity_Feed_Widget extends WP_Widget {
 	/**
 	 * Front-end display of widget.
 	 *
+	 * @since 1.0
+	 *
 	 * @see WP_Widget::widget()
 	 *
 	 * @param array $args     Widget arguments.
 	 * @param array $instance Saved values from database.
+	 * @return void
 	 */
 	public function widget( $args, $instance ) {
 		extract( $args );
@@ -57,6 +64,8 @@ class Facebook_Activity_Feed_Widget extends WP_Widget {
 
 	/**
 	 * Sanitize widget form values as they are saved.
+	 *
+	 * @since 1.0
 	 *
 	 * @see WP_Widget::update()
 	 *
@@ -124,9 +133,12 @@ class Facebook_Activity_Feed_Widget extends WP_Widget {
 	/**
 	 * Back-end widget form.
 	 *
+	 * @since 1.0
+	 *
 	 * @see WP_Widget::form()
 	 *
 	 * @param array $instance Previously saved values from database.
+	 * @return void
 	 */
 	public function form( $instance ) {
 		$instance = wp_parse_args( (array) $instance, array(
@@ -152,10 +164,13 @@ class Facebook_Activity_Feed_Widget extends WP_Widget {
 
 	/**
 	 * Allow a publisher to customize the title displayed above the widget area
+	 *
 	 * e.g. Things we hope you will like
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $existing_value saved title
+	 * @return void
 	 */
 	public function display_title( $existing_value = '' ) {
 		echo '<p><label>' . esc_html( __( 'Title', 'facebook' ) ) . ': ';
@@ -167,10 +182,13 @@ class Facebook_Activity_Feed_Widget extends WP_Widget {
 
 	/**
 	 * Show the Facebook header
+	 *
 	 * Works best when you don't set your own widget title
 	 *
 	 * @since 1.1
+	 *
 	 * @param bool $true_false
+	 * @return void
 	 */
 	public function display_header( $true_false ) {
 		echo '<p><label><input type="checkbox" id="' . $this->get_field_id( 'header' ) . '" name="' . $this->get_field_name( 'header' ) . '"';
@@ -182,7 +200,9 @@ class Facebook_Activity_Feed_Widget extends WP_Widget {
 	 * Include recommended articles in recent activity in the bottom half
 	 *
 	 * @since 1.1
+	 *
 	 * @param bool $true_false
+	 * @return void
 	 */
 	public function display_recommendations( $true_false ) {
 		echo '<p><label><input type="checkbox" id="' . $this->get_field_id( 'recommendations' ) . '" name="' . $this->get_field_name( 'recommendations' ) . '"';
@@ -194,7 +214,9 @@ class Facebook_Activity_Feed_Widget extends WP_Widget {
 	 * Limit articles displayed in recommendations box to last N days where N is a number between 0 (no limit) and 180.
 	 *
 	 * @since 1.1
+	 *
 	 * @param int $existing_value stored value
+	 * @return void
 	 */
 	public function display_max_age( $existing_value = 0 ) {
 		echo '<p><label>' . esc_html( __( 'Maximum age', 'facebook' ) ) . ': ';
@@ -210,10 +232,12 @@ class Facebook_Activity_Feed_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Specify the width of the recommendations box in whole pixels
+	 * Specify the width of the recommendations box in whole pixels.
 	 *
 	 * @since 1.1
+	 *
 	 * @param int $existing_value previously stored value
+	 * @return void
 	 */
 	public function display_width( $existing_value = 300 ) {
 		if ( $existing_value < 200 )
@@ -222,10 +246,12 @@ class Facebook_Activity_Feed_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Specify the height of the recommendations box in whole pixels
+	 * Specify the height of the recommendations box in whole pixels.
 	 *
 	 * @since 1.1
+	 *
 	 * @param int $existing_value previously stored value
+	 * @return void
 	 */
 	public function display_height( $existing_value = 300 ) {
 		if ( $existing_value < 200 )
@@ -234,9 +260,10 @@ class Facebook_Activity_Feed_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Choose a font
+	 * Choose a font.
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $existing_value stored font value
 	 */
 	public function display_font( $existing_value = '' ) {
@@ -247,10 +274,12 @@ class Facebook_Activity_Feed_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Choose a light or dark color scheme
+	 * Choose a light or dark color scheme.
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $existing_value saved colorscheme value
+	 * @return void
 	 */
 	public function display_colorscheme( $existing_value = 'light' ) {
 		if ( ! class_exists( 'Facebook_Social_Plugin_Settings' ) )

--- a/social-plugins/widgets/follow-button.php
+++ b/social-plugins/widgets/follow-button.php
@@ -8,6 +8,10 @@ class Facebook_Follow_Button_Widget extends WP_Widget {
 
 	/**
 	 * Register widget with WordPress
+	 *
+	 * @since 1.0
+	 *
+	 * @return void
 	 */
 	public function __construct() {
 		parent::__construct(
@@ -20,10 +24,13 @@ class Facebook_Follow_Button_Widget extends WP_Widget {
 	/**
 	 * Front-end display of widget.
 	 *
+	 * @since 1.0
+	 *
 	 * @see WP_Widget::widget()
 	 *
 	 * @param array $args     Widget arguments.
 	 * @param array $instance Saved values from database.
+	 * @return void
 	 */
 	public function widget( $args, $instance ) {
 		// no follow target. fail early
@@ -56,6 +63,8 @@ class Facebook_Follow_Button_Widget extends WP_Widget {
 
 	/**
 	 * Sanitize widget form values as they are saved.
+	 *
+	 * @since 1.0
 	 *
 	 * @see WP_Widget::update()
 	 *
@@ -96,9 +105,12 @@ class Facebook_Follow_Button_Widget extends WP_Widget {
 	/**
 	 * Back-end widget form.
 	 *
+	 * @since 1.0
+	 *
 	 * @see WP_Widget::form()
 	 *
 	 * @param array $instance Previously saved values from database.
+	 * @return void
 	 */
 	public function form( $instance ) {
 		$instance = wp_parse_args( (array) $instance, array(
@@ -157,10 +169,13 @@ class Facebook_Follow_Button_Widget extends WP_Widget {
 
 	/**
 	 * Allow a publisher to customize the title displayed above the widget area
+	 *
 	 * e.g. Like us on Facebook!
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $existing_value saved title
+	 * @return void
 	 */
 	public function display_title( $existing_value = '' ) {
 		echo '<p><label>' . esc_html( __( 'Title', 'facebook' ) ) . ': ';
@@ -174,7 +189,9 @@ class Facebook_Follow_Button_Widget extends WP_Widget {
 	 * Customize the Like target
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $existing_value stored URL value
+	 * @return void
 	 */
 	public function display_href( $existing_value = '' ) {
 		echo '<p><label>URL: <input type="url" id="' . $this->get_field_id( 'href' ) . '" name="' . $this->get_field_name( 'href' ) . '" class="widefat" required';

--- a/social-plugins/widgets/like-box.php
+++ b/social-plugins/widgets/like-box.php
@@ -8,6 +8,10 @@ class Facebook_Like_Box_Widget extends WP_Widget {
 
 	/**
 	 * Register widget with WordPress
+	 *
+	 * @since 1.0
+	 *
+	 * @return void
 	 */
 	public function __construct() {
 		parent::__construct(
@@ -19,9 +23,13 @@ class Facebook_Like_Box_Widget extends WP_Widget {
 
 	/**
 	 * Test if a provided string is a URL to a Facebook page
+	 *
 	 * Sanitize the URL if valid
 	 *
 	 * @since 1.1.11
+	 *
+	 * @global wpdb $wpdb WordPress database class. sanitize FQL values.
+	 * @global \Facebook_Loader $facebook_loader access Facebook application credentials
 	 * @param string $url absolute URL
 	 * @return string Facebook Page URL or empty string if the passed URL does not seem to be a Facebook Page URL
 	 */
@@ -91,8 +99,11 @@ class Facebook_Like_Box_Widget extends WP_Widget {
 	 *
 	 * @see WP_Widget::widget()
 	 *
+	 * @since 1.0
+	 *
 	 * @param array $args     Widget arguments.
 	 * @param array $instance Saved values from database.
+	 * @return void
 	 */
 	public function widget( $args, $instance ) {
 		// no Facebook Page target specified. fail early
@@ -131,6 +142,8 @@ class Facebook_Like_Box_Widget extends WP_Widget {
 	 * Sanitize widget form values as they are saved.
 	 *
 	 * @see WP_Widget::update()
+	 *
+	 * @since 1.0
 	 *
 	 * @param array $new_instance Values just sent to be saved.
 	 * @param array $old_instance Previously saved values from database.
@@ -204,7 +217,10 @@ class Facebook_Like_Box_Widget extends WP_Widget {
 	 *
 	 * @see WP_Widget::form()
 	 *
+	 * @since 1.0
+	 *
 	 * @param array $instance Previously saved values from database.
+	 * @return void
 	 */
 	public function form( $instance ) {
 		$instance = wp_parse_args( (array) $instance, array(
@@ -233,10 +249,13 @@ class Facebook_Like_Box_Widget extends WP_Widget {
 
 	/**
 	 * Allow a publisher to customize the title displayed above the widget area
+	 *
 	 * e.g. Like us!
 	 *
 	 * @since 1.1.11
+	 *
 	 * @param string $existing_value saved title
+	 * @return void
 	 */
 	public function display_title( $existing_value = '' ) {
 		echo '<p><label for="' . $this->get_field_id( 'title' ) . '">' . esc_html( _x( 'Title', 'Section title or header', 'facebook' ) ) . '</label>: ';
@@ -247,11 +266,14 @@ class Facebook_Like_Box_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Show the Facebook header
+	 * Show the Facebook header.
+	 *
 	 * Works best when you do not set your own widget title
 	 *
 	 * @since 1.1.11
+	 *
 	 * @param bool $true_false
+	 * @return void
 	 */
 	public function display_header( $true_false ) {
 		echo '<p><input class="checkbox" type="checkbox" id="' . $this->get_field_id( 'header' ) . '" name="' . $this->get_field_name( 'header' ) . '" value="1"';
@@ -260,11 +282,14 @@ class Facebook_Like_Box_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Show the Facebook header
+	 * Show the social plugin border.
+	 *
 	 * Works best when you do not set your own widget title
 	 *
 	 * @since 1.5
+	 *
 	 * @param bool $true_false
+	 * @return void
 	 */
 	public function display_show_border( $true_false ) {
 		echo '<p><input class="checkbox" type="checkbox" id="' . $this->get_field_id( 'show_border' ) . '" name="' . $this->get_field_name( 'show_border' ) . '" value="1"';
@@ -273,10 +298,12 @@ class Facebook_Like_Box_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Set the Like target
+	 * Set the Like target.
 	 *
 	 * @since 1.1.11
+	 *
 	 * @param string $existing_value stored URL value
+	 * @return void
 	 */
 	public function display_href( $existing_value = '' ) {
 		echo '<p><label for="' . $this->get_field_id( 'href' ) . '">URL</label>: <input type="url" id="' . $this->get_field_id( 'href' ) . '" name="' . $this->get_field_name( 'href' ) . '" class="widefat" required';
@@ -288,10 +315,12 @@ class Facebook_Like_Box_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Display a stream of latest posts from the Facebook Page's wall
+	 * Display a stream of latest posts from the Facebook Page's wall.
 	 *
 	 * @since 1.1.11
+	 *
 	 * @param bool $true_false enabled or disabled
+	 * @return void
 	 */
 	public function display_stream( $true_false ) {
 		echo '<p><input type="checkbox" id="' . $this->get_field_id( 'stream' ) . '" name="' . $this->get_field_name( 'stream' ) . '" value="1"';
@@ -300,10 +329,12 @@ class Facebook_Like_Box_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Always display posts from Page's stream, even if page is a Place and checkins available
+	 * Always display posts from Page's stream, even if page is a Place and checkins available.
 	 *
 	 * @since 1.1.11
+	 *
 	 * @param bool $true_false
+	 * @return void
 	 */
 	public function display_force_wall( $true_false ) {
 		echo '<p><input type="checkbox" id="' . $this->get_field_id( 'force_wall' ) . '" name="' . $this->get_field_name( 'force_wall' ) . '" value="1"';
@@ -312,10 +343,12 @@ class Facebook_Like_Box_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Show faces of viewer's friends
+	 * Show faces of viewer's friends.
 	 *
 	 * @since 1.1.11
+	 *
 	 * @param bool $true_false enabled or disabled
+	 * @return void
 	 */
 	public function display_show_faces( $true_false ) {
 		echo '<p><input class="checkbox" type="checkbox" id="' . $this->get_field_id( 'show_faces' ) . '" name="' . $this->get_field_name( 'show_faces' ) . '" value="1"';
@@ -324,10 +357,12 @@ class Facebook_Like_Box_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Choose a light or dark color scheme
+	 * Choose a light or dark color scheme.
 	 *
 	 * @since 1.1.11
+	 *
 	 * @param string $existing_value saved colorscheme value
+	 * @return void
 	 */
 	public function display_colorscheme( $existing_value = 'light' ) {
 		if ( ! class_exists( 'Facebook_Social_Plugin_Settings' ) )
@@ -339,10 +374,12 @@ class Facebook_Like_Box_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Specify the width of the recommendations box in whole pixels
+	 * Specify the width of the recommendations box in whole pixels.
 	 *
 	 * @since 1.1.11
+	 *
 	 * @param int $existing_value previously stored value
+	 * @return void
 	 */
 	public function display_width( $existing_value = 300 ) {
 		if ( ! class_exists( 'Facebook_Like_Box' ) )
@@ -355,10 +392,12 @@ class Facebook_Like_Box_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Specify the height of the recommendations box in whole pixels
+	 * Specify the height of the recommendations box in whole pixels.
 	 *
 	 * @since 1.1.11
+	 *
 	 * @param int $existing_value previously stored value
+	 * @return void
 	 */
 	public function display_height( $existing_value = 0 ) {
 		if ( ! class_exists( 'Facebook_Like_Box' ) )

--- a/social-plugins/widgets/like-button.php
+++ b/social-plugins/widgets/like-button.php
@@ -9,6 +9,10 @@ class Facebook_Like_Button_Widget extends WP_Widget {
 
 	/**
 	 * Register widget with WordPress
+	 *
+	 * @since 1.0
+	 *
+	 * @return void
 	 */
 	public function __construct() {
 		parent::__construct(
@@ -25,8 +29,12 @@ class Facebook_Like_Button_Widget extends WP_Widget {
 	 *
 	 * @see WP_Widget::widget()
 	 *
+	 * @since 1.0
+	 *
 	 * @param array $args     Widget arguments.
 	 * @param array $instance Saved values from database.
+	 *
+	 * @return void
 	 */
 	public function widget( $args, $instance ) {
 		extract( $args );
@@ -62,6 +70,8 @@ class Facebook_Like_Button_Widget extends WP_Widget {
 	 * Sanitize widget form values as they are saved.
 	 *
 	 * @see WP_Widget::update()
+	 *
+	 * @since 1.0
 	 *
 	 * @param array $new_instance Values just sent to be saved.
 	 * @param array $old_instance Previously saved values from database.
@@ -101,7 +111,10 @@ class Facebook_Like_Button_Widget extends WP_Widget {
 	 *
 	 * @see WP_Widget::form()
 	 *
+	 * @since 1.0
+	 *
 	 * @param array $instance Previously saved values from database.
+	 * @return void
 	 */
 	public function form( $instance ) {
 		$instance = wp_parse_args( (array) $instance, array(
@@ -175,11 +188,14 @@ class Facebook_Like_Button_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Allow a publisher to customize the title displayed above the widget area
+	 * Allow a publisher to customize the title displayed above the widget area.
+	 *
 	 * e.g. Like us on Facebook!
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $existing_value saved title
+	 * @return void
 	 */
 	public function display_title( $existing_value = '' ) {
 		echo '<p><label>' . esc_html( __( 'Title', 'facebook' ) ) . ': ';
@@ -190,10 +206,12 @@ class Facebook_Like_Button_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Customize the Like target
+	 * Customize the Like target.
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $existing_value stored URL value
+	 * @return void
 	 */
 	public function display_href( $existing_value = '' ) {
 		echo '<p><label>URL: <input type="url" id="' . $this->get_field_id( 'href' ) . '" name="' . $this->get_field_name( 'href' ) . '" class="widefat"';

--- a/social-plugins/widgets/recommendations-box.php
+++ b/social-plugins/widgets/recommendations-box.php
@@ -3,12 +3,16 @@
 /**
  * Adds the Recommendations Social Plugin as a WordPress Widget
  *
- * @since 1.0
+ * @since 1.1
  */
 class Facebook_Recommendations_Widget extends WP_Widget {
 
 	/**
 	 * Register widget with WordPress
+	 *
+	 * @since 1.1
+	 *
+	 * @return void
 	 */
 	public function __construct() {
 		parent::__construct(
@@ -23,8 +27,11 @@ class Facebook_Recommendations_Widget extends WP_Widget {
 	 *
 	 * @see WP_Widget::widget()
 	 *
+	 * @since 1.1
+	 *
 	 * @param array $args     Widget arguments.
 	 * @param array $instance Saved values from database.
+	 * @return void
 	 */
 	public function widget( $args, $instance ) {
 		extract( $args );
@@ -59,6 +66,8 @@ class Facebook_Recommendations_Widget extends WP_Widget {
 	 * Sanitize widget form values as they are saved.
 	 *
 	 * @see WP_Widget::update()
+	 *
+	 * @since 1.1
 	 *
 	 * @param array $new_instance Values just sent to be saved.
 	 * @param array $old_instance Previously saved values from database.
@@ -117,7 +126,10 @@ class Facebook_Recommendations_Widget extends WP_Widget {
 	 *
 	 * @see WP_Widget::form()
 	 *
+	 * @since 1.1
+	 *
 	 * @param array $instance Previously saved values from database.
+	 * @return void
 	 */
 	public function form( $instance ) {
 		$instance = wp_parse_args( (array) $instance, array(
@@ -139,11 +151,14 @@ class Facebook_Recommendations_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Allow a publisher to customize the title displayed above the widget area
-	 * e.g. Things we hope you will like
+	 * Allow a publisher to customize the title displayed above the widget area.
+	 *
+	 * e.g. Things we hope you will like.
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $existing_value saved title
+	 * @return void
 	 */
 	public function display_title( $existing_value = '' ) {
 		echo '<p><label>' . esc_html( __( 'Title', 'facebook' ) ) . ': ';
@@ -154,11 +169,14 @@ class Facebook_Recommendations_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Show the Facebook header
-	 * Works best when you don't set your own widget title
+	 * Show the Facebook header.
+	 *
+	 * Works best when you don't set your own widget title.
 	 *
 	 * @since 1.1
+	 *
 	 * @param bool $true_false
+	 * @return void
 	 */
 	public function display_header( $true_false ) {
 		echo '<p><label><input type="checkbox" id="' . $this->get_field_id( 'header' ) . '" name="' . $this->get_field_name( 'header' ) . '"';
@@ -167,10 +185,12 @@ class Facebook_Recommendations_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Specify the width of the recommendations box in whole pixels
+	 * Specify the width of the recommendations box in whole pixels.
 	 *
 	 * @since 1.1
+	 *
 	 * @param int $existing_value previously stored value
+	 * @return void
 	 */
 	public function display_width( $existing_value = 300 ) {
 		if ( $existing_value < 200 )
@@ -179,10 +199,12 @@ class Facebook_Recommendations_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Specify the height of the recommendations box in whole pixels
+	 * Specify the height of the recommendations box in whole pixels.
 	 *
 	 * @since 1.1
+	 *
 	 * @param int $existing_value previously stored value
+	 * @return void
 	 */
 	public function display_height( $existing_value = 300 ) {
 		if ( $existing_value < 200 )
@@ -191,10 +213,11 @@ class Facebook_Recommendations_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Choose a font
+	 * Choose a font.
 	 *
 	 * @since 1.1
 	 * @param string $existing_value stored font value
+	 * @return void
 	 */
 	public function display_font( $existing_value = '' ) {
 		if ( ! class_exists( 'Facebook_Social_Plugin_Settings' ) )
@@ -204,10 +227,12 @@ class Facebook_Recommendations_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Choose a light or dark color scheme
+	 * Choose a light or dark color scheme.
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $existing_value saved colorscheme value
+	 * @return void
 	 */
 	public function display_colorscheme( $existing_value = 'light' ) {
 		if ( ! class_exists( 'Facebook_Social_Plugin_Settings' ) )
@@ -222,7 +247,9 @@ class Facebook_Recommendations_Widget extends WP_Widget {
 	 * Limit articles displayed in recommendations box to last N days where N is a number between 0 (no limit) and 180.
 	 *
 	 * @since 1.1
+	 *
 	 * @param int $existing_value stored value
+	 * @return void
 	 */
 	public function display_max_age( $existing_value = 0 ) {
 		echo '<p><label>' . esc_html( __( 'Maximum age', 'facebook' ) ) . ': ';

--- a/social-plugins/widgets/send-button.php
+++ b/social-plugins/widgets/send-button.php
@@ -8,6 +8,10 @@ class Facebook_Send_Button_Widget extends WP_Widget {
 
 	/**
 	 * Register widget with WordPress
+	 *
+	 * @since 1.0
+	 *
+	 * @return void
 	 */
 	public function __construct() {
 		parent::__construct(
@@ -22,8 +26,11 @@ class Facebook_Send_Button_Widget extends WP_Widget {
 	 *
 	 * @see WP_Widget::widget()
 	 *
+	 * @since 1.0
+	 *
 	 * @param array $args     Widget arguments.
 	 * @param array $instance Saved values from database.
+	 * @return void
 	 */
 	public function widget( $args, $instance ) {
 		extract( $args );
@@ -55,6 +62,8 @@ class Facebook_Send_Button_Widget extends WP_Widget {
 	 *
 	 * @see WP_Widget::update()
 	 *
+	 * @since 1.0
+	 *
 	 * @param array $new_instance Values just sent to be saved.
 	 * @param array $old_instance Previously saved values from database.
 	 *
@@ -83,7 +92,10 @@ class Facebook_Send_Button_Widget extends WP_Widget {
 	 *
 	 * @see WP_Widget::form()
 	 *
+	 * @since 1.0
+	 *
 	 * @param array $instance Previously saved values from database.
+	 * @return void
 	 */
 	public function form( $instance ) {
 		$instance = wp_parse_args( (array) $instance, array(
@@ -117,11 +129,14 @@ class Facebook_Send_Button_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Allow a publisher to customize the title displayed above the widget area
-	 * e.g. Like us on Facebook!
+	 * Allow a publisher to customize the title displayed above the widget area.
+	 *
+	 * e.g. Send this page to your friends!
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $existing_value saved title
+	 * @return void
 	 */
 	public function display_title( $existing_value = '' ) {
 		echo '<p><label>' . esc_html( __( 'Title', 'facebook' ) ) . ': ';
@@ -132,10 +147,12 @@ class Facebook_Send_Button_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Customize the Like target
+	 * Customize the Send target.
 	 *
 	 * @since 1.1
+	 *
 	 * @param string $existing_value stored URL value
+	 * @return void
 	 */
 	public function display_href( $existing_value = '' ) {
 		echo '<p><label>URL: <input type="url" id="' . $this->get_field_id( 'href' ) . '" name="' . $this->get_field_name( 'href' ) . '" class="widefat"';

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,14 +1,17 @@
 <?php
 /**
- * Remove data written by the Facebook plugin for WordPress after an administrative user clicks "Delete" from the plugin management page in wp-admin.
+ * Remove data written by the Facebook plugin for WordPress after an administrative user clicks "Delete" from the plugin management page in the WordPress administrative interface (wp-admin).
  *
  * @since 1.1
+ *
  * @todo post meta data
  */
 
+// only execute as part of an uninstall script
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) )
 	exit();
 
+// Facebook user helpers
 if ( ! class_exists( 'Facebook_User' ) )
 	require_once( dirname(__FILE__) . '/facebook-user.php' );
 


### PR DESCRIPTION
Update documentation for [WordPress PHP documentation standards](http://make.wordpress.org/core/handbook/inline-documentation-standards/php-documentation-standards/) and [PSR-5](https://github.com/phpDocumentor/fig-standards/blob/master/proposed/phpdoc.md).
- Improves documentation of custom filters and actions.
- Adds `@return void` to functions without a return value.
- Adds `@type` documentation of array parameters and return values.

A couple small code fixes thrown in as well:
- Facebook profile link builder was checking for the existence of the `name` key before appending the value of the `username` key; switched the check to `username`.
- Conditional loader of the Facebook section on the profile page was loading the current user object before passing to `user_can()`; changed to a `current_user_can()`
