### PR TITLE
always load transition_post_status and before_delete_post action adders

### DIFF
--- a/admin/social-publisher/social-publisher.php
+++ b/admin/social-publisher/social-publisher.php
@@ -24,11 +24,14 @@ class Facebook_Social_Publisher {
 		// post can be published or deleted many different ways
 		add_action( 'transition_post_status', array( 'Facebook_Social_Publisher', 'publish' ), 10, 3 );
 		add_action( 'before_delete_post', array( 'Facebook_Social_Publisher', 'delete_facebook_post' ) );
-		self::add_save_post_hooks();
 
-		// load meta box hooks on post creation screens
-		foreach( array( 'post', 'post-new' ) as $hook ) {
-			add_action( 'load-' . $hook . '.php', array( 'Facebook_Social_Publisher', 'load' ), 1, 0 );
+		if ( is_admin() ) {
+			self::add_save_post_hooks();
+
+			// load meta box hooks on post creation screens
+			foreach( array( 'post', 'post-new' ) as $hook ) {
+				add_action( 'load-' . $hook . '.php', array( 'Facebook_Social_Publisher', 'load' ), 1, 0 );
+			}
 		}
 	}
 

--- a/facebook.php
+++ b/facebook.php
@@ -195,6 +195,13 @@ class Facebook_Loader {
 		unset( $credentials );
 		$this->kid_directed = (bool) get_option( 'facebook_kid_directed_site' );
 
+		if ( $this->app_access_token_exists() ) {
+			// Facebook Social Publisher functionality
+			if ( ! class_exists( 'Facebook_Social_Publisher' ) )
+				require_once( $this->plugin_directory . 'admin/social-publisher/social-publisher.php' );
+			add_action( 'init', array( 'Facebook_Social_Publisher', 'init' ) );
+		}
+
 		// Include Facebook widgets
 		add_action( 'widgets_init', array( &$this, 'widgets_init' ) );
 
@@ -536,11 +543,6 @@ class Facebook_Loader {
 
 		// include social publisher functionality if app access token exists
 		if ( $this->app_access_token_exists() ) {
-			// Facebook Social Publisher functionality
-			if ( ! class_exists( 'Facebook_Social_Publisher' ) )
-				require_once( $admin_dir . 'social-publisher/social-publisher.php' );
-			add_action( 'admin_init', array( 'Facebook_Social_Publisher', 'init' ) );
-
 			// Open Graph mention tagging
 			if ( ! class_exists( 'Facebook_Mentions_Search' ) )
 				require_once( $admin_dir . 'social-publisher/mentions/mentions-search.php' );


### PR DESCRIPTION
Allow execution of post publish code even if not inside an is_admin() query type

Should improve scheduled jobs such as `future` post status types and XML-RPC at the expense of adding extra hooks when only loading a public-facing view.
