### PR TITLE
update Facebook SDK for PHP to 3.2.3

### DIFF
--- a/facebook.php
+++ b/facebook.php
@@ -420,7 +420,8 @@ class Facebook_Loader {
 
 		return new Facebook_WP_Extend( array(
 			'appId' => $this->credentials['app_id'],
-			'secret' => $this->credentials['app_secret']
+			'secret' => $this->credentials['app_secret'],
+			'allowSignedRequest' => false
 		) );
 	}
 

--- a/includes/facebook-php-sdk/base_facebook.php
+++ b/includes/facebook-php-sdk/base_facebook.php
@@ -25,6 +25,8 @@ class WP_FacebookApiException extends Exception
 {
   /**
    * The result from the API server that represents the exception information.
+   *
+   * @var mixed
    */
   protected $result;
 
@@ -36,8 +38,10 @@ class WP_FacebookApiException extends Exception
   public function __construct($result) {
     $this->result = $result;
 
-    // when api call fails (no available transport, i.e. cURL etc. not working), error code comes out as string 'http_failure', but $code needs to be int. is_int returns false if !isset()
-    $code = is_int($result['error_code']) ? $result['error_code'] : 0;
+    $code = 0;
+    if (isset($result['error_code']) && is_int($result['error_code'])) {
+      $code = $result['error_code'];
+    }
 
     if (isset($result['error_description'])) {
       // OAuth 2.0 Draft 10 style
@@ -117,7 +121,7 @@ abstract class WP_BaseFacebook
   /**
    * Version.
    */
-  const VERSION = '3.2.2';
+  const VERSION = '3.2.3';
 
   /**
    * Signed Request Algorithm.
@@ -127,6 +131,8 @@ abstract class WP_BaseFacebook
   /**
    * List of query parameters that get automatically dropped when rebuilding
    * the current URL.
+   *
+   * @var array
    */
   protected static $DROP_QUERY_PARAMS = array(
     'code',
@@ -136,6 +142,8 @@ abstract class WP_BaseFacebook
 
   /**
    * Maps aliases to Facebook domains.
+   *
+   * @var array
    */
   public static $DOMAIN_MAP = array(
     'api'         => 'https://api.facebook.com/',
@@ -169,11 +177,15 @@ abstract class WP_BaseFacebook
 
   /**
    * The data from the signed_request token.
+   *
+   * @var string
    */
   protected $signedRequest;
 
   /**
    * A CSRF state variable to assist in the defense against CSRF attacks.
+   *
+   * @var string
    */
   protected $state;
 
@@ -200,12 +212,22 @@ abstract class WP_BaseFacebook
   protected $trustForwarded = false;
 
   /**
+   * Indicates if signed_request is allowed in query parameters.
+   *
+   * @var boolean
+   */
+  protected $allowSignedRequest = true;
+
+  /**
    * Initialize a Facebook Application.
    *
    * The configuration:
    * - appId: the application ID
    * - secret: the application secret
    * - fileUpload: (optional) boolean indicating if file uploads are enabled
+   * - allowSignedRequest: (optional) boolean indicating if signed_request is
+   *                       allowed in query parameters or POST body.  Should be
+   *                       false for non-canvas apps.  Defaults to true.
    *
    * @param array $config The application configuration
    */
@@ -218,6 +240,10 @@ abstract class WP_BaseFacebook
     if (isset($config['trustForwarded']) && $config['trustForwarded']) {
       $this->trustForwarded = true;
     }
+    if (isset($config['allowSignedRequest'])
+        && !$config['allowSignedRequest']) {
+        $this->allowSignedRequest = false;
+    }
     $state = $this->getPersistentData('state');
     if (!empty($state)) {
       $this->state = $state;
@@ -228,6 +254,7 @@ abstract class WP_BaseFacebook
    * Set the Application ID.
    *
    * @param string $appId The Application ID
+   *
    * @return WP_BaseFacebook
    */
   public function setAppId($appId) {
@@ -248,8 +275,10 @@ abstract class WP_BaseFacebook
    * Set the App Secret.
    *
    * @param string $apiSecret The App Secret
+   *
    * @return WP_BaseFacebook
-   * @deprecated
+   * @deprecated Use setAppSecret instead.
+   * @see setAppSecret()
    */
   public function setApiSecret($apiSecret) {
     $this->setAppSecret($apiSecret);
@@ -260,6 +289,7 @@ abstract class WP_BaseFacebook
    * Set the App Secret.
    *
    * @param string $appSecret The App Secret
+   *
    * @return WP_BaseFacebook
    */
   public function setAppSecret($appSecret) {
@@ -271,7 +301,9 @@ abstract class WP_BaseFacebook
    * Get the App Secret.
    *
    * @return string the App Secret
-   * @deprecated
+   *
+   * @deprecated Use getAppSecret instead.
+   * @see getAppSecret()
    */
   public function getApiSecret() {
     return $this->getAppSecret();
@@ -290,6 +322,7 @@ abstract class WP_BaseFacebook
    * Set the file upload support status.
    *
    * @param boolean $fileUploadSupport The file upload support status.
+   *
    * @return WP_BaseFacebook
    */
   public function setFileUploadSupport($fileUploadSupport) {
@@ -307,11 +340,12 @@ abstract class WP_BaseFacebook
   }
 
   /**
-   * DEPRECATED! Please use getFileUploadSupport instead.
-   *
    * Get the file upload support status.
    *
    * @return boolean true if and only if the server supports file upload.
+   *
+   * @deprecated Use getFileUploadSupport instead.
+   * @see getFileUploadSupport()
    */
   public function useFileUploadSupport() {
     return $this->getFileUploadSupport();
@@ -323,6 +357,7 @@ abstract class WP_BaseFacebook
    * to use it.
    *
    * @param string $access_token an access token.
+   *
    * @return WP_BaseFacebook
    */
   public function setAccessToken($access_token) {
@@ -475,9 +510,10 @@ abstract class WP_BaseFacebook
    */
   public function getSignedRequest() {
     if (!$this->signedRequest) {
-      if (!empty($_REQUEST['signed_request'])) {
+      if ($this->allowSignedRequest && !empty($_REQUEST['signed_request'])) {
         $this->signedRequest = $this->parseSignedRequest(
-          $_REQUEST['signed_request']);
+          $_REQUEST['signed_request']
+        );
       } else if (!empty($_COOKIE[$this->getSignedRequestCookieName()])) {
         $this->signedRequest = $this->parseSignedRequest(
           $_COOKIE[$this->getSignedRequestCookieName()]);
@@ -576,11 +612,15 @@ abstract class WP_BaseFacebook
     return $this->getUrl(
       'www',
       'dialog/oauth',
-      array_merge(array(
-                    'client_id' => $this->getAppId(),
-                    'redirect_uri' => $currentUrl, // possibly overwritten
-                    'state' => $this->state),
-                  $params));
+      array_merge(
+        array(
+          'client_id' => $this->getAppId(),
+          'redirect_uri' => $currentUrl, // possibly overwritten
+          'state' => $this->state,
+          'sdk' => 'php-sdk-'.self::VERSION
+        ),
+        $params
+      ));
   }
 
   /**
@@ -606,24 +646,14 @@ abstract class WP_BaseFacebook
   /**
    * Get a login status URL to fetch the status from Facebook.
    *
-   * The parameters:
-   * - ok_session: the URL to go to if a session is found
-   * - no_session: the URL to go to if the user is not connected
-   * - no_user: the URL to go to if the user is not signed into facebook
-   *
    * @param array $params Provide custom parameters
    * @return string The URL for the logout flow
    */
   public function getLoginStatusUrl($params=array()) {
-    return $this->getUrl(
-      'www',
-      'extern/login_status.php',
+    return $this->getLoginUrl(
       array_merge(array(
-        'api_key' => $this->getAppId(),
-        'no_session' => $this->getCurrentUrl(),
-        'no_user' => $this->getCurrentUrl(),
-        'ok_session' => $this->getCurrentUrl(),
-        'session_version' => 3,
+        'response_type' => 'code',
+        'display' => 'none',
       ), $params)
     );
   }
@@ -656,7 +686,7 @@ abstract class WP_BaseFacebook
   }
 
   /**
-   * Constructs and returns the name of the coookie that potentially contain
+   * Constructs and returns the name of the cookie that potentially contain
    * metadata. The cookie is not set by the WP_BaseFacebook class, but it may be
    * set by the JavaScript SDK.
    *
@@ -675,20 +705,16 @@ abstract class WP_BaseFacebook
    *               code could not be determined.
    */
   protected function getCode() {
-    if (isset($_REQUEST['code'])) {
-      if ($this->state !== null &&
-          isset($_REQUEST['state']) &&
-          $this->state === $_REQUEST['state']) {
-
+    if (!isset($_REQUEST['code']) || !isset($_REQUEST['state'])) {
+      return false;
+    }
+    if ($this->state === $_REQUEST['state']) {
         // CSRF state has done its job, so clear it
         $this->state = null;
         $this->clearPersistentData('state');
         return $_REQUEST['code'];
-      } else {
-        self::errorLog('CSRF state token does not match one provided.');
-        return false;
-      }
     }
+    self::errorLog('CSRF state token does not match one provided.');
 
     return false;
   }
@@ -719,7 +745,7 @@ abstract class WP_BaseFacebook
    * @return string The application access token, useful for gathering
    *                public information about users and applications.
    */
-  protected function getApplicationAccessToken() {
+  public function getApplicationAccessToken() {
     return $this->appId.'|'.$this->appSecret;
   }
 
@@ -744,6 +770,8 @@ abstract class WP_BaseFacebook
    * either logged in to Facebook or has granted an offline access permission.
    *
    * @param string $code An authorization code.
+   * @param string $redirect_uri Optional redirect URI. Default null
+   *
    * @return mixed An access token exchanged for the authorization code, or
    *               false if an access token could not be generated.
    */
@@ -892,7 +920,7 @@ abstract class WP_BaseFacebook
 
     // json_encode all params values that are not strings
     foreach ($params as $key => $value) {
-      if (!is_string($value)) {
+      if (!is_string($value) && !($value instanceof CURLFile)) {
         $params[$key] = json_encode($value);
       }
     }
@@ -950,11 +978,13 @@ abstract class WP_BaseFacebook
     curl_setopt_array($ch, $opts);
     $result = curl_exec($ch);
 
-    if (curl_errno($ch) == 60) { // CURLE_SSL_CACERT
+    $errno = curl_errno($ch);
+    // CURLE_SSL_CACERT || CURLE_SSL_CACERT_BADFILE
+    if ($errno == 60 || $errno == 77) {
       self::errorLog('Invalid or no certificate authority found, '.
                      'using bundled information');
       curl_setopt($ch, CURLOPT_CAINFO,
-                  dirname(__FILE__) . '/fb_ca_chain_bundle.crt');
+                  dirname(__FILE__) . DIRECTORY_SEPARATOR . 'fb_ca_chain_bundle.crt');
       $result = curl_exec($ch);
     }
 
@@ -996,6 +1026,7 @@ abstract class WP_BaseFacebook
    * Parses a signed_request and validates the signature.
    *
    * @param string $signed_request A signed token
+   *
    * @return array The payload inside it or null if the sig is wrong
    */
   protected function parseSignedRequest($signed_request) {
@@ -1014,18 +1045,30 @@ abstract class WP_BaseFacebook
     // check sig
     $expected_sig = hash_hmac('sha256', $payload,
                               $this->getAppSecret(), $raw = true);
-    if ($sig !== $expected_sig) {
+
+    if (strlen($expected_sig) !== strlen($sig)) {
       self::errorLog('Bad Signed JSON signature!');
       return null;
     }
 
-    return $data;
+    $result = 0;
+    for ($i = 0; $i < strlen($expected_sig); $i++) {
+      $result |= ord($expected_sig[$i]) ^ ord($sig[$i]);
+    }
+
+    if ($result == 0) {
+      return $data;
+    } else {
+      self::errorLog('Bad Signed JSON signature!');
+      return null;
+    }
   }
 
   /**
    * Makes a signed_request blob using the given data.
    *
-   * @param array The data array.
+   * @param array $data The data array.
+   *
    * @return string The signed request.
    */
   protected function makeSignedRequest($data) {
@@ -1045,7 +1088,8 @@ abstract class WP_BaseFacebook
   /**
    * Build the URL for api given parameters.
    *
-   * @param $method String the method name.
+   * @param string $method The method name.
+   *
    * @return string The URL for the given parameters
    */
   protected function getApiUrl($method) {
@@ -1122,9 +1166,9 @@ abstract class WP_BaseFacebook
   /**
    * Build the URL for given domain alias, path and parameters.
    *
-   * @param $name string The name of the domain
-   * @param $path string Optional path (without a leading slash)
-   * @param $params array Optional query parameters
+   * @param string $name   The name of the domain
+   * @param string $path   Optional path (without a leading slash)
+   * @param array  $params Optional query parameters
    *
    * @return string The URL for the given parameters
    */
@@ -1143,13 +1187,26 @@ abstract class WP_BaseFacebook
     return $url;
   }
 
+  /**
+   * Returns the HTTP Host
+   *
+   * @return string The HTTP Host
+   */
   protected function getHttpHost() {
     if ($this->trustForwarded && isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
-      return $_SERVER['HTTP_X_FORWARDED_HOST'];
+      $forwardProxies = explode(',', $_SERVER['HTTP_X_FORWARDED_HOST']);
+      if (!empty($forwardProxies)) {
+        return $forwardProxies[0];
+      }
     }
     return $_SERVER['HTTP_HOST'];
   }
 
+  /**
+   * Returns the HTTP Protocol
+   *
+   * @return string The HTTP Protocol
+   */
   protected function getHttpProtocol() {
     if ($this->trustForwarded && isset($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
       if ($_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
@@ -1171,7 +1228,9 @@ abstract class WP_BaseFacebook
   }
 
   /**
-   * Get the base domain used for the cookie.
+   * Returns the base domain used for the cookie.
+   *
+   * @return string The base domain
    */
   protected function getBaseDomain() {
     // The base domain is stored in the metadata cookie if not we fallback
@@ -1183,8 +1242,6 @@ abstract class WP_BaseFacebook
     }
     return $this->getHttpHost();
   }
-
-  /**
 
   /**
    * Returns the Current URL, stripping it of known FB parameters that should
@@ -1232,13 +1289,14 @@ abstract class WP_BaseFacebook
    * params that should be stripped out.
    *
    * @param string $param A key or key/value pair within a URL's query (e.g.
-   *                     'foo=a', 'foo=', or 'foo'.
+   *                      'foo=a', 'foo=', or 'foo'.
    *
    * @return boolean
    */
   protected function shouldRetainParam($param) {
     foreach (self::$DROP_QUERY_PARAMS as $drop_query_param) {
-      if (strpos($param, $drop_query_param.'=') === 0) {
+      if ($param === $drop_query_param ||
+          strpos($param, $drop_query_param.'=') === 0) {
         return false;
       }
     }
@@ -1251,7 +1309,7 @@ abstract class WP_BaseFacebook
    * because the access token is no longer valid.  If that is
    * the case, then we destroy the session.
    *
-   * @param $result array A record storing the error message returned
+   * @param array $result A record storing the error message returned
    *                      by a failed API call.
    */
   protected function throwAPIException($result) {
@@ -1300,8 +1358,9 @@ abstract class WP_BaseFacebook
    *   _ instead of /
    *   No padded =
    *
-   * @param string $input base64UrlEncoded string
-   * @return string
+   * @param string $input base64UrlEncoded input
+   *
+   * @return string The decoded string
    */
   protected static function base64UrlDecode($input) {
     return base64_decode(strtr($input, '-_', '+/'));
@@ -1313,8 +1372,8 @@ abstract class WP_BaseFacebook
    *   - instead of +
    *   _ instead of /
    *
-   * @param string $input string
-   * @return string base64Url encoded string
+   * @param string $input The input to encode
+   * @return string The base64Url encoded input, as a string.
    */
   protected static function base64UrlEncode($input) {
     $str = strtr(base64_encode($input), '+/', '-_');
@@ -1354,7 +1413,7 @@ abstract class WP_BaseFacebook
   /**
    * Parses the metadata cookie that our Javascript API set
    *
-   * @return  an array mapping key to value
+   * @return array an array mapping key to value
    */
   protected function getMetadataCookie() {
     $cookie_name = $this->getMetadataCookieName();
@@ -1382,6 +1441,14 @@ abstract class WP_BaseFacebook
     return $metadata;
   }
 
+  /**
+   * Finds whether the given domain is allowed or not
+   *
+   * @param string $big   The value to be checked against $small
+   * @param string $small The input string
+   *
+   * @return boolean Returns TRUE if $big matches $small
+   */
   protected static function isAllowedDomain($big, $small) {
     if ($big === $small) {
       return true;
@@ -1389,6 +1456,14 @@ abstract class WP_BaseFacebook
     return self::endsWith($big, '.'.$small);
   }
 
+  /**
+   * Checks if $big string ends with $small string
+   *
+   * @param string $big   The value to be checked against $small
+   * @param string $small The input string
+   *
+   * @return boolean TRUE if $big ends with $small
+   */
   protected static function endsWith($big, $small) {
     $len = strlen($small);
     if ($len === 0) {
@@ -1432,6 +1507,7 @@ abstract class WP_BaseFacebook
    * Clear the data with $key from the persistent storage
    *
    * @param string $key
+   *
    * @return void
    */
   abstract protected function clearPersistentData($key);


### PR DESCRIPTION
Update to the latest version of the [Facebook SDK for PHP](https://github.com/facebook/facebook-php-sdk): version 3.2.3.

Biggest change: `allowSignedRequest` set to `true` by default in SDK is overridden by the Facebook plugin to `false` for non-canvas usage.
