### PR TITLE
do not escape widget title. matches behavior of default widgets

### DIFF
--- a/social-plugins/widgets/activity-feed.php
+++ b/social-plugins/widgets/activity-feed.php
@@ -55,7 +55,7 @@ class Facebook_Activity_Feed_Widget extends WP_Widget {
 		$title = apply_filters( 'widget_title', empty( $instance['title'] ) ? '' : $instance['title'], $instance, $this->id_base );
 
 		if ( $title )
-			echo $before_title . esc_html( $title ) . $after_title;
+			echo $before_title . $title . $after_title;
 
 		echo $activity_feed_html;
 

--- a/social-plugins/widgets/follow-button.php
+++ b/social-plugins/widgets/follow-button.php
@@ -54,7 +54,7 @@ class Facebook_Follow_Button_Widget extends WP_Widget {
 		$title = apply_filters( 'widget_title', empty( $instance['title'] ) ? '' : $instance['title'], $instance, $this->id_base );
 
 		if ( $title )
-			echo $before_title . esc_html( $title ) . $after_title;
+			echo $before_title . $title . $after_title;
 
 		echo $follow_button_html;
 

--- a/social-plugins/widgets/like-box.php
+++ b/social-plugins/widgets/like-box.php
@@ -131,7 +131,7 @@ class Facebook_Like_Box_Widget extends WP_Widget {
 		$title = apply_filters( 'widget_title', empty( $instance['title'] ) ? '' : $instance['title'], $instance, $this->id_base );
 
 		if ( $title )
-			echo $before_title . esc_html( $title ) . $after_title;
+			echo $before_title . $title . $after_title;
 
 		echo $box_html;
 

--- a/social-plugins/widgets/like-button.php
+++ b/social-plugins/widgets/like-button.php
@@ -59,7 +59,7 @@ class Facebook_Like_Button_Widget extends WP_Widget {
 		$title = apply_filters( 'widget_title', empty( $instance['title'] ) ? '' : $instance['title'], $instance, $this->id_base );
 
 		if ( $title )
-			echo $before_title . esc_html( $title ) . $after_title;
+			echo $before_title . $title . $after_title;
 
 		echo $like_button_html;
 

--- a/social-plugins/widgets/recommendations-box.php
+++ b/social-plugins/widgets/recommendations-box.php
@@ -55,7 +55,7 @@ class Facebook_Recommendations_Widget extends WP_Widget {
 		$title = apply_filters( 'widget_title', empty( $instance['title'] ) ? '' : $instance['title'], $instance, $this->id_base );
 
 		if ( $title )
-			echo $before_title . esc_html( $title ) . $after_title;
+			echo $before_title . $title . $after_title;
 
 		echo $box_html;
 

--- a/social-plugins/widgets/send-button.php
+++ b/social-plugins/widgets/send-button.php
@@ -50,7 +50,7 @@ class Facebook_Send_Button_Widget extends WP_Widget {
 		$title = apply_filters( 'widget_title', empty( $instance['title'] ) ? '' : $instance['title'], $instance, $this->id_base );
 
 		if ( $title )
-			echo $before_title . esc_html( $title ) . $after_title;
+			echo $before_title . $title . $after_title;
 
 		echo $send_button_html;
 


### PR DESCRIPTION
Do not escape a widget title before output. Matches the behavior of [default widgets in WordPress Core](https://core.trac.wordpress.org/browser/trunk/src/wp-includes/default-widgets.php).
