### PR TITLE
add empty directory indexes to prevent directory listings

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/admin/social-publisher/index.php
+++ b/admin/social-publisher/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/admin/social-publisher/mentions/index.php
+++ b/admin/social-publisher/mentions/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/extras/index.php
+++ b/extras/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/facebook-php-sdk/index.php
+++ b/includes/facebook-php-sdk/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/index.php
+++ b/includes/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/social-plugins/index.php
+++ b/social-plugins/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/social-plugins/widgets/index.php
+++ b/social-plugins/widgets/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/static/css/admin/index.html
+++ b/static/css/admin/index.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf=8"><title>Empty Index</title></head><body><p>Silence is golden.</p></body></html>

--- a/static/css/index.html
+++ b/static/css/index.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf=8"><title>Empty Index</title></head><body><p>Silence is golden.</p></body></html>

--- a/static/fonts/index.html
+++ b/static/fonts/index.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf=8"><title>Empty Index</title></head><body><p>Silence is golden.</p></body></html>

--- a/static/img/index.html
+++ b/static/img/index.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf=8"><title>Empty Index</title></head><body><p>Silence is golden.</p></body></html>

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf=8"><title>Empty Index</title></head><body><p>Silence is golden.</p></body></html>

--- a/static/js/admin/index.html
+++ b/static/js/admin/index.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf=8"><title>Empty Index</title></head><body><p>Silence is golden.</p></body></html>

--- a/static/js/extras/analytics/index.html
+++ b/static/js/extras/analytics/index.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf=8"><title>Empty Index</title></head><body><p>Silence is golden.</p></body></html>

--- a/static/js/extras/index.html
+++ b/static/js/extras/index.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf=8"><title>Empty Index</title></head><body><p>Silence is golden.</p></body></html>


### PR DESCRIPTION
Provide default index files in plugin directories to prevent directory traversal on sites with autoindex on.
