### PR TITLE
Call made to deprecated function

### DIFF
--- a/admin/settings-debug.php
+++ b/admin/settings-debug.php
@@ -492,7 +492,7 @@ class Facebook_Settings_Debugger {
 				} else {
 					$s = '';
 					foreach( $public_post_types as $post_type ) {
-						$s .= "'" . $wpdb->escape( $post_type ) . "',";
+						$s .= "'" . esc_sql( $post_type ) . "',";
 					}
 					$where .= ' IN (' . rtrim( $s, ',' ) . ')';
 					unset( $s );
@@ -508,7 +508,7 @@ class Facebook_Settings_Debugger {
 				} else {
 					$s = '';
 					foreach( $public_states as $state ) {
-						$s .= "'" . $wpdb->escape( $state ) . "',";
+						$s .= "'" . esc_sql( $state ) . "',";
 					}
 					$where .= ' IN (' . rtrim( $s, ',' ) . ')';
 					unset( $s );


### PR DESCRIPTION
wpdb::escape was deprecated in Wordpress 3.6. However two calls were still made to it by settings-debug.php. 'esc_sql' [1] is functionally similar to wpdb::escape but with "stronger" escaping [2].

[1] http://codex.wordpress.org/Function_Reference/esc_sql
[2] http://wordpress.org/support/topic/wordpress-36-rc2-last-minute-wpdbescape-deprecation-is-not-nice

![screen shot 2013-11-28 at 2 30 49 pm](https://f.cloud.github.com/assets/553949/1641792/c18f6620-5863-11e3-971a-f4d6a1b76837.png)
