### PR TITLE
load impression beacon over HTTPS

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -335,7 +335,7 @@ class Facebook_Settings {
 	public static function stats_beacon( $app_id = '' ) {
 		$debug = self::debug_output( $app_id );
 		if ( ! empty( $debug ) )
-			echo '<div><img src="http://www.facebook.com/impression.php?' . http_build_query( array( 'plugin' => 'wordpress', 'payload' => json_encode( $debug ) ) ) . '" width="1" height="1" alt=" " /></div>';
+			echo '<div><img src="https://www.facebook.com/impression.php?' . http_build_query( array( 'plugin' => 'wordpress', 'payload' => json_encode( $debug ) ) ) . '" width="1" height="1" alt=" " /></div>';
 	}
 
 	/**


### PR DESCRIPTION
send usage statistics to Facebook servers over HTTPS, avoiding mixed content page issues
