### PR TITLE
remove break statement from catch block

### DIFF
--- a/social-plugins/widgets/like-box.php
+++ b/social-plugins/widgets/like-box.php
@@ -81,7 +81,7 @@ class Facebook_Like_Box_Widget extends WP_Widget {
 			try {
 				$page_info = Facebook_WP_Extend::graph_api_with_app_access_token( '/fql', 'GET', array( 'q' => 'SELECT page_url FROM page WHERE ' . $where ) );
 			} catch ( WP_FacebookApiException $e ) {
-				break;
+				return '';
 			}
 			unset( $where );
 


### PR DESCRIPTION
This will fix PHP Fatal error:  'break' not in the 'loop' or 'switch' context in php7.0