### PR TITLE
convert Instagram WP_Embeds in post content to an og:image

### DIFF
--- a/open-graph-protocol.php
+++ b/open-graph-protocol.php
@@ -629,6 +629,22 @@ class Facebook_Open_Graph_Protocol {
 			unset( $images );
 		}
 
+		// test for WP_Embed handled images
+		if ( ! empty( $post->post_content ) ) {
+			// Instagram
+			preg_match_all( '#\s*http://instagr(\.am|am\.com)/p/(.*)/\s*#i', $post->post_content, $matches );
+			if ( isset( $matches[2] ) ) {
+				foreach( $matches[2] as $instagram_id ) {
+					$instagram_url = esc_url_raw( 'http://instagram.com/p/' . $instagram_id . '/media/?size=l', array( 'http' ) );
+					if ( ! $instagram_url || isset( $og_images[$instagram_url] ) )
+						continue;
+					$og_images[$instagram_url] = array( 'url' => $instagram_url );
+					unset( $instagram_url );
+				}
+			}
+			unset( $matches );
+		}
+
 		// add gallery content
 		if ( function_exists( 'get_post_galleries' ) ) {
 			// use get_post_galleries function from WP 3.6+


### PR DESCRIPTION
- Find Instagram media URIs on its own line in post content similar to `WP_Embed->autoembed()` discovery.
- Construct an [Instagram media redirect URI](http://instagram.com/developer/embedding/#media_redirect) from the Instagram media ID. This URI will 302 redirect to a large Instagram image (if the Instagram media ID still exists).

The full image URI and dimensions are available via the [Instagram OEmbed endpoint](http://instagram.com/developer/embedding/#oembed) but would require an additional HTTP request and caching, possibly integrated with the autoembed handlers run during `the_content`. Capturing the quick win of the media redirect for now.

An Instagram video page has the same URI structure as an Instagram image page. A media ID corresponding to an Instagram video will return an image when requested via the media redirect endpoint.

Open Graph image values are an array with priority given to ordering of the list of images. This diff considers `WP_Embed` images a lower priority than attached images but a higher priority than gallery content.
