### PR TITLE
Allow filtering of open graph images

### DIFF
--- a/open-graph-protocol.php
+++ b/open-graph-protocol.php
@@ -690,7 +690,7 @@ class Facebook_Open_Graph_Protocol {
 			$og_images = self::gallery_images( $post, $og_images );
 		}
 
-		return $og_images;
+		return apply_filters( 'facebook_og_images', $og_images, $post );
 	}
 
 	/**


### PR DESCRIPTION
There currently isn't a way (which I can see) to filter the images for open graph. This is useful if a plugin/theme wants to show a default image or change it.
