### PR TITLE
update link to Facebook application insights

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -246,7 +246,7 @@ class Facebook_Settings {
 				$submenu[$menu_slug][] = array(
 					_x( 'Insights', 'Facebook Insights', 'facebook' ),
 					'manage_options',
-					'https://www.facebook.com/insights/?' . http_build_query( array( 'sk' => 'ao_' . $facebook_loader->credentials['app_id'] ) ),
+					esc_url( 'https://www.facebook.com/insights/' . $facebook_loader->credentials['app_id'], array( 'https', 'http' ) ),
 					''
 				);
 			}


### PR DESCRIPTION
Update link to Facebook application insights. [Facebook introduced App Insights 2.0 beta on January 23, 2014](https://developers.facebook.com/blog/post/2014/01/23/introducing-app-insights-2-0-beta/).
