### PR TITLE
replace deprecated wpdb->escape() with esc_sql()

### DIFF
--- a/admin/settings-debug.php
+++ b/admin/settings-debug.php
@@ -492,7 +492,7 @@ class Facebook_Settings_Debugger {
 				} else {
 					$s = '';
 					foreach( $public_post_types as $post_type ) {
-						$s .= "'" . $wpdb->escape( $post_type ) . "',";
+						$s .= "'" . esc_sql( $post_type ) . "',";
 					}
 					$where .= ' IN (' . rtrim( $s, ',' ) . ')';
 					unset( $s );
@@ -508,7 +508,7 @@ class Facebook_Settings_Debugger {
 				} else {
 					$s = '';
 					foreach( $public_states as $state ) {
-						$s .= "'" . $wpdb->escape( $state ) . "',";
+						$s .= "'" . esc_sql( $state ) . "',";
 					}
 					$where .= ' IN (' . rtrim( $s, ',' ) . ')';
 					unset( $s );


### PR DESCRIPTION
use [esc_sql](https://codex.wordpress.org/Function_Reference/esc_sql) instead of wpdb->escape. esc_sql exists since 2.8 and has been preferred since 3.6.
