### PR TITLE
support Vimeo embeds for video post formats

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -218,6 +218,7 @@ Security fixes. Improved customization and debugging of settings. l10n and i18n 
 * Delete Facebook account data associated with a WordPress user from the user profile screen.
 * Facebook application data for Facebook Login displayed in the settings debug screen.
 * Improve social publisher compatibility with scheduled posts.
+* (beta) Convert Instagram embeds to `og:image`s. Convert YouTube and Vimeo embeds to Open Graph media objects for video post formats.
 * Improved code documentation.
 
 = 1.5.2 =


### PR DESCRIPTION
Add Vimeo videos to `WP_Embed`-style converters. Adds `og:video` markup for HTML and SWF players.

No additional HTTP requests, just URL builders based on extracted Vimeo video ID. No `og:image` is generated (requires API call), which may affect playback functionality. Adding an `og:image` as a post thumbnail will correct the lack of Vimeo thumbnail.

Moves URL matching into four pieces:
1. Grab all URIs on their own lines using the same extractor as `WP_Embed::autoembed`.
2. Match against the URIs we want to handle.
3. Find the unique video ID in the URL for the service we are matching.
4. Build Open Graph media markup based on the provider and video id.
